### PR TITLE
Fix hosting middleware for plain CloudAdapter activities

### DIFF
--- a/src/a365/hosting/activityCompat.ts
+++ b/src/a365/hosting/activityCompat.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ActivityLike } from "./types.js";
+
+type ActivityCompatLike = ActivityLike & {
+  recipient?: ActivityLike["recipient"] & {
+    tenantId?: string;
+    agenticAppId?: string;
+  };
+  conversation?: ActivityLike["conversation"] & {
+    tenantId?: string;
+  };
+};
+
+/**
+ * Ensures agentic helper methods exist on plain activity objects.
+ *
+ * Agent365 hosting utilities read identity via Activity helper methods.
+ * CloudAdapter can provide plain JSON activity objects without those methods.
+ */
+export function ensureAgenticActivityHelpers(activity: ActivityLike | undefined): void {
+  const a = activity as ActivityCompatLike | undefined;
+  if (!a) {
+    return;
+  }
+
+  if (typeof a.isAgenticRequest !== "function") {
+    a.isAgenticRequest = () => a.recipient?.role === "agenticUser";
+  }
+
+  if (typeof a.getAgenticTenantId !== "function") {
+    a.getAgenticTenantId = () => a.recipient?.tenantId ?? a.conversation?.tenantId ?? "";
+  }
+
+  if (typeof a.getAgenticInstanceId !== "function") {
+    a.getAgenticInstanceId = () =>
+      a.isAgenticRequest?.() ? (a.recipient?.agenticAppId ?? "") : "";
+  }
+}

--- a/src/a365/hosting/baggageMiddleware.ts
+++ b/src/a365/hosting/baggageMiddleware.ts
@@ -17,6 +17,7 @@ import {
   getChannelBaggagePairs,
   getConversationIdAndItemLinkPairs,
 } from "./turnContextUtils.js";
