### PR TITLE
Add Agent365 span exporter (Phase 6, Task 2)

### DIFF
--- a/src/_a365/exporter/Agent365Exporter.ts
+++ b/src/_a365/exporter/Agent365Exporter.ts
@@ -5,7 +5,7 @@ import type { ExportResult } from "@opentelemetry/core";
 import { ExportResultCode } from "@opentelemetry/core";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 
-import type { Agent365ExporterOptions, TokenResolver } from "./Agent365ExporterOptions.js";
+import type { Agent365ExporterOptions } from "./Agent365ExporterOptions.js";
 import { ResolvedExporterOptions } from "./Agent365ExporterOptions.js";
 import {
   partitionByIdentity,

--- a/src/_a365/exporter/Agent365Exporter.ts
+++ b/src/_a365/exporter/Agent365Exporter.ts
@@ -1,0 +1,339 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ExportResult } from "@opentelemetry/core";
+import { ExportResultCode } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import type { Agent365ExporterOptions, TokenResolver } from "./Agent365ExporterOptions.js";
+import { ResolvedExporterOptions } from "./Agent365ExporterOptions.js";
+import {
+  partitionByIdentity,
+  parseIdentityKey,
+  hexTraceId,
+  hexSpanId,
+  kindName,
+  statusName,
+  resolveAgent365Endpoint,
+  truncateSpan,
+} from "./utils.js";
+import { Logger } from "../../shared/logging/index.js";
+
+const DEFAULT_MAX_RETRIES = 3;
+
+// ── OTLP-like payload types ─────────────────────────────────────────────────
+
+interface OTLPExportRequest {
+  resourceSpans: ResourceSpan[];
+}
+
+interface ResourceSpan {
+  resource: { attributes: Record<string, unknown> | null };
+  scopeSpans: ScopeSpan[];
+}
+
+interface ScopeSpan {
+  scope: { name: string; version?: string };
+  spans: OTLPSpan[];
+}
+
+interface OTLPSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: string;
+  startTimeUnixNano: number;
+  endTimeUnixNano: number;
+  attributes: Record<string, unknown> | null;
+  events?: OTLPEvent[] | null;
+  links?: OTLPLink[] | null;
+  status: OTLPStatus;
+}
+
+interface OTLPEvent {
+  timeUnixNano: number;
+  name: string;
+  attributes?: Record<string, unknown> | null;
+}
+
+interface OTLPLink {
+  traceId: string;
+  spanId: string;
+  attributes?: Record<string, unknown> | null;
+}
+
+interface OTLPStatus {
+  code: string;
+  message?: string;
+}
+
+/**
+ * Agent365 span exporter.
+ *
+ * Implements `SpanExporter` from `@opentelemetry/sdk-trace-base`.
+ * Partitions spans by (tenantId, agentId), builds OTLP-like JSON payloads,
+ * and POSTs them to the Agent365 observability service with Bearer auth.
+ */
+export class Agent365Exporter implements SpanExporter {
+  private closed = false;
+  private readonly options: ResolvedExporterOptions;
+  private readonly logger = Logger.getInstance();
+
+  constructor(options?: Agent365ExporterOptions) {
+    this.options = new ResolvedExporterOptions(options);
+  }
+
+  async export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): Promise<void> {
+    if (this.closed) {
+      resultCallback({ code: ExportResultCode.FAILED });
+      return;
+    }
+
+    try {
+      this.logger.info(`[Agent365Exporter] Exporting ${spans.length} spans`);
+      const groups = partitionByIdentity(spans);
+
+      if (groups.size === 0) {
+        resultCallback({ code: ExportResultCode.SUCCESS });
+        return;
+      }
+
+      let anyFailure = false;
+      const promises: Promise<void>[] = [];
+
+      for (const [identityKey, groupSpans] of groups) {
+        const promise = this.exportGroup(identityKey, groupSpans).catch((err) => {
+          anyFailure = true;
+          this.logger.error(`[Agent365Exporter] Error exporting group ${identityKey}:`, err);
+        });
+        promises.push(promise);
+      }
+
+      await Promise.all(promises);
+      resultCallback({
+        code: anyFailure ? ExportResultCode.FAILED : ExportResultCode.SUCCESS,
+      });
+    } catch (err) {
+      this.logger.error("[Agent365Exporter] Export failed:", err);
+      resultCallback({ code: ExportResultCode.FAILED });
+    }
+  }
+
+  private async exportGroup(identityKey: string, spans: ReadableSpan[]): Promise<void> {
+    const { tenantId, agentId } = parseIdentityKey(identityKey);
+
+    const payload = this.buildExportRequest(spans);
+    const body = JSON.stringify(payload);
+
+    const endpointPath = this.options.useS2SEndpoint
+      ? `/observabilityService/tenants/${encodeURIComponent(tenantId)}/agents/${encodeURIComponent(agentId)}/traces`
+      : `/observability/tenants/${encodeURIComponent(tenantId)}/agents/${encodeURIComponent(agentId)}/traces`;
+
+    const baseUrl = this.options.domainOverride
+      ?? resolveAgent365Endpoint(this.options.clusterCategory);
+    const url = `${baseUrl}${endpointPath}?api-version=1`;
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "x-ms-tenant-id": tenantId,
+    };
+
+    // Resolve token
+    const token = await this.resolveToken(agentId, tenantId);
+    if (!token) {
+      this.logger.warn(
+        `[Agent365Exporter] Skipping export for ${tenantId}/${agentId}: no token available`,
+      );
+      return;
+    }
+    headers["authorization"] = `Bearer ${token}`;
+
+    const { ok } = await this.postWithRetries(url, body, headers);
+    if (!ok) {
+      throw new Error(`Failed to export spans for ${tenantId}/${agentId}`);
+    }
+  }
+
+  private async resolveToken(
+    agentId: string,
+    tenantId: string,
+  ): Promise<string | null> {
+    if (!this.options.tokenResolver) return null;
+    const result = this.options.tokenResolver(agentId, tenantId);
+    return result instanceof Promise ? result : result;
+  }
+
+  private async postWithRetries(
+    url: string,
+    body: string,
+    headers: Record<string, string>,
+  ): Promise<{ ok: boolean; correlationId: string }> {
+    let lastCorrelationId = "unknown";
+
+    for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
+      try {
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body,
+          signal: AbortSignal.timeout(this.options.httpRequestTimeoutMilliseconds),
+        });
+
+        const correlationId =
+          response.headers.get("x-ms-correlation-id") ??
+          response.headers.get("x-correlation-id") ??
+          "unknown";
+        lastCorrelationId = correlationId;
+
+        if (response.status >= 200 && response.status < 300) {
+          return { ok: true, correlationId };
+        }
+
+        // Retry on transient errors
+        if (
+          [408, 429].includes(response.status) ||
+          (response.status >= 500 && response.status < 600)
+        ) {
+          if (attempt < DEFAULT_MAX_RETRIES) {
+            const sleepMs = 200 * (attempt + 1) + Math.floor(Math.random() * 100);
+            this.logger.warn(
+              `[Agent365Exporter] Transient error ${response.status}, retrying after ${sleepMs}ms`,
+            );
+            await sleep(sleepMs);
+            continue;
+          }
+        }
+
+        this.logger.error(
+          `[Agent365Exporter] Failed with status ${response.status}, correlation: ${correlationId}`,
+        );
+        return { ok: false, correlationId };
+      } catch (error) {
+        this.logger.error("[Agent365Exporter] Request error:", error);
+        if (attempt < DEFAULT_MAX_RETRIES) {
+          await sleep(200 * (attempt + 1));
+          continue;
+        }
+        return { ok: false, correlationId: lastCorrelationId };
+      }
+    }
+
+    return { ok: false, correlationId: lastCorrelationId };
+  }
+
+  private buildExportRequest(spans: ReadableSpan[]): OTLPExportRequest {
+    const scopeMap = new Map<string, OTLPSpan[]>();
+
+    for (const sp of spans) {
+      const scope = sp.instrumentationScope;
+      const scopeKey = `${scope?.name ?? "unknown"}:${scope?.version ?? ""}`;
+      let existing = scopeMap.get(scopeKey);
+      if (!existing) {
+        existing = [];
+        scopeMap.set(scopeKey, existing);
+      }
+      existing.push(truncateSpan(this.mapSpan(sp)));
+    }
+
+    const scopeSpans: ScopeSpan[] = [];
+    for (const [scopeKey, mappedSpans] of scopeMap) {
+      const [name, version] = scopeKey.split(":");
+      scopeSpans.push({
+        scope: { name, version: version || undefined },
+        spans: mappedSpans,
+      });
+    }
+
+    let resourceAttrs: Record<string, unknown> = {};
+    if (spans.length > 0 && spans[0].resource?.attributes) {
+      resourceAttrs = { ...spans[0].resource.attributes };
+    }
+
+    return {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: Object.keys(resourceAttrs).length > 0 ? resourceAttrs : null,
+          },
+          scopeSpans,
+        },
+      ],
+    };
+  }
+
+  private mapSpan(sp: ReadableSpan): OTLPSpan {
+    const ctx = sp.spanContext();
+
+    let parentSpanId: string | undefined;
+    if (sp.parentSpanContext?.spanId && sp.parentSpanContext.spanId !== "0000000000000000") {
+      parentSpanId = hexSpanId(sp.parentSpanContext.spanId);
+    }
+
+    const attrs = sp.attributes ? { ...sp.attributes } : {};
+
+    const events: OTLPEvent[] = (sp.events ?? []).map((ev) => {
+      const timeNs = Array.isArray(ev.time)
+        ? ev.time[0] * 1_000_000_000 + ev.time[1]
+        : (ev.time as number);
+      const evAttrs =
+        ev.attributes && Object.keys(ev.attributes).length > 0
+          ? { ...ev.attributes }
+          : null;
+      return { timeUnixNano: timeNs, name: ev.name, attributes: evAttrs };
+    });
+
+    const links: OTLPLink[] = (sp.links ?? []).map((ln) => {
+      const lnAttrs =
+        ln.attributes && Object.keys(ln.attributes).length > 0
+          ? { ...ln.attributes }
+          : null;
+      return {
+        traceId: hexTraceId(ln.context.traceId),
+        spanId: hexSpanId(ln.context.spanId),
+        attributes: lnAttrs,
+      };
+    });
+
+    const status: OTLPStatus = {
+      code: statusName(sp.status?.code ?? 0),
+      message: sp.status?.message || "",
+    };
+
+    const startTimeNs = Array.isArray(sp.startTime)
+      ? sp.startTime[0] * 1_000_000_000 + sp.startTime[1]
+      : (sp.startTime as number);
+    const endTimeNs = Array.isArray(sp.endTime)
+      ? sp.endTime[0] * 1_000_000_000 + sp.endTime[1]
+      : (sp.endTime as number);
+
+    return {
+      traceId: hexTraceId(ctx.traceId),
+      spanId: hexSpanId(ctx.spanId),
+      parentSpanId,
+      name: sp.name,
+      kind: kindName(sp.kind),
+      startTimeUnixNano: startTimeNs,
+      endTimeUnixNano: endTimeNs,
+      attributes: Object.keys(attrs).length > 0 ? attrs : null,
+      events: events.length > 0 ? events : null,
+      links: links.length > 0 ? links : null,
+      status,
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    this.closed = true;
+  }
+
+  async forceFlush(): Promise<void> {
+    // No-op — spans are exported immediately on export() call
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/_a365/exporter/Agent365ExporterOptions.ts
+++ b/src/_a365/exporter/Agent365ExporterOptions.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ClusterCategory } from "../configuration/A365ConfigurationOptions.js";
+
+/**
+ * A function that resolves an authentication token for the given agent and tenant.
+ * Return null if a token cannot be provided.
+ */
+export type TokenResolver = (
+  agentId: string,
+  tenantId: string,
+) => string | null | Promise<string | null>;
+
+/**
+ * Options controlling the behavior of the Agent365 span exporter.
+ */
+export interface Agent365ExporterOptions {
+  /** Cluster category for endpoint resolution. @default "prod" */
+  clusterCategory?: ClusterCategory;
+
+  /** Token resolver for authentication. Required for batch export. */
+  tokenResolver?: TokenResolver;
+
+  /** When true, use the S2S endpoint path (/observabilityService/...). @default false */
+  useS2SEndpoint?: boolean;
+
+  /** Override the A365 observability service domain. */
+  domainOverride?: string;
+
+  /** Maximum span queue size before drops occur. @default 2048 */
+  maxQueueSize?: number;
+
+  /** Delay (ms) between automatic batch flush attempts. @default 5000 */
+  scheduledDelayMilliseconds?: number;
+
+  /** Maximum time (ms) for the entire export() call. @default 90000 */
+  exporterTimeoutMilliseconds?: number;
+
+  /** Timeout (ms) per individual HTTP request. Each retry gets a fresh timeout. @default 30000 */
+  httpRequestTimeoutMilliseconds?: number;
+
+  /** Maximum number of spans per export batch. @default 512 */
+  maxExportBatchSize?: number;
+}
+
+/** Resolved options with defaults applied. */
+export class ResolvedExporterOptions {
+  public readonly clusterCategory: ClusterCategory;
+  public readonly tokenResolver?: TokenResolver;
+  public readonly useS2SEndpoint: boolean;
+  public readonly domainOverride?: string;
+  public readonly maxQueueSize: number;
+  public readonly scheduledDelayMilliseconds: number;
+  public readonly exporterTimeoutMilliseconds: number;
+  public readonly httpRequestTimeoutMilliseconds: number;
+  public readonly maxExportBatchSize: number;
+
+  constructor(options?: Agent365ExporterOptions) {
+    this.clusterCategory = options?.clusterCategory ?? "prod";
+    this.tokenResolver = options?.tokenResolver;
+    this.useS2SEndpoint = options?.useS2SEndpoint ?? false;
+    this.domainOverride = options?.domainOverride;
+    this.maxQueueSize = options?.maxQueueSize ?? 2048;
+    this.scheduledDelayMilliseconds = options?.scheduledDelayMilliseconds ?? 5000;
+    this.exporterTimeoutMilliseconds = options?.exporterTimeoutMilliseconds ?? 90000;
+    this.httpRequestTimeoutMilliseconds = options?.httpRequestTimeoutMilliseconds ?? 30000;
+    this.maxExportBatchSize = options?.maxExportBatchSize ?? 512;
+  }
+}

--- a/src/_a365/exporter/ExporterEventNames.ts
+++ b/src/_a365/exporter/ExporterEventNames.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Event names used by Agent365Exporter for logging and monitoring.
+ */
+export enum ExporterEventNames {
+  EXPORT = "agent365-export",
+  EXPORT_GROUP = "export-group",
+  EXPORT_PARTITION_SPAN_MISSING_IDENTITY = "export-partition-span-missing-identity",
+}

--- a/src/_a365/exporter/index.ts
+++ b/src/_a365/exporter/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export { Agent365Exporter } from "./Agent365Exporter.js";
+export type { Agent365ExporterOptions, TokenResolver } from "./Agent365ExporterOptions.js";
+export { ResolvedExporterOptions } from "./Agent365ExporterOptions.js";
+export { ExporterEventNames } from "./ExporterEventNames.js";
+export { truncateSpan, MAX_SPAN_SIZE_BYTES } from "./utils.js";

--- a/src/_a365/exporter/utils.ts
+++ b/src/_a365/exporter/utils.ts
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type { ClusterCategory } from "../configuration/A365ConfigurationOptions.js";
+import { Logger } from "../../shared/logging/index.js";
+import { ExporterEventNames } from "./ExporterEventNames.js";
+
+// Attribute keys for identity partitioning (from Agent365 OpenTelemetryConstants)
+const TENANT_ID_KEY = "microsoft.tenant.id";
+const GEN_AI_AGENT_ID_KEY = "gen_ai.agent.id";
+
+// Message attribute keys that receive special truncation handling
+const GEN_AI_INPUT_MESSAGES_KEY = "gen_ai.input.messages";
+const GEN_AI_OUTPUT_MESSAGES_KEY = "gen_ai.output.messages";
+const MESSAGE_ATTR_KEYS = new Set([GEN_AI_INPUT_MESSAGES_KEY, GEN_AI_OUTPUT_MESSAGES_KEY]);
+
+// A365 message schema version used in overflow sentinels
+const A365_MESSAGE_SCHEMA_VERSION = "1.0";
+const MESSAGE_ROLE_SYSTEM = "system";
+
+/**
+ * Partition spans by (tenantId, agentId) identity pairs.
+ * Spans missing either attribute are skipped.
+ */
+export function partitionByIdentity(spans: ReadableSpan[]): Map<string, ReadableSpan[]> {
+  const groups = new Map<string, ReadableSpan[]>();
+  let skippedCount = 0;
+
+  for (const span of spans) {
+    const attrs = span.attributes || {};
+    const tenant = asStr(attrs[TENANT_ID_KEY]);
+    const agent = asStr(attrs[GEN_AI_AGENT_ID_KEY]);
+
+    if (!tenant || !agent) {
+      skippedCount++;
+      continue;
+    }
+
+    const key = `${tenant}:${agent}`;
+    let existing = groups.get(key);
+    if (!existing) {
+      existing = [];
+      groups.set(key, existing);
+    }
+    existing.push(span);
+  }
+
+  if (skippedCount > 0) {
+    Logger.getInstance().info(
+      `[${ExporterEventNames.EXPORT_PARTITION_SPAN_MISSING_IDENTITY}] ${skippedCount} spans skipped (missing tenant or agent ID)`,
+    );
+  }
+
+  return groups;
+}
+
+/** Parse identity key back to tenant and agent IDs. */
+export function parseIdentityKey(key: string): { tenantId: string; agentId: string } {
+  const idx = key.indexOf(":");
+  return { tenantId: key.slice(0, idx), agentId: key.slice(idx + 1) };
+}
+
+/** Convert trace ID to hex string (32 hex chars). */
+export function hexTraceId(value: string | number): string {
+  if (typeof value === "number") {
+    return value.toString(16).padStart(32, "0");
+  }
+  return value.replace(/^0x/, "").padStart(32, "0");
+}
+
+/** Convert span ID to hex string (16 hex chars). */
+export function hexSpanId(value: string | number): string {
+  if (typeof value === "number") {
+    return value.toString(16).padStart(16, "0");
+  }
+  return value.replace(/^0x/, "").padStart(16, "0");
+}
+
+/** Convert any value to a trimmed string, or undefined if empty/null. */
+export function asStr(v: unknown): string | undefined {
+  if (v === null || v === undefined) return undefined;
+  const s = String(v);
+  return s.trim() ? s : undefined;
+}
+
+/** Get span kind name. */
+export function kindName(kind: SpanKind): string {
+  switch (kind) {
+    case SpanKind.INTERNAL: return "INTERNAL";
+    case SpanKind.SERVER: return "SERVER";
+    case SpanKind.CLIENT: return "CLIENT";
+    case SpanKind.PRODUCER: return "PRODUCER";
+    case SpanKind.CONSUMER: return "CONSUMER";
+    default: return "UNSPECIFIED";
+  }
+}
+
+/** Get status name. */
+export function statusName(code: SpanStatusCode): string {
+  switch (code) {
+    case SpanStatusCode.UNSET: return "UNSET";
+    case SpanStatusCode.OK: return "OK";
+    case SpanStatusCode.ERROR: return "ERROR";
+    default: return "UNSET";
+  }
+}
+
+/**
+ * Resolve the Agent365 service endpoint base URI for a given cluster category.
+ */
+export function resolveAgent365Endpoint(clusterCategory: ClusterCategory): string {
+  switch (clusterCategory) {
+    case "prod":
+    default:
+      return "https://agent365.svc.cloud.microsoft";
+  }
+}
+
+// ── Span truncation ─────────────────────────────────────────────────────────
+
+/** Maximum allowed span size in bytes (250KB). */
+export const MAX_SPAN_SIZE_BYTES = 250 * 1024;
+
+const BLOB_SENTINEL = "[blob truncated]";
+const JSON_SENTINEL = "[truncated]";
+const TRUNCATED_SUFFIX = "… [truncated]";
+const TRUNCATED_SUFFIX_BYTES = Buffer.byteLength(TRUNCATED_SUFFIX, "utf8");
+const OVERLIMIT_SENTINEL = "[overlimit]";
+const MIN_SHRINKABLE_STRING_BYTES = 50;
+
+interface OTLPSpanLike {
+  attributes: Record<string, unknown> | null;
+}
+
+interface ShrinkAction {
+  contentBytes: number;
+  apply(bytesToShed: number): void;
+  sourceKey?: string;
+}
+
+function getSerializedSize(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+/**
+ * Build a versioned message wrapper indicating original messages were dropped.
+ */
+function serializeOverflowSentinel(totalMessages: number): string {
+  return JSON.stringify({
+    version: A365_MESSAGE_SCHEMA_VERSION,
+    messages: [
+      {
+        role: MESSAGE_ROLE_SYSTEM,
+        parts: [
+          {
+            type: "text",
+            content: `[truncated: ${totalMessages} ${totalMessages === 1 ? "message" : "messages"} exceeded limit]`,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/**
+ * Trim a string by a target UTF-8 byte budget while preserving whole code points.
+ */
+function trimString(value: string, bytesToShed: number): string {
+  const currentBytes = Buffer.byteLength(value, "utf8");
+  const targetContentBytes = Math.max(0, currentBytes - Math.max(1, bytesToShed) - TRUNCATED_SUFFIX_BYTES);
+  if (targetContentBytes <= 0) return TRUNCATED_SUFFIX;
+
+  let consumedBytes = 0;
+  let endIndex = 0;
+  for (const codePoint of value) {
+    const cpBytes = Buffer.byteLength(codePoint, "utf8");
+    if (consumedBytes + cpBytes > targetContentBytes) break;
+    consumedBytes += cpBytes;
+    endIndex += codePoint.length;
+  }
+
+  return value.slice(0, endIndex) + TRUNCATED_SUFFIX;
+}
+
+function createBlobShrinkAction(
+  part: Record<string, unknown>,
+  sourceKey?: string,
+): ShrinkAction | undefined {
+  if (part.type === "blob" && typeof part.content === "string" && part.content !== BLOB_SENTINEL) {
+    const contentSize = Buffer.byteLength(part.content, "utf8");
+    if (contentSize <= 0) return undefined;
+    const action: ShrinkAction = {
+      contentBytes: contentSize,
+      sourceKey,
+      apply() {
+        part.content = BLOB_SENTINEL;
+        action.contentBytes = 0;
+      },
+    };
+    return action;
+  }
+  return undefined;
+}
+
+/**
+ * Collect all shrink candidates from message parts and direct string attributes.
+ */
+function collectShrinkActions(
+  attributes: Record<string, unknown>,
+  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+): ShrinkAction[] {
+  const actions: ShrinkAction[] = [];
+
+  for (const key of Object.keys(attributes)) {
+    let handledAsMessage = false;
+
+    if (MESSAGE_ATTR_KEYS.has(key)) {
+      if (!parsedMessages.has(key) && typeof attributes[key] === "string") {
+        try {
+          const parsed = JSON.parse(attributes[key] as string);
+          if (parsed && typeof parsed === "object" && Array.isArray(parsed.messages)) {
+            parsedMessages.set(key, parsed);
+          }
+        } catch {
+          // Not valid JSON — will fall through to string trim
+        }
+      }
+
+      if (parsedMessages.has(key)) {
+        handledAsMessage = true;
+        const wrapper = parsedMessages.get(key)!;
+        for (const message of wrapper.messages) {
+          if (!Array.isArray(message.parts)) continue;
+          for (const part of message.parts) {
+            const partType = part.type as string;
+
+            // Blob → sentinel
+            const blobAction = createBlobShrinkAction(part, key);
+            if (blobAction) {
+              actions.push(blobAction);
+            }
+
+            // Tool/server JSON payload fields → sentinel
+            const jsonField =
+              partType === "tool_call" ? "arguments"
+                : partType === "tool_call_response" ? "response"
+                  : partType === "server_tool_call" ? "server_tool_call"
+                    : partType === "server_tool_call_response" ? "server_tool_call_response"
+                      : undefined;
+
+            if (jsonField && part[jsonField] !== undefined && part[jsonField] !== JSON_SENTINEL) {
+              let fieldSize: number;
+              try { fieldSize = Buffer.byteLength(JSON.stringify(part[jsonField]), "utf8"); }
+              catch { fieldSize = 0; }
+              if (fieldSize > 0) {
+                const action: ShrinkAction = {
+                  contentBytes: fieldSize,
+                  sourceKey: key,
+                  apply() {
+                    part[jsonField!] = JSON_SENTINEL;
+                    action.contentBytes = 0;
+                  },
+                };
+                actions.push(action);
+              }
+              continue;
+            }
+
+            // Text/reasoning → trim
+            if ((partType === "text" || partType === "reasoning") && typeof part.content === "string") {
+              const contentSize = Buffer.byteLength(part.content, "utf8");
+              if (contentSize > MIN_SHRINKABLE_STRING_BYTES) {
+                const action: ShrinkAction = {
+                  contentBytes: contentSize,
+                  sourceKey: key,
+                  apply(bytesToShed: number) {
+                    const cur = Buffer.byteLength(part.content as string, "utf8");
+                    if (cur > TRUNCATED_SUFFIX_BYTES) {
+                      part.content = trimString(part.content as string, bytesToShed);
+                      action.contentBytes = Buffer.byteLength(part.content as string, "utf8");
+                    }
+                  },
+                };
+                actions.push(action);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Non-message string attribute → trim
+    if (!handledAsMessage && typeof attributes[key] === "string") {
+      const value = attributes[key] as string;
+      const valueSize = Buffer.byteLength(value, "utf8");
+      if (valueSize > MIN_SHRINKABLE_STRING_BYTES) {
+        const action: ShrinkAction = {
+          contentBytes: valueSize,
+          apply(bytesToShed: number) {
+            const cur = Buffer.byteLength(attributes[key] as string, "utf8");
+            if (cur > TRUNCATED_SUFFIX_BYTES) {
+              attributes[key] = trimString(attributes[key] as string, bytesToShed);
+              action.contentBytes = Buffer.byteLength(attributes[key] as string, "utf8");
+            }
+          },
+        };
+        actions.push(action);
+      }
+    }
+  }
+
+  return actions;
+}
+
+function flushParsedMessages(
+  attributes: Record<string, unknown>,
+  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+): void {
+  for (const [key, wrapper] of parsedMessages) {
+    try {
+      attributes[key] = JSON.stringify(wrapper);
+    } catch {
+      // Leave the previous value intact
+    }
+  }
+}
+
+function flushParsedMessage(
+  attributes: Record<string, unknown>,
+  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  key: string,
+): void {
+  const wrapper = parsedMessages.get(key);
+  if (wrapper) {
+    try {
+      attributes[key] = JSON.stringify(wrapper);
+    } catch {
+      // Leave the previous value intact
+    }
+  }
+}
+
+function runShrinkPhase(
+  span: OTLPSpanLike,
+  attributes: Record<string, unknown>,
+  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  currentSize: number,
+): number {
+  let nextSize = currentSize;
+  const actions = collectShrinkActions(attributes, parsedMessages);
+
+  while (actions.length > 0 && nextSize > MAX_SPAN_SIZE_BYTES) {
+    let maxIdx = 0;
+    for (let j = 1; j < actions.length; j++) {
+      if (actions[j].contentBytes > actions[maxIdx].contentBytes) maxIdx = j;
+    }
+
+    const excess = nextSize - MAX_SPAN_SIZE_BYTES;
+    const previousSize = nextSize;
+    const action = actions[maxIdx];
+    action.apply(excess);
+
+    if (action.sourceKey) {
+      flushParsedMessage(attributes, parsedMessages, action.sourceKey);
+    }
+    nextSize = getSerializedSize(span);
+
+    if (nextSize >= previousSize) {
+      actions.splice(maxIdx, 1);
+    } else if (action.contentBytes <= MIN_SHRINKABLE_STRING_BYTES) {
+      actions.splice(maxIdx, 1);
+    }
+  }
+
+  flushParsedMessages(attributes, parsedMessages);
+  return nextSize;
+}
+
+/**
+ * Truncate span attributes if the serialized span exceeds MAX_SPAN_SIZE_BYTES.
+ *
+ * Phase 1: iteratively shrink fields (blobs, text, json, strings) by size priority.
+ * Phase 2 (fallback): replace remaining string attributes with overlimit sentinel.
+ */
+export function truncateSpan<T extends OTLPSpanLike>(spanDict: T): T {
+  try {
+    let currentSize = getSerializedSize(spanDict);
+    if (currentSize <= MAX_SPAN_SIZE_BYTES) return spanDict;
+
+    Logger.getInstance().warn(
+      `[Agent365Exporter] Span size (${currentSize} bytes) exceeds limit (${MAX_SPAN_SIZE_BYTES} bytes). Shrinking.`,
+    );
+
+    const truncated = { ...spanDict };
+    if (truncated.attributes) truncated.attributes = { ...truncated.attributes };
+    const attributes = truncated.attributes;
+    if (!attributes) return truncated;
+
+    const parsedMessages = new Map<
+      string,
+      { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
+    >();
+
+    // Phase 1: iteratively shrink fields by size priority
+    currentSize = runShrinkPhase(truncated, attributes, parsedMessages, currentSize);
+
+    if (currentSize > MAX_SPAN_SIZE_BYTES) {
+      // Phase 2: replace all string attributes with sentinels, largest first
+      const stringKeys = Object.keys(attributes)
+        .filter((k) => typeof attributes[k] === "string" && attributes[k] !== OVERLIMIT_SENTINEL)
+        .sort(
+          (a, b) =>
+            Buffer.byteLength(attributes[b] as string, "utf8") -
+            Buffer.byteLength(attributes[a] as string, "utf8"),
+        );
+
+      for (const key of stringKeys) {
+        if (currentSize <= MAX_SPAN_SIZE_BYTES) break;
+        if (MESSAGE_ATTR_KEYS.has(key)) {
+          let messageCount = 0;
+          const cached = parsedMessages.get(key);
+          if (cached) {
+            messageCount = cached.messages.length;
+          } else if (typeof attributes[key] === "string") {
+            try {
+              const parsed = JSON.parse(attributes[key] as string);
+              if (parsed && Array.isArray(parsed.messages)) {
+                messageCount = parsed.messages.length;
+              }
+            } catch { /* not valid JSON */ }
+          }
+          attributes[key] = serializeOverflowSentinel(messageCount);
+          parsedMessages.delete(key);
+        } else {
+          attributes[key] = OVERLIMIT_SENTINEL;
+        }
+        currentSize = getSerializedSize(truncated);
+      }
+    }
+
+    if (currentSize > MAX_SPAN_SIZE_BYTES) {
+      Logger.getInstance().warn(
+        `[Agent365Exporter] Span still ${currentSize} bytes after truncation (limit: ${MAX_SPAN_SIZE_BYTES}).`,
+      );
+    }
+
+    return truncated;
+  } catch (e) {
+    Logger.getInstance().error(`[Agent365Exporter] Error during span truncation: ${e}`);
+    return spanDict;
+  }
+}

--- a/src/_a365/index.ts
+++ b/src/_a365/index.ts
@@ -8,3 +8,7 @@ export type {
   A365BaggageOptions,
   A365HostingOptions,
 } from "./configuration/index.js";
+
+export { Agent365Exporter } from "./exporter/index.js";
+export type { Agent365ExporterOptions, TokenResolver } from "./exporter/index.js";
+export { ResolvedExporterOptions } from "./exporter/index.js";

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
+import { ExportResultCode } from "@opentelemetry/core";
+import { SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { Agent365Exporter } from "../../../../src/_a365/exporter/Agent365Exporter.js";
+import {
+  partitionByIdentity,
+  parseIdentityKey,
+  hexTraceId,
+  hexSpanId,
+  kindName,
+  statusName,
+  resolveAgent365Endpoint,
+  truncateSpan,
+  MAX_SPAN_SIZE_BYTES,
+} from "../../../../src/_a365/exporter/utils.js";
+import { ResolvedExporterOptions } from "../../../../src/_a365/exporter/Agent365ExporterOptions.js";
+
+function makeSpan(overrides: Partial<ReadableSpan> = {}): ReadableSpan {
+  return {
+    name: "test-span",
+    kind: SpanKind.INTERNAL,
+    spanContext: () => ({
+      traceId: "aaaabbbbccccddddeeee111122223333",
+      spanId: "1111222233334444",
+      traceFlags: TraceFlags.SAMPLED,
+    }),
+    parentSpanContext: undefined,
+    startTime: [1700000000, 0],
+    endTime: [1700000001, 0],
+    status: { code: SpanStatusCode.OK },
+    attributes: {
+      "microsoft.tenant.id": "tenant-1",
+      "gen_ai.agent.id": "agent-1",
+    },
+    events: [],
+    links: [],
+    resource: { attributes: {} },
+    instrumentationScope: { name: "test-scope", version: "1.0.0" },
+    instrumentationLibrary: { name: "test-scope", version: "1.0.0" },
+    duration: [1, 0],
+    ended: true,
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ...overrides,
+  } as unknown as ReadableSpan;
+}
+
+describe("Agent365Exporter", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: new Map([["x-ms-correlation-id", "corr-123"]]),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("export", () => {
+    it("should export spans successfully", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      const span = makeSpan();
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([span], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(fetchSpy.mock.calls.length, 1);
+
+      const [url, options] = fetchSpy.mock.calls[0];
+      assert.ok(url.includes("/observability/tenants/tenant-1/agents/agent-1/traces"));
+      assert.strictEqual(options.method, "POST");
+      assert.strictEqual(options.headers["authorization"], "Bearer test-token");
+      assert.strictEqual(options.headers["x-ms-tenant-id"], "tenant-1");
+      assert.strictEqual(options.headers["content-type"], "application/json");
+    });
+
+    it("should use S2S endpoint when configured", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+        useS2SEndpoint: true,
+      });
+
+      await new Promise<void>((resolve) => {
+        exporter.export([makeSpan()], () => resolve());
+      });
+
+      const [url] = fetchSpy.mock.calls[0];
+      assert.ok(url.includes("/observabilityService/tenants/"));
+    });
+
+    it("should use domain override when configured", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+        domainOverride: "https://custom.example.com",
+      });
+
+      await new Promise<void>((resolve) => {
+        exporter.export([makeSpan()], () => resolve());
+      });
+
+      const [url] = fetchSpy.mock.calls[0];
+      assert.ok(url.startsWith("https://custom.example.com/"));
+    });
+
+    it("should skip export when no token resolver", async () => {
+      const exporter = new Agent365Exporter({});
+
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(fetchSpy.mock.calls.length, 0);
+    });
+
+    it("should skip spans missing identity attributes", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      const spanNoIdentity = makeSpan({ attributes: {} });
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([spanNoIdentity], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(fetchSpy.mock.calls.length, 0);
+    });
+
+    it("should fail after shutdown", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      await exporter.shutdown();
+
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.FAILED);
+    });
+
+    it("should build correct OTLP payload", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      await new Promise<void>((resolve) => {
+        exporter.export([makeSpan()], () => resolve());
+      });
+
+      const [, options] = fetchSpy.mock.calls[0];
+      const payload = JSON.parse(options.body);
+
+      assert.ok(payload.resourceSpans);
+      assert.strictEqual(payload.resourceSpans.length, 1);
+      assert.ok(payload.resourceSpans[0].scopeSpans);
+      assert.strictEqual(payload.resourceSpans[0].scopeSpans.length, 1);
+      assert.strictEqual(payload.resourceSpans[0].scopeSpans[0].scope.name, "test-scope");
+
+      const span = payload.resourceSpans[0].scopeSpans[0].spans[0];
+      assert.strictEqual(span.name, "test-span");
+      assert.strictEqual(span.kind, "INTERNAL");
+      assert.strictEqual(span.status.code, "OK");
+    });
+
+    it("should partition spans by identity and export separately", async () => {
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      const span1 = makeSpan({
+        attributes: { "microsoft.tenant.id": "t1", "gen_ai.agent.id": "a1" },
+      });
+      const span2 = makeSpan({
+        attributes: { "microsoft.tenant.id": "t2", "gen_ai.agent.id": "a2" },
+      });
+
+      await new Promise<void>((resolve) => {
+        exporter.export([span1, span2], () => resolve());
+      });
+
+      assert.strictEqual(fetchSpy.mock.calls.length, 2);
+    });
+  });
+
+  describe("retry", () => {
+    it("should retry on 500 errors", async () => {
+      let callCount = 0;
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount < 3) {
+          return Promise.resolve({
+            status: 500,
+            headers: new Map([["x-ms-correlation-id", "corr"]]),
+          });
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: new Map([["x-ms-correlation-id", "corr"]]),
+        });
+      });
+
+      const exporter = new Agent365Exporter({
+        tokenResolver: () => "test-token",
+      });
+
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.ok(callCount >= 3);
+    });
+  });
+});
+
+describe("Exporter utils", () => {
+  describe("partitionByIdentity", () => {
+    it("should group spans by tenant:agent key", () => {
+      const spans = [
+        makeSpan({ attributes: { "microsoft.tenant.id": "t1", "gen_ai.agent.id": "a1" } }),
+        makeSpan({ attributes: { "microsoft.tenant.id": "t1", "gen_ai.agent.id": "a1" } }),
+        makeSpan({ attributes: { "microsoft.tenant.id": "t2", "gen_ai.agent.id": "a2" } }),
+      ];
+      const groups = partitionByIdentity(spans);
+      assert.strictEqual(groups.size, 2);
+      assert.strictEqual(groups.get("t1:a1")?.length, 2);
+      assert.strictEqual(groups.get("t2:a2")?.length, 1);
+    });
+
+    it("should skip spans without identity attributes", () => {
+      const spans = [
+        makeSpan({ attributes: {} }),
+        makeSpan({ attributes: { "microsoft.tenant.id": "t1" } }),
+      ];
+      const groups = partitionByIdentity(spans);
+      assert.strictEqual(groups.size, 0);
+    });
+  });
+
+  describe("parseIdentityKey", () => {
+    it("should split key into tenantId and agentId", () => {
+      const result = parseIdentityKey("tenant-1:agent-1");
+      assert.strictEqual(result.tenantId, "tenant-1");
+      assert.strictEqual(result.agentId, "agent-1");
+    });
+  });
+
+  describe("hexTraceId / hexSpanId", () => {
+    it("should pad string trace IDs to 32 chars", () => {
+      assert.strictEqual(hexTraceId("abc").length, 32);
+    });
+
+    it("should pad string span IDs to 16 chars", () => {
+      assert.strictEqual(hexSpanId("abc").length, 16);
+    });
+
+    it("should convert numeric trace IDs", () => {
+      assert.strictEqual(hexTraceId(255), "000000000000000000000000000000ff");
+    });
+  });
+
+  describe("kindName / statusName", () => {
+    it("should map span kinds", () => {
+      assert.strictEqual(kindName(SpanKind.INTERNAL), "INTERNAL");
+      assert.strictEqual(kindName(SpanKind.SERVER), "SERVER");
+      assert.strictEqual(kindName(SpanKind.CLIENT), "CLIENT");
+    });
+
+    it("should map status codes", () => {
+      assert.strictEqual(statusName(SpanStatusCode.OK), "OK");
+      assert.strictEqual(statusName(SpanStatusCode.ERROR), "ERROR");
+      assert.strictEqual(statusName(SpanStatusCode.UNSET), "UNSET");
+    });
+  });
+
+  describe("resolveAgent365Endpoint", () => {
+    it("should return prod endpoint for prod category", () => {
+      assert.strictEqual(
+        resolveAgent365Endpoint("prod"),
+        "https://agent365.svc.cloud.microsoft",
+      );
+    });
+  });
+
+  describe("ResolvedExporterOptions", () => {
+    it("should apply defaults", () => {
+      const opts = new ResolvedExporterOptions();
+      assert.strictEqual(opts.clusterCategory, "prod");
+      assert.strictEqual(opts.useS2SEndpoint, false);
+      assert.strictEqual(opts.maxQueueSize, 2048);
+      assert.strictEqual(opts.scheduledDelayMilliseconds, 5000);
+      assert.strictEqual(opts.exporterTimeoutMilliseconds, 90000);
+      assert.strictEqual(opts.httpRequestTimeoutMilliseconds, 30000);
+      assert.strictEqual(opts.maxExportBatchSize, 512);
+    });
+
+    it("should accept overrides", () => {
+      const opts = new ResolvedExporterOptions({
+        clusterCategory: "preprod",
+        maxQueueSize: 1024,
+        httpRequestTimeoutMilliseconds: 10000,
+      });
+      assert.strictEqual(opts.clusterCategory, "preprod");
+      assert.strictEqual(opts.maxQueueSize, 1024);
+      assert.strictEqual(opts.httpRequestTimeoutMilliseconds, 10000);
+    });
+  });
+
+  describe("truncateSpan", () => {
+    it("should return span unchanged if under size limit", () => {
+      const span = { attributes: { key: "small value" } };
+      const result = truncateSpan(span);
+      assert.strictEqual(result.attributes!["key"], "small value");
+    });
+
+    it("should truncate large string attributes", () => {
+      const largeValue = "x".repeat(MAX_SPAN_SIZE_BYTES + 1000);
+      const span = { attributes: { key: largeValue } };
+      const result = truncateSpan(span);
+      const size = Buffer.byteLength(JSON.stringify(result), "utf8");
+      assert.ok(size <= MAX_SPAN_SIZE_BYTES, `Truncated span is ${size} bytes, expected <= ${MAX_SPAN_SIZE_BYTES}`);
+      assert.ok((result.attributes!["key"] as string).endsWith("[truncated]"));
+    });
+
+    it("should truncate blob parts in message attributes", () => {
+      const blobContent = "b".repeat(MAX_SPAN_SIZE_BYTES);
+      const messageWrapper = JSON.stringify({
+        version: "1.0",
+        messages: [{ role: "user", parts: [{ type: "blob", content: blobContent }] }],
+      });
+      const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
+      const result = truncateSpan(span);
+      const size = Buffer.byteLength(JSON.stringify(result), "utf8");
+      assert.ok(size <= MAX_SPAN_SIZE_BYTES);
+      const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
+      assert.strictEqual(parsed.messages[0].parts[0].content, "[blob truncated]");
+    });
+
+    it("should fall back to overlimit sentinel for message attributes", () => {
+      const messages = Array.from({ length: 50 }, () => ({
+        role: "user",
+        parts: [{ type: "text", content: "y".repeat(10000) }],
+      }));
+      const messageWrapper = JSON.stringify({ version: "1.0", messages });
+      const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
+      const result = truncateSpan(span);
+      const size = Buffer.byteLength(JSON.stringify(result), "utf8");
+      assert.ok(size <= MAX_SPAN_SIZE_BYTES);
+    });
+
+    it("should handle spans with no attributes", () => {
+      const span = { attributes: null };
+      const result = truncateSpan(span);
+      assert.strictEqual(result.attributes, null);
+    });
+  });
+});


### PR DESCRIPTION
Migrate the Agent365 exporter from microsoft/Agent365-nodejs into the distro under src/_a365/exporter/. Implements SpanExporter from @opentelemetry/sdk-trace-base.

Key behaviors preserved from source:
- Span partitioning by (tenantId, agentId) identity tuples
- OTLP-like JSON payload construction (resourceSpans/scopeSpans/spans)
- Dual endpoint styles: /observability/ and /observabilityService/ (S2S)
- Token resolution via tokenResolver callback
- Retry with exponential backoff on 408/429/5xx
- HTTP request timeout via AbortSignal.timeout
- Span truncation (250KB limit) with 2-phase shrinking: Phase 1: blobs, tool JSON, text/reasoning by size priority Phase 2: overlimit sentinel fallback for remaining strings

Adaptations:
- Replaced agents-a365-runtime config with distro A365Configuration
- Replaced internal logger with distro Logger singleton
- Uses native fetch (Node 18+)
- Per-request token context deferred to Task 5

25 new tests, 55 total A365 tests passing.