### PR TITLE
Add one-line A365 hosting setup and migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Remove Azure Functions auto-instrumentation support from this package. The `instrumentationOptions.azureFunctions` option is no longer available.
 - Remove JSON configuration support (`applicationinsights.json`, `APPLICATIONINSIGHTS_CONFIGURATION_FILE`, and `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT`). Configuration now comes only from programmatic options and environment variables.
 
+### Features Added
+- Add `configureA365Hosting(adapter, options?)` as a one-liner helper to register A365 hosting middleware with defaults (`enableBaggage: true`, `enableOutputLogging: true`).
+
 ### Bugs Fixed
 - Prevent ESM/CJS interop regressions by removing the problematic Azure Functions instrumentation path and adding explicit built-ESM import regression coverage.
 - Remove startup noise caused by implicit JSON config file probing in the Microsoft distro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,32 @@
 # Release History
 
+## [0.1.0-alpha.6]
+
+### Features Added
+- Add `configureA365Hosting(adapter, options?)` helper for one-line A365 hosting middleware setup. ([#55](https://github.com/microsoft/opentelemetry-distro-javascript/pull/55))
+
+
 ## [0.1.0-alpha.5] - 2026-04-24 
 
 ### Breaking Changes
-- Remove Azure Functions auto-instrumentation support from this package. The `instrumentationOptions.azureFunctions` option is no longer available.
-- Remove JSON configuration support (`applicationinsights.json`, `APPLICATIONINSIGHTS_CONFIGURATION_FILE`, and `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT`). Configuration now comes only from programmatic options and environment variables.
+- Remove Azure Functions auto-instrumentation support from this package. The `instrumentationOptions.azureFunctions` option is no longer available. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
+- Remove JSON configuration support (`applicationinsights.json`, `APPLICATIONINSIGHTS_CONFIGURATION_FILE`, and `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT`). Configuration now comes only from programmatic options and environment variables. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
+- Remove `PerRequestSpanProcessor` and `PerRequestSpanProcessorOptions` from the public API. ([#47](https://github.com/microsoft/opentelemetry-distro-javascript/pull/47))
 
 ### Features Added
-- Add `configureA365Hosting(adapter, options?)` as a one-liner helper to register A365 hosting middleware with defaults (`enableBaggage: true`, `enableOutputLogging: true`).
+- Expose additional A365 public configuration options through `A365Options`: `serviceNamespace`, `exporterOptions`, `observabilityLogLevel`, and `logger`.
+- Add A365 logger configuration support with injectable `ILogger`, `configureA365Logger`, `getA365Logger`, and env override via `A365_OBSERVABILITY_LOG_LEVEL`.
+- Apply A365 exporter tuning options to batch processor/exporter wiring and support global `service.namespace` resource merge when configured via A365 options.
 
 ### Bugs Fixed
-- Prevent ESM/CJS interop regressions by removing the problematic Azure Functions instrumentation path and adding explicit built-ESM import regression coverage.
-- Remove startup noise caused by implicit JSON config file probing in the Microsoft distro.
+- Prevent ESM/CJS interop regressions by removing the problematic Azure Functions instrumentation path and adding explicit built-ESM import regression coverage. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
+- Remove startup noise caused by implicit JSON config file probing in the Microsoft distro. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
 
 ### Other Changes
+- Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
+- Bump hono from 4.12.12 to 4.12.14. ([#19](https://github.com/microsoft/opentelemetry-distro-javascript/pull/19))
 - Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test.
+- Update README and A365 migration guide with actionable configuration documentation, including `a365.exporterOptions` details and migration-focused steps.
 
 ## [0.1.0-alpha.4] - 2026-04-22
 

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -126,6 +126,18 @@ useMicrosoftOpenTelemetry({
 });
 ```
 
+## Hosting Middleware Setup
+
+If your app uses `@microsoft/agents-hosting` and expects hosting-layer middleware (`BaggageMiddleware`, `OutputLoggingMiddleware`), attach middleware to the adapter explicitly.
+
+### Current one-liner
+
+```typescript
+import { configureA365Hosting } from "@microsoft/opentelemetry";
+
+configureA365Hosting(adapter);
+```
+
 ## Environment Variables
 
 Environment variable names are **unchanged** from Agent365-nodejs:

--- a/README.md
+++ b/README.md
@@ -193,13 +193,14 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `boolean` | `false` | Enable hosting middleware integration (baggage middleware, output logging, etc.) |
-| `adapter` | `{ use(...middlewares): void }` | — | Adapter instance where middleware is auto-registered when `enabled` is true |
-| `enableOutputLogging` | `boolean` | `true` | Enable output logging middleware auto-registration |
+| `enabled` | `boolean` | `false` | Currently does not auto-attach, enable, or disable hosting middleware by itself; attach hosting middleware explicitly as described below. |
+| `adapter` | `{ use(...middlewares): void }` | — | Adapter reference for hosting integration configuration. |
+| `enableOutputLogging` | `boolean` | `true` | Hosting output logging preference in configuration. |
 
 #### A365 hosting middleware setup
 
-`a365.hosting.enabled` controls hosting-related configuration, but middleware still needs to be attached to your adapter.
+`a365.hosting.enabled` is currently only a configuration value and does not by itself attach middleware or gate hosting middleware behavior.
+To use A365 hosting middleware, attach it to your adapter explicitly.
 
 Use the one-liner helper:
 
@@ -210,6 +211,15 @@ configureA365Hosting(adapter);
 ```
 
 By default this registers both `BaggageMiddleware` and `OutputLoggingMiddleware`.
+
+`OutputLoggingMiddleware` captures outgoing message content as span attributes. If your responses may contain sensitive content, disable output logging:
+
+```typescript
+configureA365Hosting(adapter, {
+  enableBaggage: true,
+  enableOutputLogging: false,
+});
+```
 
 If you need explicit flags:
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,40 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 |---|---|---|---|
 | `enabled` | `boolean` | `false` | Enable hosting middleware integration (baggage middleware, output logging, etc.) |
 
+#### A365 hosting middleware setup
+
+`a365.hosting.enabled` controls hosting-related configuration, but middleware still needs to be attached to your adapter.
+
+Use the one-liner helper:
+
+```typescript
+import { configureA365Hosting } from "@microsoft/opentelemetry";
+
+configureA365Hosting(adapter);
+```
+
+By default this registers both `BaggageMiddleware` and `OutputLoggingMiddleware`.
+
+If you need explicit flags:
+
+```typescript
+configureA365Hosting(adapter, {
+  enableBaggage: true,
+  enableOutputLogging: true,
+});
+```
+
+For previously published package versions that do not include `configureA365Hosting`, use:
+
+```typescript
+import { ObservabilityHostingManager } from "@microsoft/opentelemetry";
+
+new ObservabilityHostingManager().configure(adapter as unknown as { use(...m: unknown[]): void }, {
+  enableBaggage: true,
+  enableOutputLogging: true,
+});
+```
+
 #### A365 environment variables
 
 A365 options can also be set via environment variables (highest precedence):

--- a/src/a365/hosting/configureA365Hosting.ts
+++ b/src/a365/hosting/configureA365Hosting.ts
@@ -3,14 +3,7 @@
 
 import { ObservabilityHostingManager } from "./observabilityHostingManager.js";
 import type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
-import type { MiddlewareLike } from "./types.js";
-
-/**
- * Minimal adapter contract required to register hosting middleware.
- */
-export interface HostingAdapterLike {
-  use(...middlewares: Array<MiddlewareLike>): void;
-}
+import type { HostingAdapterLike } from "./types.js";
 
 /**
  * Configure A365 hosting middleware in a single call.

--- a/src/a365/hosting/configureA365Hosting.ts
+++ b/src/a365/hosting/configureA365Hosting.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ObservabilityHostingManager } from "./observabilityHostingManager.js";
+import type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
+import type { MiddlewareLike } from "./types.js";
+
+/**
+ * Minimal adapter contract required to register hosting middleware.
+ */
+export interface HostingAdapterLike {
+  use(...middlewares: Array<MiddlewareLike>): void;
+}
+
+/**
+ * Configure A365 hosting middleware in a single call.
+ *
+ * Defaults to enabling both baggage propagation and output logging.
+ */
+export function configureA365Hosting(
+  adapter: HostingAdapterLike,
+  options?: ObservabilityHostingOptions,
+): ObservabilityHostingManager {
+  const manager = new ObservabilityHostingManager();
+  manager.configure(adapter, {
+    enableBaggage: options?.enableBaggage ?? true,
+    enableOutputLogging: options?.enableOutputLogging ?? true,
+  });
+  return manager;
+}

--- a/src/a365/hosting/index.ts
+++ b/src/a365/hosting/index.ts
@@ -20,8 +20,8 @@ export {
 export { ObservabilityHostingManager } from "./observabilityHostingManager.js";
 export type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
 export { configureA365Hosting } from "./configureA365Hosting.js";
-export type { HostingAdapterLike } from "./configureA365Hosting.js";
 export type {
+  HostingAdapterLike,
   TurnContextLike,
   ActivityLike,
   MiddlewareLike,

--- a/src/a365/hosting/index.ts
+++ b/src/a365/hosting/index.ts
@@ -19,6 +19,8 @@ export {
 } from "./outputLoggingMiddleware.js";
 export { ObservabilityHostingManager } from "./observabilityHostingManager.js";
 export type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
+export { configureA365Hosting } from "./configureA365Hosting.js";
+export type { HostingAdapterLike } from "./configureA365Hosting.js";
 export type {
   TurnContextLike,
   ActivityLike,

--- a/src/a365/hosting/observabilityHostingManager.ts
+++ b/src/a365/hosting/observabilityHostingManager.ts
@@ -10,7 +10,7 @@
 import { Logger } from "../../shared/logging/index.js";
 import { BaggageMiddleware } from "./baggageMiddleware.js";
 import { OutputLoggingMiddleware } from "./outputLoggingMiddleware.js";
-import type { MiddlewareLike } from "./types.js";
+import type { HostingAdapterLike } from "./types.js";
 
 /**
  * Configuration options for the hosting observability layer.
@@ -40,7 +40,7 @@ export class ObservabilityHostingManager {
    * Subsequent calls are ignored.
    */
   configure(
-    adapter: { use(...middlewares: Array<MiddlewareLike>): void },
+    adapter: HostingAdapterLike,
     options: ObservabilityHostingOptions,
   ): void {
     if (this._configured) {

--- a/src/a365/hosting/observabilityHostingManager.ts
+++ b/src/a365/hosting/observabilityHostingManager.ts
@@ -39,10 +39,7 @@ export class ObservabilityHostingManager {
    * Registers observability middleware on the adapter.
    * Subsequent calls are ignored.
    */
-  configure(
-    adapter: HostingAdapterLike,
-    options: ObservabilityHostingOptions,
-  ): void {
+  configure(adapter: HostingAdapterLike, options: ObservabilityHostingOptions): void {
     if (this._configured) {
       Logger.getInstance().warn(
         "[ObservabilityHostingManager] Already configured. Subsequent configure() calls are ignored.",

--- a/src/a365/hosting/types.ts
+++ b/src/a365/hosting/types.ts
@@ -60,3 +60,8 @@ export type SendActivitiesHandler = (
 export interface MiddlewareLike {
   onTurn(context: TurnContextLike, next: () => Promise<void>): Promise<void>;
 }
+
+/** Minimal adapter contract for registering hosting middleware. */
+export interface HostingAdapterLike {
+  use(...middlewares: Array<MiddlewareLike>): void;
+}

--- a/src/a365/index.ts
+++ b/src/a365/index.ts
@@ -102,9 +102,11 @@ export {
   A365_PARENT_SPAN_KEY,
   A365_AUTH_TOKEN_KEY,
   ObservabilityHostingManager,
+  configureA365Hosting,
 } from "./hosting/index.js";
 export type {
   ObservabilityHostingOptions,
+  HostingAdapterLike,
   TurnContextLike,
   ActivityLike,
   MiddlewareLike,

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,9 +97,11 @@ export {
   A365_PARENT_SPAN_KEY,
   A365_AUTH_TOKEN_KEY,
   ObservabilityHostingManager,
+  configureA365Hosting,
 } from "./a365/index.js";
 export type {
   ObservabilityHostingOptions,
+  HostingAdapterLike,
   TurnContextLike,
   ActivityLike,
   MiddlewareLike,

--- a/test/internal/unit/a365/hosting/configureA365Hosting.test.ts
+++ b/test/internal/unit/a365/hosting/configureA365Hosting.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+
+import { configureA365Hosting } from "../../../../../src/a365/hosting/configureA365Hosting.js";
+import { ObservabilityHostingManager } from "../../../../../src/a365/hosting/observabilityHostingManager.js";
+import { BaggageMiddleware } from "../../../../../src/a365/hosting/baggageMiddleware.js";
+import { OutputLoggingMiddleware } from "../../../../../src/a365/hosting/outputLoggingMiddleware.js";
+import type { MiddlewareLike } from "../../../../../src/a365/hosting/types.js";
+
+describe("configureA365Hosting", () => {
+  it("should register both middleware by default", () => {
+    const registered: MiddlewareLike[] = [];
+    const adapter = { use: (...mws: MiddlewareLike[]) => registered.push(...mws) };
+
+    const manager = configureA365Hosting(adapter);
+
+    expect(manager).toBeInstanceOf(ObservabilityHostingManager);
+    expect(registered.length).toBe(2);
+    expect(registered[0]).toBeInstanceOf(BaggageMiddleware);
+    expect(registered[1]).toBeInstanceOf(OutputLoggingMiddleware);
+  });
+
+  it("should respect explicit options", () => {
+    const registered: MiddlewareLike[] = [];
+    const adapter = { use: (...mws: MiddlewareLike[]) => registered.push(...mws) };
+
+    configureA365Hosting(adapter, { enableBaggage: false, enableOutputLogging: true });
+
+    expect(registered.length).toBe(1);
+    expect(registered[0]).toBeInstanceOf(OutputLoggingMiddleware);
+  });
+
+  it("should allow disabling both middleware", () => {
+    const registered: MiddlewareLike[] = [];
+    const adapter = { use: (...mws: MiddlewareLike[]) => registered.push(...mws) };
+
+    configureA365Hosting(adapter, { enableBaggage: false, enableOutputLogging: false });
+
+    expect(registered.length).toBe(0);
+  });
+});


### PR DESCRIPTION
- add configureA365Hosting helper with sensible defaults

- export helper through A365 and root public APIs

- add unit coverage for helper behavior

- update README, MIGRATION_A365, and CHANGELOG with setup timing and backward-compatible workaround