### PR TITLE
Fix dual ESM/CJS output, Azure Monitor disable flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/commonjs/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "npm run clean && tsc -p tsconfig.src.json && tsc -p tsconfig.src.cjs.json",
+    "build": "npm run clean && tsc -p tsconfig.src.json && tsc -p tsconfig.src.cjs.json && npm run fixup-cjs",
+    "fixup-cjs": "node scripts/fixup-cjs.cjs",
     "clean": "rimraf dist",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",

--- a/scripts/fixup-cjs.cjs
+++ b/scripts/fixup-cjs.cjs
@@ -1,0 +1,42 @@
+// Post-build fixups for the CommonJS output.
+//
+// The ESM build (dist/esm/) works as-is. The CJS build (dist/commonjs/)
+// needs two fixups:
+//
+// 1. A package.json with {"type":"commonjs"} so Node doesn't treat .js
+//    files as ESM (the root package.json has "type":"module").
+//
+// 2. The module-cjs.cts polyfill must replace module.ts in the CJS output,
+//    because module.ts uses import.meta.url which is ESM-only.
+//
+// 3. The Azure Functions instrumentation import must be fixed. The ESM
+//    build uses a default import (required because the package is a webpack
+//    bundle and Node ESM can't extract named exports). In CJS, the
+//    __importDefault helper double-wraps the require result, so we replace
+//    it with a direct require + destructure.
+
+const fs = require("fs");
+const path = require("path");
+
+const cjsDir = path.join(__dirname, "..", "dist", "commonjs");
+
+// 1. CJS package.json marker
+fs.writeFileSync(path.join(cjsDir, "package.json"), '{"type":"commonjs"}\n');
+
+// 2. module.ts → module-cjs.cts polyfill swap
+fs.copyFileSync(
+  path.join(cjsDir, "shared", "module-cjs.cjs"),
+  path.join(cjsDir, "shared", "module.js"),
+);
+
+// 3. Fix Azure Functions default-import in CJS output
+const handlerPath = path.join(cjsDir, "azureMonitor", "traces", "handler.js");
+let handler = fs.readFileSync(handlerPath, "utf8");
+// Replace the __importDefault pattern with a direct require
+handler = handler.replace(
+  /const functions_opentelemetry_instrumentation_1 = __importDefault\(require\("@azure\/functions-opentelemetry-instrumentation"\)\);\s*const \{ AzureFunctionsInstrumentation \} = functions_opentelemetry_instrumentation_1\.default;/,
+  'const { AzureFunctionsInstrumentation } = require("@azure/functions-opentelemetry-instrumentation");',
+);
+fs.writeFileSync(handlerPath, handler);
+
+console.log("CJS fixups applied.");

--- a/scripts/fixup-cjs.cjs
+++ b/scripts/fixup-cjs.cjs
@@ -24,19 +24,36 @@ const cjsDir = path.join(__dirname, "..", "dist", "commonjs");
 fs.writeFileSync(path.join(cjsDir, "package.json"), '{"type":"commonjs"}\n');
 
 // 2. module.ts → module-cjs.cts polyfill swap
+const sharedDir = path.join(cjsDir, "shared");
 fs.copyFileSync(
-  path.join(cjsDir, "shared", "module-cjs.cjs"),
-  path.join(cjsDir, "shared", "module.js"),
+  path.join(sharedDir, "module-cjs.cjs"),
+  path.join(sharedDir, "module.js"),
 );
+// Keep source maps consistent: copy the CJS map or remove the stale ESM one
+const moduleCjsMapPath = path.join(sharedDir, "module-cjs.cjs.map");
+const moduleJsMapPath = path.join(sharedDir, "module.js.map");
+if (fs.existsSync(moduleCjsMapPath)) {
+  fs.copyFileSync(moduleCjsMapPath, moduleJsMapPath);
+} else if (fs.existsSync(moduleJsMapPath)) {
+  fs.unlinkSync(moduleJsMapPath);
+}
 
 // 3. Fix Azure Functions default-import in CJS output
 const handlerPath = path.join(cjsDir, "azureMonitor", "traces", "handler.js");
