### PR TITLE
Remove legacy useAzureMonitor API and add Azure Monitor E2E tests

### DIFF
--- a/src/azureMonitor/index.ts
+++ b/src/azureMonitor/index.ts
@@ -13,6 +13,7 @@ import { APPLICATIONINSIGHTS_SDKSTATS_DISABLED } from "../types.js";
 import { BrowserSdkLoader } from "./browserSdkLoader/browserSdkLoader.js";
 import { setSdkPrefix } from "./metrics/quickpulse/utils.js";
 import { getInstance } from "./utils/statsbeat.js";
+import { Logger } from "../shared/logging/index.js";
 import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-conventions";
 
 /**
@@ -20,6 +21,38 @@ import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-convention
  * @internal
  */
 const CLOUD_RESOURCE_ID_ATTRIBUTE = "cloud.resource_id";
+
+/**
+ * Check whether Azure Monitor has a usable connection string available
+ * (from config or the APPLICATIONINSIGHTS_CONNECTION_STRING env var).
+ *
+ * @internal
+ */
+export function hasAzureMonitorConnectionString(config: InternalConfig): boolean {
+  return (
+    !!config.azureMonitorExporterOptions?.connectionString ||
+    !!process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+  );
+}
+
+/**
+ * Validate Azure Monitor prerequisites and log a warning when the
+ * connection string is missing. Returns true when Azure Monitor can proceed.
+ *
+ * @internal
+ */
+export function validateAzureMonitorConfig(config: InternalConfig): boolean {
+  if (hasAzureMonitorConnectionString(config)) {
+    return true;
+  }
+  Logger.getInstance().warn(
+    "Azure Monitor was enabled but no connection string was provided. " +
+      "Set the APPLICATIONINSIGHTS_CONNECTION_STRING environment variable or pass " +
+      "azureMonitor.azureMonitorExporterOptions.connectionString. " +
+      "Azure Monitor will be disabled.",
+  );
+  return false;
+}
 
 /**
  * Set up Azure Monitor–specific components (statsbeat, browser SDK loader,

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -50,7 +50,9 @@ let disposeAzureMonitor: (() => void) | undefined;
  *
  * This is the primary entry point for the distro. It sets up OpenTelemetry
  * providers and instrumentations, then attaches the configured exporters:
- * - Azure Monitor (enabled by default; disable with `options.azureMonitor.enabled = false`)
+ * - Azure Monitor (when `options.azureMonitor` is provided or the
+ *   `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is set; explicitly disable
+ *   with `options.azureMonitor.enabled = false`)
  * - OTLP HTTP (when `OTEL_EXPORTER_OTLP_ENDPOINT` is set)
  * - A365 (when `options.a365.enabled` is true or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`)
  *
@@ -61,10 +63,11 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   patchOpenTelemetryInstrumentationEnable();
 
   // Azure Monitor is enabled when configured programmatically or via JSON config.
+  // An explicit `enabled: false` always wins, even if a connection string is present.
   // Connection-string validation is delegated to the Azure Monitor module.
   const azureMonitorRequested =
-    (options?.azureMonitor?.enabled !== false && !!options?.azureMonitor) ||
-    hasAzureMonitorConnectionString(config);
+    options?.azureMonitor?.enabled !== false &&
+    (!!options?.azureMonitor || hasAzureMonitorConnectionString(config));
   const azureMonitorEnabled = azureMonitorRequested && validateAzureMonitorConfig(config);
 
   // Reset dispose callback to avoid stale references from a previous initialization

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -23,7 +23,11 @@ import { LogHandler } from "../azureMonitor/logs/index.js";
 import { AZURE_MONITOR_OPENTELEMETRY_VERSION } from "../types.js";
 import { patchOpenTelemetryInstrumentationEnable } from "../azureMonitor/utils/opentelemetryInstrumentationPatcher.js";
 import { parseResourceDetectorsFromEnvVar } from "../utils/common.js";
-import { setupAzureMonitorComponents } from "../azureMonitor/index.js";
+import {
+  setupAzureMonitorComponents,
+  hasAzureMonitorConnectionString,
+  validateAzureMonitorConfig,
+} from "../azureMonitor/index.js";
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
 import {
   A365Configuration,
@@ -56,10 +60,12 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
 
-  // Azure Monitor is enabled when configured programmatically or via JSON config
-  const azureMonitorEnabled =
+  // Azure Monitor is enabled when configured programmatically or via JSON config.
+  // Connection-string validation is delegated to the Azure Monitor module.
+  const azureMonitorRequested =
     (options?.azureMonitor?.enabled !== false && !!options?.azureMonitor) ||
-    !!config.azureMonitorExporterOptions?.connectionString;
+    hasAzureMonitorConnectionString(config);
+  const azureMonitorEnabled = azureMonitorRequested && validateAzureMonitorConfig(config);
 
   // Reset dispose callback to avoid stale references from a previous initialization
   disposeAzureMonitor = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { AzureMonitorOpenTelemetryOptions, MicrosoftOpenTelemetryOptions } from "./types.js";
-import { useMicrosoftOpenTelemetry, shutdownMicrosoftOpenTelemetry } from "./distro/distro.js";
+import type { AzureMonitorOpenTelemetryOptions } from "./types.js";
 
 // ── Re-exports from distro ──────────────────────────────────────────────────
 export type { AzureMonitorOpenTelemetryOptions };
@@ -109,22 +108,3 @@ export type {
 
 // ── Re-exports from types ───────────────────────────────────────────────────
 export type { OpenAIAgentsInstrumentationConfig, LangChainInstrumentationConfig } from "./types.js";
-
-// ── Azure Monitor backward-compatible API ───────────────────────────────────
-
-/**
- * Initialize Azure Monitor Distro
- * @param options - Microsoft OpenTelemetry Options
- * @deprecated Use {@link useMicrosoftOpenTelemetry} instead.
- */
-export function useAzureMonitor(options?: MicrosoftOpenTelemetryOptions): void {
-  useMicrosoftOpenTelemetry(options);
-}
-
-/**
- * Shutdown Azure Monitor Open Telemetry Distro
- * @deprecated Use {@link shutdownMicrosoftOpenTelemetry} instead.
- */
-export function shutdownAzureMonitor(): Promise<void> {
-  return shutdownMicrosoftOpenTelemetry();
-}