+import { ensureAgenticActivityHelpers } from "./activityCompat.js";
 
 /**
  * Middleware that propagates OpenTelemetry baggage context derived from TurnContext.
@@ -24,6 +25,8 @@ import {
  */
 export class BaggageMiddleware implements MiddlewareLike {
   async onTurn(context: TurnContextLike, next: () => Promise<void>): Promise<void> {
+    ensureAgenticActivityHelpers(context.activity);
+
     const isAsyncReply =
       context.activity?.type === "event" && context.activity?.name === "ContinueConversation";
 

--- a/src/a365/hosting/outputLoggingMiddleware.ts
+++ b/src/a365/hosting/outputLoggingMiddleware.ts
@@ -9,6 +9,7 @@
 
 import { OutputScope } from "../scopes/index.js";
 import { ScopeUtils } from "./scopeUtils.js";
+import { ensureAgenticActivityHelpers } from "./activityCompat.js";
 import { Logger } from "../../shared/logging/index.js";
 import type {
   AgentDetails,
@@ -46,6 +47,8 @@ export const A365_AUTH_TOKEN_KEY = "A365AuthToken";
  */
 export class OutputLoggingMiddleware implements MiddlewareLike {
   async onTurn(context: TurnContextLike, next: () => Promise<void>): Promise<void> {
+    ensureAgenticActivityHelpers(context.activity);
+
     const authToken = (context.turnState.get(A365_AUTH_TOKEN_KEY) as string) ?? "";
     const agentDetails = ScopeUtils.deriveAgentDetails(context, authToken);
 

--- a/test/internal/unit/a365/hosting/baggageMiddleware.test.ts
+++ b/test/internal/unit/a365/hosting/baggageMiddleware.test.ts
@@ -166,4 +166,51 @@ describe("BaggageMiddleware", () => {
     // Should still set baggage for non-ContinueConversation events
     expect(Object.keys(capturedBaggage).length).toBeGreaterThan(0);
   });
+
+  it("should populate tenant and agent baggage from plain activity fields", async () => {
+    const middleware = new BaggageMiddleware();
+    const ctx = makeMockTurnContext();
+    const activity = ctx.activity as TurnContextLike["activity"] & {
+      recipient?: {
+        tenantId?: string;
+        agenticAppId?: string;
+        role?: string;
+      };
+      conversation?: {
+        id?: string;
+        tenantId?: string;
+      };
+    };
+
+    delete (activity as { getAgenticTenantId?: () => string }).getAgenticTenantId;
+    delete (activity as { getAgenticInstanceId?: () => string }).getAgenticInstanceId;
+    delete (activity as { isAgenticRequest?: () => boolean }).isAgenticRequest;
+
+    activity.recipient = {
+      ...activity.recipient,
+      role: "agenticUser",
+      tenantId: "tenant-from-recipient",
+      agenticAppId: "agent-from-recipient",
+    };
+    activity.conversation = {
+      ...activity.conversation,
+      tenantId: "tenant-from-conversation",
+    };
+
+    const capturedBaggage: Record<string, string> = {};
+
+    await middleware.onTurn(ctx, async () => {
+      const bag = propagation.getBaggage(otelContext.active());
+      if (bag) {
+        for (const [key, entry] of bag.getAllEntries()) {
+          capturedBaggage[key] = entry.value;
+        }
+      }
+    });
+
+    expect(capturedBaggage[OpenTelemetryConstants.TENANT_ID_KEY]).toBe("tenant-from-recipient");
+    expect(capturedBaggage[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]).toBe(
+      "agent-from-recipient",
+    );
+  });
 });

--- a/test/internal/unit/a365/hosting/outputLoggingMiddleware.test.ts
+++ b/test/internal/unit/a365/hosting/outputLoggingMiddleware.test.ts
@@ -233,6 +233,54 @@ describe("OutputLoggingMiddleware", () => {
     expect(outputSpan!.attributes[OpenTelemetryConstants.CHANNEL_NAME_KEY]).toBe("teams");
   });
 
+  it("should create OutputScope when activity helper methods are missing", async () => {
+    const middleware = new OutputLoggingMiddleware();
+    const ctx = makeMockTurnContext({ text: "Hello" });
+    ctx.turnState.set(A365_AUTH_TOKEN_KEY, "");
+
+    const activity = ctx.activity as TurnContextLike["activity"] & {
+      recipient?: {
+        tenantId?: string;
+        agenticAppId?: string;
+        role?: string;
+      };
+      conversation?: {
+        id?: string;
+        tenantId?: string;
+      };
+    };
+
+    delete (activity as { getAgenticTenantId?: () => string }).getAgenticTenantId;
+    delete (activity as { getAgenticInstanceId?: () => string }).getAgenticInstanceId;
+    delete (activity as { isAgenticRequest?: () => boolean }).isAgenticRequest;
+
+    activity.recipient = {
+      ...activity.recipient,
+      role: "agenticUser",
+      tenantId: "tenant-from-recipient",
+      agenticAppId: "agent-from-recipient",
+    };
+    activity.conversation = {
+      ...activity.conversation,
+      tenantId: "tenant-from-conversation",
+    };
+
+    await middleware.onTurn(ctx, async () => {
+      await ctx.simulateSend([{ type: "message", text: "Reply" }]);
+    });
+
+    await flushProvider.forceFlush();
+    const outputSpan = exporter.getFinishedSpans().find((s) => s.name.includes("output_messages"));
+
+    expect(outputSpan).toBeDefined();
+    expect(outputSpan!.attributes[OpenTelemetryConstants.TENANT_ID_KEY]).toBe(
+      "tenant-from-recipient",
+    );
+    expect(outputSpan!.attributes[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]).toBe(
+      "agent-from-recipient",
+    );
+  });
+
   it("should link OutputScope to parent when parentSpanRef is set", async () => {
     const middleware = new OutputLoggingMiddleware();
     const ctx = makeMockTurnContext({ text: "Hello" });


### PR DESCRIPTION
Keep vendored A365 identity extraction logic unchanged and add a boundary compatibility shim that hydrates missing activity helper methods when adapters provide plain JSON activities
Add regression tests for baggage and output logging middleware to verify tenant/agent identity is populated when getAgenticTenantId/getAgenticInstanceId/isAgenticRequest are absent.

Fixes #61