### PR TITLE
fix: resolve A365 scopes producing no-op spans after distro init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 - Add a365 hosting middleware ([#29](https://github.com/microsoft/opentelemetry-distro-javascript/pull/29))
 
 ### Bugs Fixed
-- Fix A365 scopes producing no-op spans with zeroed trace/span IDs after distro initialization. ([#39](https://github.com/microsoft/opentelemetry-distro-javascript/pull/39))
-Remove legacy useAzureMonitor API and add Azure Monitor E2E tests([#38](https://github.com/microsoft/opentelemetry-distro-javascript/pull/38))
+- Fix A365 scopes producing no-op spans with zeroed trace/span IDs after distro initialization. ([#41](https://github.com/microsoft/opentelemetry-distro-javascript/pull/41))
+- Remove legacy useAzureMonitor API and add Azure Monitor E2E tests([#38](https://github.com/microsoft/opentelemetry-distro-javascript/pull/38))
 
 ## [0.1.0-alpha.3] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Conditional azure monitor and readme updates ([#33](https://github.com/microsoft/opentelemetry-distro-javascript/pull/33))
 - Add a365 hosting middleware ([#29](https://github.com/microsoft/opentelemetry-distro-javascript/pull/29))
 
+### Bugs Fixed
+- Fix A365 scopes producing no-op spans with zeroed trace/span IDs after distro initialization. ([#39](https://github.com/microsoft/opentelemetry-distro-javascript/pull/39))
+Remove legacy useAzureMonitor API and add Azure Monitor E2E tests([#38](https://github.com/microsoft/opentelemetry-distro-javascript/pull/38))
+
 ## [0.1.0-alpha.3] - 2026-04-21
 
 ### Features Added

--- a/src/a365/scopes/OpenTelemetryScope.ts
+++ b/src/a365/scopes/OpenTelemetryScope.ts
@@ -31,7 +31,19 @@ import { Logger } from "../../shared/logging/index.js";
  * Subclasses: `InvokeAgentScope`, `ExecuteToolScope`, `InferenceScope`, `OutputScope`.
  */
 export abstract class OpenTelemetryScope {
-  private static readonly tracer = trace.getTracer(OpenTelemetryConstants.SOURCE_NAME);
+  /**
+   * Returns a tracer from the current global TracerProvider.
+   *
+   * This **must not** be stored in a static field because the distro's
+   * `useMicrosoftOpenTelemetry()` resets the global API state
+   * (`trace.disable()` + global-object deletion) before starting the
+   * NodeSDK. A static field would capture a `ProxyTracer` bound to the
+   * old `ProxyTracerProvider` whose delegate is never set, producing
+   * `NoopSpan` instances with zeroed trace/span IDs.
+   */
+  private static getTracer() {
+    return trace.getTracer(OpenTelemetryConstants.SOURCE_NAME);
+  }
 
   protected readonly span: Span;
   private readonly wallClockStartMs: number;
@@ -70,7 +82,7 @@ export abstract class OpenTelemetryScope {
       }
     }
 
-    this.span = OpenTelemetryScope.tracer.startSpan(
+    this.span = OpenTelemetryScope.getTracer().startSpan(
       spanName,
       {
         kind,

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -132,6 +132,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
 
   // ── A365 exporter (enabled via options.a365 or env vars) ──────────
   const a365Config = new A365Configuration(options?.a365);
+  const a365ConsoleExportFallback = !a365Config.enabled && !!options?.a365;
   if (a365Config.enabled) {
     const a365Exporter = new Agent365Exporter({
       clusterCategory: a365Config.clusterCategory,
@@ -148,6 +149,11 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
       ? new PerRequestSpanProcessor(a365Exporter)
       : new BatchSpanProcessor(a365Exporter);
     spanProcessors.push(a365ExportProcessor);
+  } else if (a365ConsoleExportFallback) {
+    // A365 options provided but exporter disabled — fall back to console export
+    // so developers can validate spans locally (matches upstream A365 SDK behavior
+    // when ENABLE_A365_OBSERVABILITY_EXPORTER=false).
+    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
   }
 
   // Merge views: use Azure Monitor views when available (they cover the same
@@ -165,7 +171,10 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     options?.enableConsoleExporters ??
     (!azureMonitorEnabled && !isOtlpEnabled() && !a365Config.enabled && !hasCustomProcessors);
   if (consoleEnabled) {
-    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+    // Skip span console exporter when A365 fallback already added one
+    if (!a365ConsoleExportFallback) {
+      spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+    }
     metricReaders.push(
       new PeriodicExportingMetricReader({
         exporter: new ConsoleMetricExporter(),

--- a/test/internal/unit/a365/scopesAfterDistroInit.test.ts
+++ b/test/internal/unit/a365/scopesAfterDistroInit.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Verifies that A365 scopes produce valid (non-zero) trace/span IDs when used
+ * after `useMicrosoftOpenTelemetry()` resets the global OpenTelemetry state.
+ *
+ * The distro calls `trace.disable()` and then deletes the global API object to
+ * clear stale version locks. This creates a new `ProxyTracerProvider`, so any
+ * `ProxyTracer` captured *before* the reset would delegate to the old provider
+ * whose delegate is never set — producing NoopSpans with zeroed IDs.
+ *
+ * The fix: `OpenTelemetryScope.getTracer()` fetches the tracer lazily at
+ * span-creation time instead of caching it in a static field.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { trace, context as otelContext } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  BasicTracerProvider,
+} from "@opentelemetry/sdk-trace-base";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+
+// Import the scopes (and thus OpenTelemetryScope) BEFORE calling
+// useMicrosoftOpenTelemetry — this is the typical user import order.
+import {
+  InvokeAgentScope,
+  InferenceScope,
+  ExecuteToolScope,
+  OutputScope,
+  InferenceOperationType,
+} from "../../../../src/a365/index.js";
+import type { AgentDetails } from "../../../../src/a365/index.js";
+
+const ZERO_TRACE_ID = "00000000000000000000000000000000";
+const ZERO_SPAN_ID = "0000000000000000";
+
+/**
+ * Simulates the global-state reset that `useMicrosoftOpenTelemetry()` performs,
+ * then registers a fresh provider with an in-memory exporter.
+ */
+function simulateDistroInit(): InMemorySpanExporter {
+  // ── Step 1: Same reset the distro does ──────────────────────────
+  trace.disable();
+  otelContext.disable();
+  const globalKey = Symbol.for("opentelemetry.js.api.1");
+  delete (globalThis as Record<symbol, unknown>)[globalKey];
+
+  // ── Step 2: Register a new provider (like NodeSDK.start()) ──────
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+
+  const contextManager = new AsyncLocalStorageContextManager();
+  contextManager.enable();
+  otelContext.setGlobalContextManager(contextManager);
+  trace.setGlobalTracerProvider(provider);
+
+  return exporter;
+}
+
+describe("A365 scopes after distro global-state reset", () => {
+  const agentDetails: AgentDetails = {
+    agentId: "test-agent",
+    agentName: "TestAgent",
+    tenantId: "test-tenant",
+  };
+  const request = { conversationId: "conv-1" };
+
+  afterEach(() => {
+    trace.disable();
+    otelContext.disable();
+  });
+
+  it("InvokeAgentScope should produce valid trace/span IDs", () => {
+    const exporter = simulateDistroInit();
+
+    const scope = InvokeAgentScope.start(request, {}, agentDetails);
+    const ctx = scope.getSpanContext();
+    expect(ctx.traceId).not.toBe(ZERO_TRACE_ID);
+    expect(ctx.spanId).not.toBe(ZERO_SPAN_ID);
+    scope.dispose();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].spanContext().traceId).not.toBe(ZERO_TRACE_ID);
+  });
+
+  it("InferenceScope should produce valid trace/span IDs", () => {
+    const exporter = simulateDistroInit();
+
+    const scope = InferenceScope.start(
+      request,
+      { operationName: InferenceOperationType.CHAT, model: "gpt-4o" },
+      agentDetails,
+    );
+    const ctx = scope.getSpanContext();
+    expect(ctx.traceId).not.toBe(ZERO_TRACE_ID);
+    expect(ctx.spanId).not.toBe(ZERO_SPAN_ID);
+    scope.dispose();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+  });
+
+  it("ExecuteToolScope should produce valid trace/span IDs", () => {
+    const exporter = simulateDistroInit();
+
+    const scope = ExecuteToolScope.start(
+      request,
+      { toolName: "search", toolCallId: "tc-1", toolType: "function" },
+      agentDetails,
+    );
+    const ctx = scope.getSpanContext();
+    expect(ctx.traceId).not.toBe(ZERO_TRACE_ID);
+    expect(ctx.spanId).not.toBe(ZERO_SPAN_ID);
+    scope.dispose();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+  });
+
+  it("OutputScope should produce valid trace/span IDs", () => {
+    const exporter = simulateDistroInit();
+
+    const scope = OutputScope.start(request, { messages: ["Hello"] }, agentDetails);
+    const ctx = scope.getSpanContext();
+    expect(ctx.traceId).not.toBe(ZERO_TRACE_ID);
+    expect(ctx.spanId).not.toBe(ZERO_SPAN_ID);
+    scope.dispose();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+  });
+
+  it("ConsoleSpanExporter scenario: spans reach user-provided processors", () => {
+    const exporter = simulateDistroInit();
+
+    // Full agent flow: invoke → inference → tool → output
+    const invokeScope = InvokeAgentScope.start(request, {}, agentDetails);
+    invokeScope.dispose();
+
+    const inferenceScope = InferenceScope.start(
+      request,
+      { operationName: InferenceOperationType.CHAT, model: "gpt-4o" },
+      agentDetails,
+    );
+    inferenceScope.dispose();
+
+    const toolScope = ExecuteToolScope.start(
+      request,
+      { toolName: "lookup", toolCallId: "tc-2", toolType: "function" },
+      agentDetails,
+    );
+    toolScope.dispose();
+
+    const outputScope = OutputScope.start(request, { messages: ["Done"] }, agentDetails);
+    outputScope.dispose();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(4);
+
+    for (const span of spans) {
+      expect(span.spanContext().traceId).not.toBe(ZERO_TRACE_ID);
+      expect(span.spanContext().spanId).not.toBe(ZERO_SPAN_ID);
+    }
+  });
+});


### PR DESCRIPTION
The static tracer field in OpenTelemetryScope captured a ProxyTracer bound to the old ProxyTracerProvider. After useMicrosoftOpenTelemetry() resets global state (trace.disable() + global object deletion), the new TracerProvider was registered on a new proxy, leaving the cached tracer orphaned — all spans were NoopSpan with zeroed IDs.

Changes:
- Replace static tracer field with lazy getTracer() method that resolves through the current global TracerProvider each time
- Add console span exporter fallback when A365 options are provided but the exporter is disabled (matches upstream A365 SDK behavior)
- Prevent duplicate console span exporters when both A365 fallback and general console fallback would fire
- Add test suite verifying all four scope types produce valid IDs after the global-state reset sequence

Fixes #39