-let handler = fs.readFileSync(handlerPath, "utf8");
+const handler = fs.readFileSync(handlerPath, "utf8");
+const azureFunctionsImportPattern =
+  /const functions_opentelemetry_instrumentation_1 = __importDefault\(require\("@azure\/functions-opentelemetry-instrumentation"\)\);\s*const \{ AzureFunctionsInstrumentation \} = functions_opentelemetry_instrumentation_1\.default;/;
 // Replace the __importDefault pattern with a direct require
-handler = handler.replace(
-  /const functions_opentelemetry_instrumentation_1 = __importDefault\(require\("@azure\/functions-opentelemetry-instrumentation"\)\);\s*const \{ AzureFunctionsInstrumentation \} = functions_opentelemetry_instrumentation_1\.default;/,
+const updatedHandler = handler.replace(
+  azureFunctionsImportPattern,
   'const { AzureFunctionsInstrumentation } = require("@azure/functions-opentelemetry-instrumentation");',
 );
-fs.writeFileSync(handlerPath, handler);
+if (updatedHandler === handler) {
+  throw new Error(
+    `Azure Functions CJS import fixup did not match expected output in ${handlerPath}. ` +
+    `The emitted CommonJS handler format may have changed; update scripts/fixup-cjs.cjs before publishing.`,
+  );
+}
+fs.writeFileSync(handlerPath, updatedHandler);
 
 console.log("CJS fixups applied.");

--- a/src/azureMonitor/traces/handler.ts
+++ b/src/azureMonitor/traces/handler.ts
@@ -23,7 +23,11 @@ import type { InternalConfig } from "../../shared/config.js";
 import type { MetricHandler } from "../metrics/handler.js";
 import { ignoreOutgoingRequestHook } from "../utils/common.js";
 import { AzureMonitorSpanProcessor } from "./spanProcessor.js";
-import { AzureFunctionsInstrumentation } from "@azure/functions-opentelemetry-instrumentation";
+// Default-import + destructure: this package is a webpack bundle so Node.js
+// ESM cannot extract named exports from it (see Node error SyntaxError:
+// "Named export 'AzureFunctionsInstrumentation' not found").
+import azureFunctionsOtelPkg from "@azure/functions-opentelemetry-instrumentation";
+const { AzureFunctionsInstrumentation } = azureFunctionsOtelPkg;
 import type { Instrumentation } from "@opentelemetry/instrumentation";
 import { ApplicationInsightsSampler } from "./sampler.js";
 

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -8,6 +8,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import type { MetricReader, ViewOptions } from "@opentelemetry/sdk-metrics";
 import { type SpanProcessor, BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type { LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import type { Instrumentation } from "@opentelemetry/instrumentation";
 
 import { InternalConfig } from "../shared/config.js";
 import { MetricHandler } from "../azureMonitor/metrics/index.js";
@@ -48,8 +49,12 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
 
+  const azureMonitorEnabled = options?.azureMonitor?.enabled !== false;
+
   // ── Azure Monitor components (statsbeat, browser SDK loader, etc.) ─
-  disposeAzureMonitor = setupAzureMonitorComponents(config);
+  if (azureMonitorEnabled) {
+    disposeAzureMonitor = setupAzureMonitorComponents(config);
+  }
 
   // ── Register global providers ─────────────────────────────────────
   // Remove global providers in OpenTelemetry, these would be overridden if present
@@ -67,14 +72,21 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const globalOpentelemetryApiKey = Symbol.for("opentelemetry.js.api.1");
   delete (globalThis as Record<symbol, unknown>)[globalOpentelemetryApiKey];
 
-  // ── Azure Monitor handlers ────────────────────────────────────────
-  const metricHandler = new MetricHandler(config);
-  const traceHandler = new TraceHandler(config, metricHandler);
-  const logHandler = new LogHandler(config, metricHandler);
+  // ── Azure Monitor handlers (conditional) ──────────────────────────
+  let metricHandler: MetricHandler | undefined;
+  let traceHandler: TraceHandler | undefined;
+  let logHandler: LogHandler | undefined;
+  const instrumentations: Instrumentation[] = [];
 
-  const instrumentations = traceHandler
-    .getInstrumentations()
-    .concat(logHandler.getInstrumentations());
+  if (azureMonitorEnabled) {
+    metricHandler = new MetricHandler(config);
+    traceHandler = new TraceHandler(config, metricHandler);
+    logHandler = new LogHandler(config, metricHandler);
+    instrumentations.push(
+      ...traceHandler.getInstrumentations(),
+      ...logHandler.getInstrumentations(),
+    );
+  }
 
   const resourceDetectorsList = parseResourceDetectorsFromEnvVar();
 
@@ -84,9 +96,8 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const logRecordProcessors: LogRecordProcessor[] = [...(options?.logRecordProcessors || [])];
   const customViews: ViewOptions[] = [...(options?.views || [])];
 
-  // Always include Azure Monitor metric reader
   const metricReaders: MetricReader[] = [
-    metricHandler.getMetricReader(),
+    ...(metricHandler ? [metricHandler.getMetricReader()] : []),
     ...(options?.metricReaders || []),
   ];
 
@@ -124,7 +135,10 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     spanProcessors.push(a365ExportProcessor);
   }
 
-  const views: ViewOptions[] = metricHandler.getViews().concat(customViews);
+  const views: ViewOptions[] = [
+    ...(metricHandler ? metricHandler.getViews() : []),
+    ...customViews,
+  ];
 
   // ── Create and start NodeSDK ──────────────────────────────────────
   const sdkConfig: Partial<NodeSDKConfiguration> = {
@@ -133,16 +147,16 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     views,
     instrumentations: instrumentations,
     logRecordProcessors: [
-      logHandler.getAzureLogRecordProcessor(),
+      ...(logHandler ? [logHandler.getAzureLogRecordProcessor()] : []),
       ...logRecordProcessors,
-      logHandler.getBatchLogRecordProcessor(),
+      ...(logHandler ? [logHandler.getBatchLogRecordProcessor()] : []),
     ],
     resource: config.resource,
-    sampler: traceHandler.getSampler(),
+    sampler: traceHandler?.getSampler(),
     spanProcessors: [
-      traceHandler.getAzureMonitorSpanProcessor(),
+      ...(traceHandler ? [traceHandler.getAzureMonitorSpanProcessor()] : []),
       ...spanProcessors,
-      traceHandler.getBatchSpanProcessor(),
+      ...(traceHandler ? [traceHandler.getBatchSpanProcessor()] : []),
     ],
     resourceDetectors: resourceDetectorsList,
   };

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -39,7 +39,7 @@ let disposeAzureMonitor: (() => void) | undefined;
  *
  * This is the primary entry point for the distro. It sets up OpenTelemetry
  * providers and instrumentations, then attaches the configured exporters:
- * - Azure Monitor (when `options.azureMonitor` is provided)
+ * - Azure Monitor (enabled by default; disable with `options.azureMonitor.enabled = false`)
  * - OTLP HTTP (when `OTEL_EXPORTER_OTLP_ENDPOINT` is set)
  * - A365 (when `options.a365.enabled` is true or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`)
  *
@@ -52,6 +52,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const azureMonitorEnabled = options?.azureMonitor?.enabled !== false;
 
   // ── Azure Monitor components (statsbeat, browser SDK loader, etc.) ─
+  disposeAzureMonitor = undefined;
   if (azureMonitorEnabled) {
     disposeAzureMonitor = setupAzureMonitorComponents(config);
   }
@@ -135,10 +136,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     spanProcessors.push(a365ExportProcessor);
   }
 
-  const views: ViewOptions[] = [
-    ...(metricHandler ? metricHandler.getViews() : []),
-    ...customViews,
-  ];
+  const views: ViewOptions[] = [...(metricHandler ? metricHandler.getViews() : []), ...customViews];
 
   // ── Create and start NodeSDK ──────────────────────────────────────
   const sdkConfig: Partial<NodeSDKConfiguration> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,10 @@ export {
   OpenTelemetryConstants,
   MessageRole,
   FinishReason,
+  Modality,
+  InvocationRole,
   InferenceOperationType,
+  A365_MESSAGE_SCHEMA_VERSION,
   isParentSpanRef,
   createContextWithParentSpanRef,
   runWithParentSpanRef,
@@ -72,6 +75,10 @@ export type {
   OutputMessagesParam,
   ResponseMessagesParam,
   MessagePart,
+  TextPart,
+  ToolCallRequestPart,
+  ToolCallResponsePart,
+  ReasoningPart,
   HeadersCarrier,
 } from "./a365/index.js";
 export type { PerRequestSpanProcessorOptions } from "./a365/index.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface MicrosoftOpenTelemetryOptions {
  * distro level in {@link MicrosoftOpenTelemetryOptions}.
  */
 export interface AzureMonitorOpenTelemetryOptions {
+  /** Enable or disable Azure Monitor export (Default true) */
+  enabled?: boolean;
   /** Azure Monitor Exporter Configuration */
   azureMonitorExporterOptions?: AzureMonitorExporterOptions;
   /** Enable Live Metrics feature (Default false) */

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -811,4 +811,48 @@ describe("Main functions", () => {
 
     void shutdownAzureMonitor();
   });
+
+  it("useMicrosoftOpenTelemetry with azureMonitor.enabled=false should skip Azure Monitor handlers", async () => {
+    const { useMicrosoftOpenTelemetry, shutdownMicrosoftOpenTelemetry } =
+      await import("../../../src/index.js");
+    const processor: SpanProcessor = {
+      forceFlush: () => Promise.resolve(),
+      onStart: () => {
+        /* no-op */
+      },
+      onEnd: () => {
+        /* no-op */
+      },
+      shutdown: () => Promise.resolve(),
+    };
+
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      spanProcessors: [processor],
+    });
+
+    // Providers should still be registered (the SDK still starts)
+    const internalSdk = _getSdkInstance();
+    assert.isDefined(internalSdk);
+
+    // The tracer provider should contain the user-provided processor
+    // but NOT Azure Monitor span processors (AzureMonitorSpanProcessor / BatchSpanProcessor)
+    const tracerProvider = (internalSdk as any)["_tracerProvider"];
+    const registeredProcessors = tracerProvider?.["_registeredSpanProcessors"] || [];
+    const processorNames = registeredProcessors.map((p: SpanProcessor) => p.constructor.name);
+    // User-provided processor (Object) should be present but no Azure Monitor ones
+    expect(processorNames).not.toContain("AzureMonitorSpanProcessor");
+    expect(processorNames).not.toContain("AzureMonitorExporterProcessor");
+
+    // Metric readers should not contain Azure Monitor readers
+    const meterProvider = (internalSdk as any)["_meterProvider"];
+    const metricReaders = meterProvider?.["_sharedState"]?.metricCollectors || [];
+    assert.strictEqual(
+      metricReaders.length,
+      0,
+      "Should have no metric readers when Azure Monitor is disabled and no custom readers provided",
+    );
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
 });

--- a/test/internal/unit/traces/traceHandler.test.ts
+++ b/test/internal/unit/traces/traceHandler.test.ts
@@ -109,6 +109,7 @@ describe("Library/TraceHandler", () => {
       _config.instrumentationOptions = {
         http: { enabled: false },
         azureSdk: { enabled: false },
+        azureFunctions: { enabled: false },
         mongoDb: { enabled: false },
         mySql: { enabled: false },
         postgreSql: { enabled: false },
@@ -258,6 +259,7 @@ describe("Library/TraceHandler", () => {
       _config.instrumentationOptions = {
         http: { enabled: true },
         azureSdk: { enabled: false },
+        azureFunctions: { enabled: false },
         mongoDb: { enabled: false },
         mySql: { enabled: false },
         postgreSql: { enabled: false },


### PR DESCRIPTION
- Add post-build CJS fixups (scripts/fixup-cjs.cjs):
  * dist/commonjs/package.json with {type:commonjs} so Node respects CJS
  * Copy module-cjs.cts polyfill over module.ts (import.meta.url is ESM-only)
  * Fix Azure Functions default-import in CJS output (__importDefault double-wrap)
- Fix Azure Functions import for ESM: use default-import + destructure because the package is a webpack bundle and Node ESM cannot extract named exports
- Add enabled flag to AzureMonitorOpenTelemetryOptions (default true) so consumers can run the distro without Azure Monitor
- Make all Azure Monitor handlers conditional in distro.ts
- Add missing re-exports to index.ts: Modality, InvocationRole, A365_MESSAGE_SCHEMA_VERSION, TextPart, ToolCallRequestPart, ToolCallResponsePart, ReasoningPart