--- a/test/internal/functional/e2e-azure-monitor.test.ts
+++ b/test/internal/functional/e2e-azure-monitor.test.ts
@@ -1,0 +1,288 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * E2E validation: Azure Monitor telemetry (traces, metrics, logs) is exported
+ * when using the distro with a connection string.
+ *
+ * This test intercepts the HTTP client used by the Azure Monitor exporters so
+ * it never actually sends data to Application Insights — it captures the
+ * envelopes and asserts they are well-formed.
+ */
+
+import { describe, it, afterEach, expect, vi } from "vitest";
+import * as opentelemetry from "@opentelemetry/api";
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import type { HttpClient, PipelineRequest } from "@azure/core-rest-pipeline";
+import type { TelemetryItem as Envelope } from "../../utils/models/index.js";
+import { successfulBreezeResponse } from "../../utils/breezeTestUtils.js";
+
+const TEST_IKEY = "1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+const TEST_CONNECTION_STRING = `InstrumentationKey=${TEST_IKEY}`;
+
+/**
+ * Create a mock HTTP client that captures Breeze-protocol envelopes.
+ */
+function createCapturingHttpClient(ingest: Envelope[]): HttpClient {
+  return {
+    sendRequest: vi.fn().mockImplementation((request: PipelineRequest) => {
+      // Only capture requests aimed at the Breeze ingestion endpoint
+      if (request.body && typeof request.body === "string") {
+        try {
+          const items = JSON.parse(request.body) as Envelope[];
+          ingest.push(...items);
+        } catch {
+          // ignore non-JSON requests (e.g. QuickPulse pings)
+        }
+      }
+      return Promise.resolve({
+        headers: request.headers,
+        request,
+        status: 200,
+        bodyAsText: JSON.stringify(successfulBreezeResponse(1)),
+      });
+    }),
+  };
+}
+
+describe("E2E: Azure Monitor telemetry export via distro", () => {
+  let ingest: Envelope[] = [];
+
+  afterEach(async () => {
+    // Dynamic import so each test can re-initialize the distro cleanly
+    const { shutdownMicrosoftOpenTelemetry } = await import("../../../src/distro/distro.js");
+    await shutdownMicrosoftOpenTelemetry().catch(() => {});
+    opentelemetry.trace.disable();
+    opentelemetry.metrics.disable();
+    logs.disable();
+    ingest = [];
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 1: New API — useMicrosoftOpenTelemetry with azureMonitor key
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry sends traces to Azure Monitor when azureMonitor options are provided", async () => {
+    const { useMicrosoftOpenTelemetry } = await import("../../../src/distro/distro.js");
+    const httpClient = createCapturingHttpClient(ingest);
+
+    useMicrosoftOpenTelemetry({
+      tracesPerSecond: 0, // disable rate limiting for deterministic test
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: TEST_CONNECTION_STRING,
+          httpClient,
+        },
+        enableLiveMetrics: false,
+        enableStandardMetrics: false,
+      },
+    });
+
+    // Emit a trace
+    const tracer = opentelemetry.trace.getTracer("e2e-test");
+    const span = tracer.startSpan("test-operation", {
+      kind: opentelemetry.SpanKind.SERVER,
+    });
+    span.end();
+
+    // Force-flush to push data through the BatchSpanProcessor
+    const provider = (
+      opentelemetry.trace.getTracerProvider() as opentelemetry.ProxyTracerProvider
+    ).getDelegate() as { forceFlush(): Promise<void> };
+    await provider.forceFlush();
+
+    // Verify at least one Request or RemoteDependency envelope was captured
+    const traceEnvelopes = ingest.filter(
+      (e) =>
+        e.name === "Microsoft.ApplicationInsights.Request" ||
+        e.name === "Microsoft.ApplicationInsights.RemoteDependency",
+    );
+    expect(traceEnvelopes.length).toBeGreaterThanOrEqual(1);
+    expect(traceEnvelopes[0]!.iKey).toBe(TEST_IKEY);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 2: New API — useMicrosoftOpenTelemetry sends logs
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry sends logs to Azure Monitor", async () => {
+    const { useMicrosoftOpenTelemetry } = await import("../../../src/distro/distro.js");
+    const httpClient = createCapturingHttpClient(ingest);
+
+    useMicrosoftOpenTelemetry({
+      tracesPerSecond: 0,
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: TEST_CONNECTION_STRING,
+          httpClient,
+        },
+        enableLiveMetrics: false,
+        enableStandardMetrics: false,
+      },
+    });
+
+    // Emit a log
+    const logger = logs.getLogger("e2e-test");
+    logger.emit({
+      severityNumber: SeverityNumber.INFO,
+      severityText: "INFO",
+      body: "E2E test log message",
+      attributes: { testAttr: "value" },
+    });
+
+    // Force-flush the logger provider
+    const loggerProvider = logs.getLoggerProvider() as { forceFlush(): Promise<void> };
+    await loggerProvider.forceFlush();
+
+    const logEnvelopes = ingest.filter((e) => e.name === "Microsoft.ApplicationInsights.Message");
+    expect(logEnvelopes.length).toBeGreaterThanOrEqual(1);
+    expect(logEnvelopes[0]!.iKey).toBe(TEST_IKEY);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 3: New API — useMicrosoftOpenTelemetry sends metrics
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry sends metrics to Azure Monitor", async () => {
+    const { useMicrosoftOpenTelemetry } = await import("../../../src/distro/distro.js");
+    const httpClient = createCapturingHttpClient(ingest);
+
+    useMicrosoftOpenTelemetry({
+      tracesPerSecond: 0,
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: TEST_CONNECTION_STRING,
+          httpClient,
+        },
+        enableLiveMetrics: false,
+        enableStandardMetrics: false,
+      },
+    });
+
+    // Emit a metric
+    const meter = opentelemetry.metrics.getMeter("e2e-test");
+    const counter = meter.createCounter("e2e-test-counter");
+    counter.add(42);
+
+    // Force-flush metrics
+    const meterProvider = opentelemetry.metrics.getMeterProvider() as {
+      forceFlush(): Promise<void>;
+    };
+    await meterProvider.forceFlush();
+
+    const metricEnvelopes = ingest.filter((e) => e.name === "Microsoft.ApplicationInsights.Metric");
+    expect(metricEnvelopes.length).toBeGreaterThanOrEqual(1);
+    // At least one should have our ikey
+    const hasOurIkey = metricEnvelopes.some((e) => e.iKey === TEST_IKEY);
+    expect(hasOurIkey).toBe(true);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 4: useMicrosoftOpenTelemetry imported from package root
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry from index sends traces with nested azureMonitor options", async () => {
+    const { useMicrosoftOpenTelemetry: init } = await import("../../../src/index.js");
+    const httpClient = createCapturingHttpClient(ingest);
+
+    init({
+      tracesPerSecond: 0,
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: TEST_CONNECTION_STRING,
+          httpClient,
+        },
+        enableLiveMetrics: false,
+        enableStandardMetrics: false,
+      },
+    });
+
+    const tracer = opentelemetry.trace.getTracer("e2e-compat");
+    const span = tracer.startSpan("compat-operation", {
+      kind: opentelemetry.SpanKind.SERVER,
+    });
+    span.end();
+
+    const provider = (
+      opentelemetry.trace.getTracerProvider() as opentelemetry.ProxyTracerProvider
+    ).getDelegate() as { forceFlush(): Promise<void> };
+    await provider.forceFlush();
+
+    const traceEnvelopes = ingest.filter(
+      (e) =>
+        e.name === "Microsoft.ApplicationInsights.Request" ||
+        e.name === "Microsoft.ApplicationInsights.RemoteDependency",
+    );
+    expect(traceEnvelopes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 5: Connection string via env var only (no explicit options)
+  // Validates that APPLICATIONINSIGHTS_CONNECTION_STRING alone enables
+  // Azure Monitor export — this is the pattern many users rely on.
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry enables Azure Monitor when APPLICATIONINSIGHTS_CONNECTION_STRING env var is set", async () => {
+    const { useMicrosoftOpenTelemetry, _getSdkInstance } =
+      await import("../../../src/distro/distro.js");
+    const { AzureMonitorSpanProcessor } =
+      await import("../../../src/azureMonitor/traces/spanProcessor.js");
+    const originalEnv = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    try {
+      process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = TEST_CONNECTION_STRING;
+
+      // Call with no azureMonitor key — the env var alone should enable AM
+      useMicrosoftOpenTelemetry();
+
+      // The SDK should have been initialized
+      const sdk = _getSdkInstance();
+      expect(sdk).toBeDefined();
+
+      // Verify that AzureMonitorSpanProcessor is registered — this is the
+      // definitive check that Azure Monitor is active, not just console exporters.
+      const tracerProvider = (sdk as any)["_tracerProvider"];
+      const activeSpanProcessor = tracerProvider["_activeSpanProcessor"];
+      const spanProcessors: unknown[] = activeSpanProcessor["_spanProcessors"] || [
+        activeSpanProcessor,
+      ];
+      const hasAzureMonitor = spanProcessors.some((sp) => sp instanceof AzureMonitorSpanProcessor);
+      expect(
+        hasAzureMonitor,
+        "AzureMonitorSpanProcessor should be registered when env var is set",
+      ).toBe(true);
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = originalEnv;
+      } else {
+        delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+      }
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Scenario 6: Verify that without any Azure Monitor config, AM is
+  // correctly disabled (no crash, console exporters may activate)
+  // ────────────────────────────────────────────────────────────────────
+  it("useMicrosoftOpenTelemetry without any config still starts (console fallback)", async () => {
+    const { useMicrosoftOpenTelemetry, _getSdkInstance } =
+      await import("../../../src/distro/distro.js");
+    const originalEnv = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    try {
+      delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+      useMicrosoftOpenTelemetry();
+
+      // SDK should still start (console exporters kick in)
+      expect(_getSdkInstance()).toBeDefined();
+
+      const tracer = opentelemetry.trace.getTracerProvider().getTracer("no-config-test");
+      const span = tracer.startSpan("no-config-span");
+      const { traceId } = span.spanContext();
+      span.end();
+      expect(traceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(traceId).not.toBe("00000000000000000000000000000000");
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = originalEnv;
+      } else {
+        delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+      }
+    }
+  });
+});

