### PR TITLE
feat: add AgenticTokenCache for built-in token caching support

### DIFF
--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Adapted from microsoft/Agent365-nodejs agents-a365-observability-hosting/src/caching/AgenticTokenCache.ts
+ */
+
+import { getA365Logger } from "../logging.js";
+import type { TurnContextLike } from "./types.js";
+
+/**
+ * Minimal authorization shape required by AgenticTokenCache.
+ *
+ * Mirrors the `Authorization` interface from `@microsoft/agents-hosting`
+ * so the cache can be used without a direct dependency on that package.
+ */
+export interface AuthorizationLike {
+  exchangeToken(
+    turnContext: TurnContextLike,
+    authHandlerName: string,
+    options: { scopes: string[] },
+  ): Promise<{ token?: string } | undefined>;
+}
+
+interface CacheEntry {
+  scopes: string[];
+  token?: string;
+  expiresOn?: number;
+  acquiredOn?: number;
+}
+
+/**
+ * Cache for agentic authentication tokens used by observability services.
+ *
+ * @example
+ * ```typescript
+ * // Use the default singleton:
+ * import { AgenticTokenCacheInstance } from '@microsoft/opentelemetry';
+ *
+ * // Or create an instance with custom scopes:
+ * const cache = new AgenticTokenCache({ authScopes: ['api://my-scope/.default'] });
+ * ```
+ */
+export class AgenticTokenCache {
+  private readonly _map = new Map<string, CacheEntry>();
+  private readonly _defaultRefreshSkewMs = 60_000;
+  private readonly _defaultMaxTokenAgeMs = 3_600_000;
+  private readonly _maxCacheSize = 10_000;
+  private readonly _maxExpSeconds = 86_400; // 24 hours
+  private readonly _keyLocks = new Map<string, Promise<unknown>>();
+  private readonly _authScopes: string[];
+
+  constructor(options?: AgenticTokenCacheOptions) {
+    const envScopes = process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE?.trim();
+    if (envScopes) {
+      this._authScopes = envScopes.split(/\s+/).filter(Boolean);
+    } else {
+      this._authScopes = options?.authScopes ?? [
+        "api://9b975845-388f-4429-889e-eab1ef63949c/.default",
+      ];
+    }
+  }
+
+  public static makeKey(agentId: string, tenantId: string): string {
+    return `${agentId}:${tenantId}`;
+  }
+
+  public getObservabilityToken(agentId: string, tenantId: string): string | null {
+    const key = AgenticTokenCache.makeKey(agentId, tenantId);
+    const entry = this._map.get(key);
+    if (!entry) {
+      getA365Logger().error(`[AgenticTokenCache] No cache entry for ${key}`);
+      return null;
+    }
+    if (!entry.token) {
+      getA365Logger().error(`[AgenticTokenCache] No token cached for ${key}`);
+      return null;
+    }
+    if (this.isExpired(entry)) {
+      getA365Logger().error(`[AgenticTokenCache] Token expired for ${key}`);
+      return null;
+    }
+    return entry.token;
+  }
+
+  public async refreshObservabilityToken(
+    agentId: string,
+    tenantId: string,
+    turnContext: TurnContextLike,
+    authorization: AuthorizationLike,
+    scopes?: string[],
+    authHandlerName: string = "agentic",
+  ): Promise<void> {
+    const key = AgenticTokenCache.makeKey(agentId, tenantId);
+    if (!authorization) {
+      throw new Error("[AgenticTokenCache] Authorization not set");
+    }
+    if (!turnContext) {
+      throw new Error("[AgenticTokenCache] TurnContext not set");
+    }
+    return this.withKeyLock<void>(key, async () => {
+      let entry = this._map.get(key);
+      if (!entry) {
+        const effectiveScopes =
+          scopes && scopes.length > 0 ? scopes : [...this._authScopes];
+        if (!Array.isArray(effectiveScopes) || effectiveScopes.length === 0) {
+          getA365Logger().error("[AgenticTokenCache] No valid scopes");
+          return;
+        }
+        entry = { scopes: effectiveScopes };
+        if (this._map.size >= this._maxCacheSize) {
+          const oldest = this._map.keys().next().value;
+          if (oldest !== undefined) {
+            this._map.delete(oldest);
+          }
+        }
+        this._map.set(key, entry);
+      }
+      if (!Array.isArray(entry.scopes) || entry.scopes.length === 0) {
+        getA365Logger().error("[AgenticTokenCache] Entry has invalid scopes");
+        return;
+      }
+
+      if (entry.token && !this.isExpired(entry)) {
+        return;
+      }
+
+      const maxRetries = 2;
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        getA365Logger().info(
+          `[AgenticTokenCache] Exchanging token attempt ${attempt + 1}/${maxRetries + 1}`,
+        );
+        try {
+          const tokenResponse = await authorization.exchangeToken(
+            turnContext,
+            authHandlerName,
+            { scopes: entry.scopes },
+          );
+          if (!tokenResponse?.token) {
+            getA365Logger().error("[AgenticTokenCache] Undefined token returned");
+            entry.token = undefined;
+            entry.expiresOn = undefined;
+            break;
+          }
+          entry.token = tokenResponse.token;
+          entry.acquiredOn = Date.now();
+          const oboExp = this.decodeExp(entry.token);
+          if (oboExp) {
+            entry.expiresOn = oboExp * 1000;
+          } else {
+            getA365Logger().warn("[AgenticTokenCache] No exp claim, fallback TTL");
+          }
+          getA365Logger().info("[AgenticTokenCache] Token cached");
+          return;
+        } catch (e) {
+          const retriable = this.isRetriableError(e);
+          if (retriable && attempt < maxRetries) {
+            getA365Logger().warn(
+              `[AgenticTokenCache] Retriable failure attempt ${attempt + 1}`,
+              e instanceof Error ? e.message : String(e),
+            );
+            await this.sleep(200 * (attempt + 1));
+            continue;
+          }
+          getA365Logger().error(
+            "[AgenticTokenCache] Non-retriable failure",
+            e instanceof Error ? e.message : String(e),
+          );
+          entry.token = undefined;
+          entry.expiresOn = undefined;
+          break;
+        }
+      }
+    });
+  }
+
+  public invalidateToken(agentId: string, tenantId: string): void {
+    const entry = this._map.get(AgenticTokenCache.makeKey(agentId, tenantId));
+    if (entry) {
+      entry.token = undefined;
+      entry.expiresOn = undefined;
+    }
+  }
+
+  public invalidateAll(): void {
+    this._map.clear();
+  }
+
+  private decodeExp(jwt: string): number | undefined {
+    try {
+      if (!jwt) return undefined;
+      const parts = jwt.split(".");
+      if (parts.length < 2) return undefined;
+      const payloadSegment = parts[1];
+      const padded = payloadSegment + "=".repeat((4 - (payloadSegment.length % 4)) % 4);
+      const json = JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as {
+        exp?: unknown;
+      };
+      if (typeof json.exp !== "number") return undefined;
+      const maxExp = Math.floor(Date.now() / 1000) + this._maxExpSeconds;
+      return Math.min(json.exp, maxExp);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private isExpired(entry: CacheEntry): boolean {
+    const now = Date.now();
+    if (entry.expiresOn) {
+      return now >= entry.expiresOn - this._defaultRefreshSkewMs;
+    }
+    if (entry.acquiredOn) {
+      return now >= entry.acquiredOn + this._defaultMaxTokenAgeMs;
+    }
+    return true;
+  }
+
+  private isRetriableError(err: unknown): boolean {
+    const e = err as { code?: string; status?: number; message?: string } | undefined;
+    if (!e) return false;
+    const msg = (e.message || "").toLowerCase();
+    if (msg.includes("timeout") || msg.includes("econnreset") || msg.includes("network"))
+      return true;
+    if (typeof e.status === "number") {
+      if (e.status === 408 || e.status === 429) return true;
+      if (e.status >= 500 && e.status < 600) return true;
+    }
+    return false;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this._keyLocks.get(key);
+    if (previous) {
+      try {
+        await previous;
+      } catch (err) {
+        getA365Logger().warn(
+          `[AgenticTokenCache] previous promise for ${key} rejected:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    const currentPromise: Promise<T> = fn().finally(() => {
+      if (this._keyLocks.get(key) === currentPromise) {
+        this._keyLocks.delete(key);
+      }
+    });
+    this._keyLocks.set(key, currentPromise);
+    return currentPromise;
+  }
+}
+
+/**
+ * Options for constructing an AgenticTokenCache instance.
+ */
+export interface AgenticTokenCacheOptions {
+  /** OAuth scopes for token exchange. Defaults to the A365 observability scope. */
+  authScopes?: string[];
+}
+
+/**
+ * Default singleton instance of AgenticTokenCache using the default configuration.
+ */
+export const AgenticTokenCacheInstance = new AgenticTokenCache();

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -56,7 +56,7 @@ export class AgenticTokenCache {
       this._authScopes = envScopes.split(/\s+/).filter(Boolean);
     } else {
       this._authScopes = options?.authScopes ?? [
-        "api://9b975845-388f-4429-889e-eab1ef63949c/.default",
+        "https://api.powerplatform.com/.default",
       ];
     }
   }
@@ -68,6 +68,11 @@ export class AgenticTokenCache {
   public getObservabilityToken(agentId: string, tenantId: string): string | null {
     const key = AgenticTokenCache.makeKey(agentId, tenantId);
     const entry = this._map.get(key);
+    // Touch entry for LRU recency
+    if (entry) {
+      this._map.delete(key);
+      this._map.set(key, entry);
+    }
     if (!entry) {
       getA365Logger().error(`[AgenticTokenCache] No cache entry for ${key}`);
       return null;
@@ -102,19 +107,28 @@ export class AgenticTokenCache {
       let entry = this._map.get(key);
       if (!entry) {
         const effectiveScopes =
-          scopes && scopes.length > 0 ? scopes : [...this._authScopes];
+          scopes && scopes.length > 0 ? [...scopes] : [...this._authScopes];
         if (!Array.isArray(effectiveScopes) || effectiveScopes.length === 0) {
           getA365Logger().error("[AgenticTokenCache] No valid scopes");
           return;
         }
         entry = { scopes: effectiveScopes };
         if (this._map.size >= this._maxCacheSize) {
-          const oldest = this._map.keys().next().value;
-          if (oldest !== undefined) {
-            this._map.delete(oldest);
+          // Evict least-recently-used (first key in Map insertion order)
+          const lruKey = this._map.keys().next().value;
+          if (lruKey !== undefined) {
+            this._map.delete(lruKey);
           }
         }
         this._map.set(key, entry);
+      } else {
+        // Touch for LRU recency
+        this._map.delete(key);
+        this._map.set(key, entry);
+        // Update scopes if caller provided new ones
+        if (scopes && scopes.length > 0) {
+          entry.scopes = [...scopes];
+        }
       }
       if (!Array.isArray(entry.scopes) || entry.scopes.length === 0) {
         getA365Logger().error("[AgenticTokenCache] Entry has invalid scopes");
@@ -232,25 +246,19 @@ export class AgenticTokenCache {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  private async withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const previous = this._keyLocks.get(key);
-    if (previous) {
-      try {
-        await previous;
-      } catch (err) {
-        getA365Logger().warn(
-          `[AgenticTokenCache] previous promise for ${key} rejected:`,
-          err instanceof Error ? err.message : String(err),
-        );
-      }
-    }
-    const currentPromise: Promise<T> = fn().finally(() => {
-      if (this._keyLocks.get(key) === currentPromise) {
+  private withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    // Chain onto any existing promise for this key so that concurrent
+    // callers are serialised rather than racing after the same await.
+    const previous = this._keyLocks.get(key) ?? Promise.resolve();
+    const next = previous.catch(() => {/* swallow */}).then(fn);
+    this._keyLocks.set(key, next);
+    // Clean up the lock when the chain settles and hasn't been extended.
+    next.finally(() => {
+      if (this._keyLocks.get(key) === next) {
         this._keyLocks.delete(key);
       }
     });
-    this._keyLocks.set(key, currentPromise);
-    return currentPromise;
+    return next;
   }
 }
 

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -55,9 +55,7 @@ export class AgenticTokenCache {
     if (envScopes) {
       this._authScopes = envScopes.split(/\s+/).filter(Boolean);
     } else {
-      this._authScopes = options?.authScopes ?? [
-        "https://api.powerplatform.com/.default",
-      ];
+      this._authScopes = options?.authScopes ?? ["https://api.powerplatform.com/.default"];
     }
   }
 
@@ -106,8 +104,7 @@ export class AgenticTokenCache {
     return this.withKeyLock<void>(key, async () => {
       let entry = this._map.get(key);
       if (!entry) {
-        const effectiveScopes =
-          scopes && scopes.length > 0 ? [...scopes] : [...this._authScopes];
+        const effectiveScopes = scopes && scopes.length > 0 ? [...scopes] : [...this._authScopes];
         if (!Array.isArray(effectiveScopes) || effectiveScopes.length === 0) {
           getA365Logger().error("[AgenticTokenCache] No valid scopes");
           return;
@@ -145,11 +142,9 @@ export class AgenticTokenCache {
           `[AgenticTokenCache] Exchanging token attempt ${attempt + 1}/${maxRetries + 1}`,
         );
         try {
-          const tokenResponse = await authorization.exchangeToken(
-            turnContext,
-            authHandlerName,
-            { scopes: entry.scopes },
-          );
+          const tokenResponse = await authorization.exchangeToken(turnContext, authHandlerName, {
+            scopes: entry.scopes,
+          });
           if (!tokenResponse?.token) {
             getA365Logger().error("[AgenticTokenCache] Undefined token returned");
             entry.token = undefined;
@@ -250,7 +245,11 @@ export class AgenticTokenCache {
     // Chain onto any existing promise for this key so that concurrent
     // callers are serialised rather than racing after the same await.
     const previous = this._keyLocks.get(key) ?? Promise.resolve();
-    const next = previous.catch(() => {/* swallow */}).then(fn);
+    const next = previous
+      .catch(() => {
+        /* swallow */
+      })
+      .then(fn);
     this._keyLocks.set(key, next);
     // Clean up the lock when the chain settles and hasn't been extended.
     next.finally(() => {

--- a/src/a365/hosting/index.ts
+++ b/src/a365/hosting/index.ts
@@ -19,6 +19,11 @@ export {
 } from "./outputLoggingMiddleware.js";
 export { ObservabilityHostingManager } from "./observabilityHostingManager.js";
 export type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
+export {
+  AgenticTokenCache,
+  AgenticTokenCacheInstance,
+} from "./agenticTokenCache.js";
+export type { AuthorizationLike, AgenticTokenCacheOptions } from "./agenticTokenCache.js";
 export type {
   TurnContextLike,
   ActivityLike,

--- a/src/a365/hosting/index.ts
+++ b/src/a365/hosting/index.ts
@@ -19,10 +19,7 @@ export {
 } from "./outputLoggingMiddleware.js";
 export { ObservabilityHostingManager } from "./observabilityHostingManager.js";
 export type { ObservabilityHostingOptions } from "./observabilityHostingManager.js";
-export {
-  AgenticTokenCache,
-  AgenticTokenCacheInstance,
-} from "./agenticTokenCache.js";
+export { AgenticTokenCache, AgenticTokenCacheInstance } from "./agenticTokenCache.js";
 export type { AuthorizationLike, AgenticTokenCacheOptions } from "./agenticTokenCache.js";
 export { configureA365Hosting } from "./configureA365Hosting.js";
 export type {

--- a/src/a365/index.ts
+++ b/src/a365/index.ts
@@ -105,9 +105,13 @@ export {
   A365_PARENT_SPAN_KEY,
   A365_AUTH_TOKEN_KEY,
   ObservabilityHostingManager,
+  AgenticTokenCache,
+  AgenticTokenCacheInstance,
 } from "./hosting/index.js";
 export type {
   ObservabilityHostingOptions,
+  AuthorizationLike,
+  AgenticTokenCacheOptions,
   TurnContextLike,
   ActivityLike,
   MiddlewareLike,

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,9 +97,13 @@ export {
   A365_PARENT_SPAN_KEY,
   A365_AUTH_TOKEN_KEY,
   ObservabilityHostingManager,
+  AgenticTokenCache,
+  AgenticTokenCacheInstance,
 } from "./a365/index.js";
 export type {
   ObservabilityHostingOptions,
+  AuthorizationLike,
+  AgenticTokenCacheOptions,
   TurnContextLike,
   ActivityLike,
   MiddlewareLike,

--- a/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
+++ b/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
@@ -1,0 +1,352 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  AgenticTokenCache,
+  type AuthorizationLike,
+} from "../../../../../src/a365/hosting/agenticTokenCache.js";
+import type { TurnContextLike } from "../../../../../src/a365/hosting/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTurnContext(): TurnContextLike {
+  return {
+    activity: { type: "message" },
+    turnState: new Map<string, unknown>(),
+  };
+}
+
+/** Build a minimal JWT with a given `exp` claim (seconds since epoch). */
+function makeJwtWithExp(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+function makeAuthMock(
+  tokenOrFn?: string | (() => Promise<{ token?: string } | undefined>),
+): AuthorizationLike {
+  const impl =
+    typeof tokenOrFn === "function"
+      ? tokenOrFn
+      : async () => (tokenOrFn !== undefined ? { token: tokenOrFn } : undefined);
+  return { exchangeToken: vi.fn(impl) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AgenticTokenCache", () => {
+  let cache: AgenticTokenCache;
+
+  beforeEach(() => {
+    cache = new AgenticTokenCache();
+  });
+
+  // ── Basic get / refresh ──────────────────────────────────────────────────
+
+  it("returns null when no entry exists", () => {
+    expect(cache.getObservabilityToken("a", "t")).toBeNull();
+  });
+
+  it("exchanges and caches token on first call", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const jwt = makeJwtWithExp(exp);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(1);
+    expect(cache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
+  it("does not re-exchange when token is still valid", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const jwt = makeJwtWithExp(exp);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Retry on retriable errors ────────────────────────────────────────────
+
+  it("retries on retriable error then succeeds", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const jwt = makeJwtWithExp(exp);
+    let callCount = 0;
+    const auth = makeAuthMock(async () => {
+      callCount++;
+      if (callCount === 1) throw Object.assign(new Error("timeout"), { status: 503 });
+      return { token: jwt };
+    });
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(2);
+    expect(cache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
+  it("stops on non-retriable error and leaves token null", async () => {
+    const auth = makeAuthMock(async () => {
+      throw new Error("forbidden");
+    });
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(cache.getObservabilityToken("a", "t")).toBeNull();
+  });
+
+  // ── Expiry / refresh behaviour ───────────────────────────────────────────
+
+  it("treats near-expiry token as expired (skew refresh)", async () => {
+    // Token that expires in 30 seconds (within the 60 s skew window)
+    const exp = Math.floor(Date.now() / 1000) + 30;
+    const jwt = makeJwtWithExp(exp);
+    const freshJwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 7200);
+    let call = 0;
+    const auth = makeAuthMock(async () => {
+      call++;
+      return { token: call === 1 ? jwt : freshJwt };
+    });
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    // Token is within skew, so getObservabilityToken returns null
+    expect(cache.getObservabilityToken("a", "t")).toBeNull();
+
+    // Refreshing again should exchange a new token
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(2);
+    expect(cache.getObservabilityToken("a", "t")).toBe(freshJwt);
+  });
+
+  it("uses fallback TTL when JWT has no exp claim", async () => {
+    const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ sub: "test" })).toString("base64url");
+    const jwt = `${header}.${payload}.sig`;
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    // Token should still be cached (acquiredOn-based TTL is 1 hour)
+    expect(cache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
+  it("caps JWT exp claim to 24 hours", async () => {
+    const farFuture = Math.floor(Date.now() / 1000) + 200_000; // ~55 hours
+    const jwt = makeJwtWithExp(farFuture);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    expect(cache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
+  // ── Invalidation ─────────────────────────────────────────────────────────
+
+  it("invalidateToken clears a single entry", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    expect(cache.getObservabilityToken("a", "t")).toBe(jwt);
+
+    cache.invalidateToken("a", "t");
+    expect(cache.getObservabilityToken("a", "t")).toBeNull();
+  });
+
+  it("invalidateAll clears every entry", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a1", "t1", makeTurnContext(), auth);
+    await cache.refreshObservabilityToken("a2", "t2", makeTurnContext(), auth);
+
+    cache.invalidateAll();
+    expect(cache.getObservabilityToken("a1", "t1")).toBeNull();
+    expect(cache.getObservabilityToken("a2", "t2")).toBeNull();
+  });
+
+  // ── Scopes handling ──────────────────────────────────────────────────────
+
+  it("updates scopes on existing entry when caller provides new scopes", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth, ["scope1"]);
+    // Invalidate and refresh with different scopes
+    cache.invalidateToken("a", "t");
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth, ["scope2"]);
+
+    const lastCall = (auth.exchangeToken as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(lastCall?.[2]).toEqual({ scopes: ["scope2"] });
+  });
+
+  it("clones caller-provided scopes to prevent external mutation", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+    const scopes = ["original"];
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth, scopes);
+    scopes[0] = "mutated";
+
+    // Invalidate and refresh — should still use original scopes
+    cache.invalidateToken("a", "t");
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    const lastCall = (auth.exchangeToken as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(lastCall?.[2]).toEqual({ scopes: ["original"] });
+  });
+
+  it("passes authHandlerName to exchangeToken when provided", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth, undefined, "custom");
+
+    expect(auth.exchangeToken).toHaveBeenCalledWith(
+      expect.anything(),
+      "custom",
+      expect.anything(),
+    );
+  });
+
+  it('defaults authHandlerName to "agentic"', async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledWith(
+      expect.anything(),
+      "agentic",
+      expect.anything(),
+    );
+  });
+
+  // ── LRU eviction ─────────────────────────────────────────────────────────
+
+  it("evicts least-recently-used entry when cache exceeds max size", async () => {
+    // Use a small cache to test eviction
+    const smallCache = new (class extends AgenticTokenCache {
+      constructor() {
+        super();
+        // Override private max via Object.defineProperty
+        Object.defineProperty(this, "_maxCacheSize", { value: 3 });
+      }
+    })();
+
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+    const ctx = makeTurnContext();
+
+    await smallCache.refreshObservabilityToken("a1", "t", ctx, auth);
+    await smallCache.refreshObservabilityToken("a2", "t", ctx, auth);
+    await smallCache.refreshObservabilityToken("a3", "t", ctx, auth);
+
+    // Access a1 to make it recently-used (move it ahead of a2)
+    smallCache.getObservabilityToken("a1", "t");
+
+    // Adding a4 should evict a2 (the least recently used)
+    await smallCache.refreshObservabilityToken("a4", "t", ctx, auth);
+
+    expect(smallCache.getObservabilityToken("a1", "t")).toBe(jwt);
+    expect(smallCache.getObservabilityToken("a2", "t")).toBeNull(); // evicted
+    expect(smallCache.getObservabilityToken("a3", "t")).toBe(jwt);
+    expect(smallCache.getObservabilityToken("a4", "t")).toBe(jwt);
+  });
+
+  // ── Per-key locking (serialisation) ──────────────────────────────────────
+
+  it("serialises concurrent refreshes for the same key", async () => {
+    let concurrency = 0;
+    let maxConcurrency = 0;
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(async () => {
+        concurrency++;
+        maxConcurrency = Math.max(maxConcurrency, concurrency);
+        // Simulate async work
+        await new Promise((r) => setTimeout(r, 50));
+        concurrency--;
+        return { token: jwt };
+      }),
+    };
+
+    // Invalidate between calls so both attempts actually exchange
+    const p1 = cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+    // Kick off a second concurrent refresh for the same key
+    cache.invalidateToken("a", "t");
+    const p2 = cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    await Promise.all([p1, p2]);
+
+    // With proper serialisation, concurrency should never exceed 1
+    expect(maxConcurrency).toBe(1);
+  });
+
+  it("allows concurrent refreshes for different keys", async () => {
+    let concurrency = 0;
+    let maxConcurrency = 0;
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(async () => {
+        concurrency++;
+        maxConcurrency = Math.max(maxConcurrency, concurrency);
+        await new Promise((r) => setTimeout(r, 50));
+        concurrency--;
+        return { token: jwt };
+      }),
+    };
+
+    const p1 = cache.refreshObservabilityToken("a1", "t", makeTurnContext(), auth);
+    const p2 = cache.refreshObservabilityToken("a2", "t", makeTurnContext(), auth);
+
+    await Promise.all([p1, p2]);
+
+    // Different keys should run concurrently
+    expect(maxConcurrency).toBe(2);
+  });
+
+  // ── Constructor / env override ───────────────────────────────────────────
+
+  it("uses custom authScopes from options", async () => {
+    const customCache = new AgenticTokenCache({ authScopes: ["custom://scope"] });
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await customCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledWith(
+      expect.anything(),
+      "agentic",
+      { scopes: ["custom://scope"] },
+    );
+  });
+
+  it("uses default scope (powerplatform) when no options provided", async () => {
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth = makeAuthMock(jwt);
+
+    await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledWith(
+      expect.anything(),
+      "agentic",
+      { scopes: ["https://api.powerplatform.com/.default"] },
+    );
+  });
+
+  // ── Static helper ────────────────────────────────────────────────────────
+
+  it("makeKey produces agent:tenant format", () => {
+    expect(AgenticTokenCache.makeKey("agent1", "tenant1")).toBe("agent1:tenant1");
+  });
+});

--- a/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
+++ b/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
@@ -209,11 +209,7 @@ describe("AgenticTokenCache", () => {
 
     await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth, undefined, "custom");
 
-    expect(auth.exchangeToken).toHaveBeenCalledWith(
-      expect.anything(),
-      "custom",
-      expect.anything(),
-    );
+    expect(auth.exchangeToken).toHaveBeenCalledWith(expect.anything(), "custom", expect.anything());
   });
 
   it('defaults authHandlerName to "agentic"', async () => {
@@ -324,11 +320,9 @@ describe("AgenticTokenCache", () => {
 
     await customCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
 
-    expect(auth.exchangeToken).toHaveBeenCalledWith(
-      expect.anything(),
-      "agentic",
-      { scopes: ["custom://scope"] },
-    );
+    expect(auth.exchangeToken).toHaveBeenCalledWith(expect.anything(), "agentic", {
+      scopes: ["custom://scope"],
+    });
   });
 
   it("uses default scope (powerplatform) when no options provided", async () => {
@@ -337,11 +331,9 @@ describe("AgenticTokenCache", () => {
 
     await cache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
 
-    expect(auth.exchangeToken).toHaveBeenCalledWith(
-      expect.anything(),
-      "agentic",
-      { scopes: ["https://api.powerplatform.com/.default"] },
-    );
+    expect(auth.exchangeToken).toHaveBeenCalledWith(expect.anything(), "agentic", {
+      scopes: ["https://api.powerplatform.com/.default"],
+    });
   });
 
   // ── Static helper ────────────────────────────────────────────────────────


### PR DESCRIPTION
Migrate AgenticTokenCache from Agent365-nodejs to provide built-in token exchange caching for A365 observability services, removing the need for each customer to implement their own token management.

- Add AgenticTokenCache class with per-key locking, retry logic, JWT exp parsing, and LRU eviction (max 10,000 entries)
- Add AgenticTokenCacheInstance default singleton
- Add AuthorizationLike interface (duck-typed, no hard dependency on @microsoft/agents-hosting)
- Export from hosting, a365, and top-level index

Fixes #58