### PR TITLE
chore: prepare v0.1.0-alpha.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## [0.1.0-alpha.3] - 2026-04-21
+
+### Features Added
+- Vendor A365 observability code in-repo: scopes, exporter, processors, baggage, context propagation, and configuration ([#27](https://github.com/microsoft/opentelemetry-distro-javascript/pull/27))
+- Add Azure Monitor disable flag ([30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
+
+### Bugs Fixed
+- Fix dual ESM/CJS output ([30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
+- Fix samples build: use local package reference, add `skipLibCheck`, replace deprecated `ChatOpenAI` with `AzureChatOpenAI` ([#28](https://github.com/microsoft/opentelemetry-distro-javascript/pull/28))
+
+
 ## [0.1.0-alpha.2] - 2026-04-20
 
 ### Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Features Added
 - Vendor A365 observability code in-repo: scopes, exporter, processors, baggage, context propagation, and configuration ([#27](https://github.com/microsoft/opentelemetry-distro-javascript/pull/27))
-- Add Azure Monitor disable flag ([30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
+- Add Azure Monitor disable flag ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 
 ### Bugs Fixed
-- Fix dual ESM/CJS output ([30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
+- Fix dual ESM/CJS output ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 - Fix samples build: use local package reference, add `skipLibCheck`, replace deprecated `ChatOpenAI` with `AzureChatOpenAI` ([#28](https://github.com/microsoft/opentelemetry-distro-javascript/pull/28))
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/opentelemetry",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/opentelemetry",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/opentelemetry",
   "author": "Microsoft Corporation",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Microsoft OpenTelemetry distribution for JavaScript/TypeScript",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ import type { A365Options } from "./a365/index.js";
 /**
  * Microsoft OpenTelemetry distribution version.
  */
-export const MICROSOFT_OPENTELEMETRY_VERSION = "0.1.0";
+export const MICROSOFT_OPENTELEMETRY_VERSION = "0.1.0-alpha.3";
 
 /**
  * Microsoft OpenTelemetry Options


### PR DESCRIPTION
- Bump version to 0.1.0-alpha.3 in package.json and MICROSOFT_OPENTELEMETRY_VERSION
- Add changelog entry for vendored A365 code and samples fixes