--- a/test/internal/unit/browserSdkLoader/browserSdkLoader.test.ts
+++ b/test/internal/unit/browserSdkLoader/browserSdkLoader.test.ts
@@ -5,7 +5,10 @@ import type http from "node:http";
 import { BrowserSdkLoader } from "../../../../src/azureMonitor/browserSdkLoader/browserSdkLoader.js";
 import * as BrowserSdkLoaderHelper from "../../../../src/azureMonitor/browserSdkLoader/browserSdkLoaderHelper.js";
 import type { MicrosoftOpenTelemetryOptions } from "../../../../src/index.js";
-import { shutdownAzureMonitor, useAzureMonitor } from "../../../../src/index.js";
+import {
+  useMicrosoftOpenTelemetry,
+  shutdownMicrosoftOpenTelemetry,
+} from "../../../../src/distro/distro.js";
 import { getOsPrefix } from "../../../../src/azureMonitor/utils/common.js";
 import { metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
@@ -17,7 +20,7 @@ describe("#BrowserSdkLoader", () => {
 
   afterEach(async () => {
     process.env = originalEnv;
-    await shutdownAzureMonitor();
+    await shutdownMicrosoftOpenTelemetry();
     vi.restoreAllMocks();
   });
 
@@ -43,7 +46,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.strictEqual(BrowserSdkLoader.getInstance().isInitialized(), true);
   });
 
@@ -59,7 +62,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     const _headers: any = {};
@@ -101,7 +104,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     const _headers: any = {};
@@ -145,7 +148,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
     const _headers: any = {};
 
@@ -180,7 +183,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     const _headers: any = {};
@@ -225,7 +228,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     const _headers: any = {};
@@ -270,7 +273,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     const _headers: any = {};
@@ -314,7 +317,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     assert.equal(browserSdkLoader["_isIkeyValid"], true, "ikey should be set to valid");
@@ -361,7 +364,7 @@ describe("#BrowserSdkLoader", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const browserSdkLoader = BrowserSdkLoader.getInstance();
 
     assert.equal(browserSdkLoader["_isIkeyValid"], false, "ikey should be set to invalid");

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -5,7 +5,6 @@ import type { Context, TracerProvider } from "@opentelemetry/api";
 import { metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import type { MicrosoftOpenTelemetryOptions } from "../../../src/index.js";
-import { useAzureMonitor, shutdownAzureMonitor } from "../../../src/index.js";
 import {
   useMicrosoftOpenTelemetry,
   shutdownMicrosoftOpenTelemetry,
@@ -81,7 +80,7 @@ describe("Main functions", () => {
     logs.disable();
   });
 
-  it("useAzureMonitor", () => {
+  it("useMicrosoftOpenTelemetry", () => {
     const config: MicrosoftOpenTelemetryOptions = {
       azureMonitor: {
         azureMonitorExporterOptions: {
@@ -89,13 +88,13 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.isDefined(metrics.getMeterProvider());
     assert.isDefined(trace.getTracerProvider());
     assert.isDefined(logs.getLoggerProvider());
   });
 
-  it("useAzureMonitor should clear stale global API version before initializing", () => {
+  it("useMicrosoftOpenTelemetry should clear stale global API version before initializing", () => {
     (globalThis as Record<symbol, unknown>)[GLOBAL_OPENTELEMETRY_API_KEY] = {
       version: "1.6.0",
     };
@@ -106,8 +105,8 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
-    // After useAzureMonitor, real (non-noop) providers should be registered
+    useMicrosoftOpenTelemetry(config);
+    // After useMicrosoftOpenTelemetry, real (non-noop) providers should be registered
     const tracerProvider = trace.getTracerProvider();
     const tracer = tracerProvider.getTracer("test");
     // A noop tracer would return a span whose spanContext has an invalid (all-zero) traceId
@@ -119,7 +118,7 @@ describe("Main functions", () => {
     expect(traceId).not.toBe("00000000000000000000000000000000");
   });
 
-  it("useAzureMonitor should handle stale global with a newer/future API version", () => {
+  it("useMicrosoftOpenTelemetry should handle stale global with a newer/future API version", () => {
     // Even if the stale version is higher than the current one, the mismatch still
     // causes registerGlobal() to fail. Our fix should handle any version mismatch.
     (globalThis as Record<symbol, unknown>)[GLOBAL_OPENTELEMETRY_API_KEY] = {
@@ -132,7 +131,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const tracer = trace.getTracerProvider().getTracer("test");
     const span = tracer.startSpan("test-future-version");
     const { traceId } = span.spanContext();
@@ -141,7 +140,7 @@ describe("Main functions", () => {
     expect(traceId).not.toBe("00000000000000000000000000000000");
   });
 
-  it("useAzureMonitor should work when no stale global exists", () => {
+  it("useMicrosoftOpenTelemetry should work when no stale global exists", () => {
     // Regression: deleting a non-existent global key should not throw or break anything.
     delete (globalThis as Record<symbol, unknown>)[GLOBAL_OPENTELEMETRY_API_KEY];
     const config: MicrosoftOpenTelemetryOptions = {
@@ -151,7 +150,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const tracer = trace.getTracerProvider().getTracer("test");
     const span = tracer.startSpan("test-clean-state");
     const { traceId } = span.spanContext();
@@ -160,8 +159,8 @@ describe("Main functions", () => {
     expect(traceId).not.toBe("00000000000000000000000000000000");
   });
 
-  it("useAzureMonitor should work on repeated calls with stale globals", () => {
-    // Simulate calling useAzureMonitor twice — both should succeed even if
+  it("useMicrosoftOpenTelemetry should work on repeated calls with stale globals", () => {
+    // Simulate calling useMicrosoftOpenTelemetry twice — both should succeed even if
     // a stale global is re-injected between calls (e.g. another extension reloads).
     const config: MicrosoftOpenTelemetryOptions = {
       azureMonitor: {
@@ -175,7 +174,7 @@ describe("Main functions", () => {
     (globalThis as Record<symbol, unknown>)[GLOBAL_OPENTELEMETRY_API_KEY] = {
       version: "1.6.0",
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     let tracer = trace.getTracerProvider().getTracer("test");
     let span = tracer.startSpan("test-first-call");
     let { traceId } = span.spanContext();
@@ -187,7 +186,7 @@ describe("Main functions", () => {
     (globalThis as Record<symbol, unknown>)[GLOBAL_OPENTELEMETRY_API_KEY] = {
       version: "1.4.0",
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     tracer = trace.getTracerProvider().getTracer("test");
     span = tracer.startSpan("test-second-call");
     ({ traceId } = span.spanContext());
@@ -204,8 +203,8 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
-    shutdownAzureMonitor();
+    useMicrosoftOpenTelemetry(config);
+    shutdownMicrosoftOpenTelemetry();
     const meterProvider = metrics.getMeterProvider() as MeterProvider;
     assert.strictEqual(meterProvider["_shutdown"], true);
   });
@@ -218,8 +217,8 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
-    await shutdownAzureMonitor();
+    useMicrosoftOpenTelemetry(config);
+    await shutdownMicrosoftOpenTelemetry();
     const meterProvider = metrics.getMeterProvider() as MeterProvider;
     assert.strictEqual(meterProvider["_shutdown"], true);
   });
@@ -247,7 +246,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     // Verify the custom processor was added to the SDK configuration
     // by checking it's in the tracer provider's span processors
     const internalSdk = _getSdkInstance();
@@ -280,7 +279,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     logs.getLogger("testLogger").emit({ body: "testLog" });
     expect(spyonEmit).toHaveBeenCalled();
   });
@@ -295,7 +294,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
 
     const meterConfig = (_getSdkInstance() as any)?._meterProviderConfig;
     expect(meterConfig).toBeDefined();
@@ -329,7 +328,7 @@ describe("Main functions", () => {
         enableLiveMetrics: true,
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const features = Number(output["feature"]);
     const instrumentations = Number(output["instrumentation"]);
@@ -363,7 +362,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const features = Number(output["feature"]);
     assert.ok(features & StatsbeatFeature.SHIM, `SHIM is not set ${features}`);
@@ -381,7 +380,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const features = Number(output["feature"]);
     assert.ok(
@@ -398,7 +397,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const features = Number(output["feature"]);
     assert.notOk(
@@ -422,7 +421,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const numberOutput = Number(output["feature"]);
     assert.ok(numberOutput & StatsbeatFeature.AAD_HANDLING, "AAD_HANDLING not set");
@@ -444,7 +443,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `a${os}m_`);
   });
 
@@ -460,7 +459,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `f${os}m_`);
   });
 
@@ -476,7 +475,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `k${os}m_`);
   });
 
@@ -492,7 +491,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `k${os}m_`);
   });
 
@@ -508,7 +507,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
 
     // Access resource from the SDK's tracer provider instead of from a span
     // This avoids issues with OTel global state in test environments
@@ -535,7 +534,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
 
     // Access resource from the SDK's tracer provider instead of from a span
     // This avoids issues with OTel global state in test environments
@@ -558,7 +557,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
 
     // Access resource from the SDK's tracer provider instead of from a span
     // This avoids issues with OTel global state in test environments
@@ -591,7 +590,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const emptyStatsbeatConfig: string = JSON.stringify({ instrumentation: 0, feature: 0 });
 
     const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
@@ -622,13 +621,13 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
       feature?: number;
     };
     const features = Number(output["feature"] || 0);
     assert.ok(features & StatsbeatFeature.MULTI_IKEY, "MULTI_IKEY not detected");
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("should not detect MULTI_IKEY feature when AZURE_MONITOR_STATSBEAT_FEATURES has MULTI_IKEY disabled", () => {
@@ -642,7 +641,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
       feature?: number;
     };
@@ -651,7 +650,7 @@ describe("Main functions", () => {
       !(features & StatsbeatFeature.MULTI_IKEY),
       "MULTI_IKEY detected when it should not be",
     );
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("should detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_DISABLED is 'true'", () => {
@@ -665,7 +664,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
       feature?: number;
     };
@@ -675,7 +674,7 @@ describe("Main functions", () => {
       "CUSTOMER_SDKSTATS feature should be detected when customer explicitly disables SDK stats",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should also be set");
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("should not detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_DISABLED is not 'true'", () => {
@@ -689,7 +688,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
       feature?: number;
     };
@@ -699,7 +698,7 @@ describe("Main functions", () => {
       "CUSTOMER_SDKSTATS feature should not be detected when env var is not 'true'",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("should not detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_DISABLED is not set", () => {
@@ -713,7 +712,7 @@ describe("Main functions", () => {
         },
       },
     };
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
       feature?: number;
     };
@@ -723,7 +722,7 @@ describe("Main functions", () => {
       "CUSTOMER_SDKSTATS feature should not be detected when env var is undefined",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("should create both AzureMonitor and OTLP metric exporters when OTLP environment variables are set", () => {
@@ -746,7 +745,7 @@ describe("Main functions", () => {
     };
 
     // Initialize the SDK
-    useAzureMonitor(config);
+    useMicrosoftOpenTelemetry(config);
 
     // Get the internal SDK instance
     const internalSdk = _getSdkInstance();
@@ -813,7 +812,7 @@ describe("Main functions", () => {
     assert.isTrue(hasAzureMonitorReader, "Should have Azure Monitor metric reader");
     assert.isTrue(hasOTLPReader, "Should have OTLP metric reader");
 
-    void shutdownAzureMonitor();
+    void shutdownMicrosoftOpenTelemetry();
   });
 
   it("useMicrosoftOpenTelemetry with azureMonitor.enabled=false should skip Azure Monitor handlers", async () => {

--- a/test/internal/unit/traces/azureFnInstrumentation.test.ts
+++ b/test/internal/unit/traces/azureFnInstrumentation.test.ts
@@ -7,7 +7,10 @@ import { InternalConfig } from "../../../../src/shared/index.js";
 import { MetricHandler } from "../../../../src/azureMonitor/metrics/index.js";
 import { metrics, trace } from "@opentelemetry/api";
 import { describe, it, beforeEach, afterEach, assert } from "vitest";
-import { shutdownAzureMonitor, useAzureMonitor } from "../../../../src/index.js";
+import {
+  useMicrosoftOpenTelemetry,
+  shutdownMicrosoftOpenTelemetry,
+} from "../../../../src/distro/distro.js";
 
 describe("Library/AzureFunctionsInstrumentation", () => {
   let metricHandler: MetricHandler;
@@ -22,11 +25,11 @@ describe("Library/AzureFunctionsInstrumentation", () => {
     }
     metrics.disable();
     trace.disable();
-    await shutdownAzureMonitor();
+    await shutdownMicrosoftOpenTelemetry();
   });
 
   beforeEach(() => {
-    useAzureMonitor({
+    useMicrosoftOpenTelemetry({
       azureMonitor: {
         azureMonitorExporterOptions: {
           connectionString: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333;",

--- a/test/snippets.spec.ts
+++ b/test/snippets.spec.ts
@@ -3,7 +3,7 @@
 
 import { resourceFromAttributes, emptyResource } from "@opentelemetry/resources";
 import type { MicrosoftOpenTelemetryOptions } from "../src";
-import { useAzureMonitor } from "../src";
+import { useMicrosoftOpenTelemetry } from "../src";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import type { Context, Exception, ObservableResult, Span } from "@opentelemetry/api";
 import { metrics, SpanKind, trace, TraceFlags } from "@opentelemetry/api";
@@ -23,16 +23,18 @@ import type { IncomingMessage, RequestOptions } from "node:http";
 
 describe("snippets", () => {
   it("ReadmeSampleESMUsage", () => {
-    useAzureMonitor({
-      azureMonitorExporterOptions: {
-        connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
+    useMicrosoftOpenTelemetry({
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
+        },
       },
     });
 
     // Your application code follows...
   });
 
-  it("ReadmeSampleUseAzureMonitor", () => {
+  it("ReadmeSampleUseMicrosoftOpenTelemetry", () => {
     const options: MicrosoftOpenTelemetryOptions = {
       azureMonitor: {
         azureMonitorExporterOptions: {
@@ -41,7 +43,7 @@ describe("snippets", () => {
         },
       },
     };
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleConfiguration", () => {
@@ -85,7 +87,7 @@ describe("snippets", () => {
       },
     };
 
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleCustomConfig", () => {
@@ -95,7 +97,7 @@ describe("snippets", () => {
   });
 
   it("ReadmeSampleCustomInstrumentation", () => {
-    useAzureMonitor();
+    useMicrosoftOpenTelemetry();
     registerInstrumentations({
       tracerProvider: trace.getTracerProvider(),
       meterProvider: metrics.getMeterProvider(),
@@ -113,7 +115,7 @@ describe("snippets", () => {
     customResource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID] = "my-instance";
     // @ts-preserve-whitespace
     const options: MicrosoftOpenTelemetryOptions = { resource: customResource };
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleAddCustomProperty", () => {
@@ -139,7 +141,7 @@ describe("snippets", () => {
       spanProcessors: [new SpanEnrichingProcessor()],
     };
     // @ts-preserve-whitespace
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleAddOperationName", () => {
@@ -183,7 +185,7 @@ describe("snippets", () => {
       logRecordProcessors: [new LogRecordEnrichingProcessor()],
     };
     // @ts-preserve-whitespace
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleExcludeUrl", () => {
@@ -211,7 +213,7 @@ describe("snippets", () => {
       },
     };
     // @ts-preserve-whitespace
-    useAzureMonitor(options);
+    useMicrosoftOpenTelemetry(options);
   });
 
   it("ReadmeSampleCustomProcessor", () => {
@@ -235,7 +237,7 @@ describe("snippets", () => {
   });
 
   it("ReadmeSampleCustomMetrics", () => {
-    useAzureMonitor();
+    useMicrosoftOpenTelemetry();
     const meter = metrics.getMeter("testMeter");
     // @ts-preserve-whitespace
     const histogram = meter.createHistogram("histogram");
@@ -256,7 +258,7 @@ describe("snippets", () => {
   });
 
   it("ReadmeSampleCustomExceptions", () => {
-    useAzureMonitor();
+    useMicrosoftOpenTelemetry();
     const tracer = trace.getTracer("testMeter");
     // @ts-preserve-whitespace
     const span = tracer.startSpan("hello");
@@ -272,6 +274,6 @@ describe("snippets", () => {
     process.env["APPLICATIONINSIGHTS_LOG_DESTINATION"] = "file";
     process.env["APPLICATIONINSIGHTS_LOGDIR"] = "path/to/logs";
     // @ts-preserve-whitespace
-    useAzureMonitor();
+    useMicrosoftOpenTelemetry();
   });
 });

--- a/test/utils/basic.ts
+++ b/test/utils/basic.ts
@@ -16,7 +16,7 @@ import type { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type { LoggerProvider } from "@opentelemetry/sdk-logs";
 
-import { useAzureMonitor } from "../../src/index.js";
+import { useMicrosoftOpenTelemetry } from "../../src/distro/index.js";
 import type { Expectation, Scenario } from "./types.js";
 import type { HttpClient } from "@azure/core-rest-pipeline";
 
@@ -41,7 +41,7 @@ export class TraceBasicScenario implements Scenario {
       "k8s.namespace.name": "testNamespaceName",
       "k8s.pod.name": "testPodName",
     });
-    useAzureMonitor({
+    useMicrosoftOpenTelemetry({
       resource: resource,
       tracesPerSecond: 0,
       azureMonitor: {
@@ -204,7 +204,7 @@ export class MetricBasicScenario implements Scenario {
       [SEMRESATTRS_SERVICE_NAMESPACE]: "my-namespace",
       [SEMRESATTRS_SERVICE_INSTANCE_ID]: "my-instance",
     });
-    useAzureMonitor({
+    useMicrosoftOpenTelemetry({
       resource: testResource,
       azureMonitor: {
         azureMonitorExporterOptions: {
@@ -392,7 +392,7 @@ export class MetricBasicScenario implements Scenario {
 
 export class LogBasicScenario implements Scenario {
   prepare(httpClient?: HttpClient): void {
-    useAzureMonitor({
+    useMicrosoftOpenTelemetry({
       azureMonitor: {
         azureMonitorExporterOptions: {
           connectionString: `instrumentationkey=${COMMON_ENVELOPE_PARAMS.instrumentationKey}`,


### PR DESCRIPTION
- Remove useAzureMonitor/shutdownAzureMonitor from public API surface
- Move Azure Monitor connection string validation from distro into azureMonitor module
- Update all tests to use useMicrosoftOpenTelemetry/shutdownMicrosoftOpenTelemetry
- Fix snippets.spec.ts to use correct API and nested options shape
- Add E2E test suite validating Azure Monitor traces, metrics, and logs export


Fixes #37