### PR TITLE
feat: migrate PerRequestSpanProcessor from Agent365-nodejs 

### DIFF
--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -145,7 +145,42 @@ Core A365 export variables continue to work:
 | `CLUSTER_CATEGORY` | Cluster category (`prod`, `dev`, `test`, etc.) |
 | `A365_OBSERVABILITY_LOG_LEVEL` | A365 internal log filter (`none`, `info`, `warn`, `error`, pipe combinations) |
 
-## 7) Migration checklist
+## 7) PerRequestSpanProcessor migration note
+
+`PerRequestSpanProcessor` behavior is treated as a **private/internal compatibility path** and is **not part of the public migration surface**.
+
+What this means:
+
+- Do not rely on `PerRequestSpanProcessor` as a public API contract in `@microsoft/opentelemetry`.
+- Public migration guidance remains: use the standard distro setup (`useMicrosoftOpenTelemetry`) and public A365 APIs.
+- If you previously depended on per-request buffering semantics, implement your own per-request `SpanProcessor` in application code and wire it using public APIs (`Agent365Exporter` + `spanProcessors`).
+
+Example shape:
+
+```typescript
+import {
+  Agent365Exporter,
+  A365SpanProcessor,
+  useMicrosoftOpenTelemetry,
+} from "@microsoft/opentelemetry";
+
+const exporter = new Agent365Exporter({
+  tokenResolver: async (agentId, tenantId) => getToken(agentId, tenantId),
+  clusterCategory: "prod",
+});
+
+useMicrosoftOpenTelemetry({
+  // Provide your own processor pipeline.
+  spanProcessors: [
+    new A365SpanProcessor(),
+    new MyPerRequestSpanProcessor(exporter),
+  ],
+});
+```
+
+`MyPerRequestSpanProcessor` is your app-owned implementation of request-buffered flush behavior.
+
+## 8) Migration checklist
 
 - [ ] Replace `@microsoft/agents-a365-observability` with `@microsoft/opentelemetry`
 - [ ] If used, replace `@microsoft/agents-a365-observability-hosting` imports with `@microsoft/opentelemetry`
@@ -153,5 +188,6 @@ Core A365 export variables continue to work:
 - [ ] Rename `Request` to `A365Request`
 - [ ] Rename `SpanDetails` to `A365SpanDetails`
 - [ ] Rename A365 `SpanProcessor` usage to `A365SpanProcessor`
+- [ ] If you previously depended on `PerRequestSpanProcessor`, move that behavior into an app-owned custom `SpanProcessor` wired via `spanProcessors`
 - [ ] Migrate middleware setup to `configureA365Hosting(adapter, ...)` (or `ObservabilityHostingManager`)
 - [ ] Set new diagnostics logging variables for rollout validation (`OTEL_LOG_LEVEL`; optionally `AZURE_LOG_LEVEL`)

--- a/src/a365/configuration/A365Configuration.ts
+++ b/src/a365/configuration/A365Configuration.ts
@@ -8,15 +8,6 @@ import type {
 } from "./A365ConfigurationOptions.js";
 import { getA365Logger } from "../logging.js";
 
-type InternalPerRequestOptions = {
-  enabled: boolean;
-  maxTraces: number;
-  maxSpansPerTrace: number;
-  maxConcurrentExports: number;
-  flushGraceMs: number;
-  maxTraceAgeMs: number;
-};
-
 /**
  * Parse an environment variable as a boolean.
  * Recognizes 'true', '1', 'yes', 'on' (case-insensitive) as true and
@@ -37,37 +28,19 @@ function parseEnvBoolean(envValue: string | undefined): boolean | undefined {
   return undefined;
 }
 
-function parsePositiveInt(envValue: string | undefined): number | undefined {
-  if (!envValue) return undefined;
-  const parsed = Number.parseInt(envValue, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-  return parsed;
-}
-
 /**
  * Environment variable names for A365 configuration.
  * These match the upstream Agent365-nodejs conventions.
  */
 export const A365_ENV_VARS = {
   EXPORTER_ENABLED: "ENABLE_A365_OBSERVABILITY_EXPORTER",
-  PER_REQUEST_EXPORT_ENABLED: "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
   AUTH_SCOPES: "A365_OBSERVABILITY_SCOPES_OVERRIDE",
   DOMAIN: "A365_OBSERVABILITY_DOMAIN_OVERRIDE",
   CLUSTER_CATEGORY: "CLUSTER_CATEGORY",
   LOG_LEVEL: "A365_OBSERVABILITY_LOG_LEVEL",
-  PER_REQUEST_MAX_TRACES: "A365_PER_REQUEST_MAX_TRACES",
-  PER_REQUEST_MAX_SPANS_PER_TRACE: "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
-  PER_REQUEST_MAX_CONCURRENT_EXPORTS: "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
-  PER_REQUEST_FLUSH_GRACE_MS: "A365_PER_REQUEST_FLUSH_GRACE_MS",
-  PER_REQUEST_MAX_TRACE_AGE_MS: "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
 } as const;
 
 const DEFAULT_AUTH_SCOPE = "https://api.powerplatform.com/.default";
-const DEFAULT_PER_REQUEST_MAX_TRACES = 1000;
-const DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE = 5000;
-const DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS = 20;
-const DEFAULT_PER_REQUEST_FLUSH_GRACE_MS = 250;
-const DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS = 30 * 60 * 1000;
 
 const VALID_CLUSTER_CATEGORIES: ReadonlySet<string> = new Set([
   "local",
@@ -122,21 +95,12 @@ export class A365Configuration {
     enableOutputLogging: boolean;
   };
 
-  /** Internal per-request export options. */
-  private readonly _perRequest: InternalPerRequestOptions;
-
   constructor(options?: A365Options) {
     // 1. Set defaults
     let enabled = false;
     let clusterCategory: ClusterCategory = "prod";
     let domainOverride: string | undefined = options?.domainOverride;
     let authScopes: string[] = options?.authScopes ?? [DEFAULT_AUTH_SCOPE];
-    let perRequestEnabled = false;
-    let perRequestMaxTraces = DEFAULT_PER_REQUEST_MAX_TRACES;
-    let perRequestMaxSpansPerTrace = DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE;
-    let perRequestMaxConcurrentExports = DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS;
-    let perRequestFlushGraceMs = DEFAULT_PER_REQUEST_FLUSH_GRACE_MS;
-    let perRequestMaxTraceAgeMs = DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS;
 
     // 2. Apply programmatic options
     if (options) {
@@ -148,13 +112,6 @@ export class A365Configuration {
     const envEnabled = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
     if (envEnabled !== undefined) {
       enabled = envEnabled;
-    }
-
-    const envPerRequestEnabled = parseEnvBoolean(
-      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED],
-    );
-    if (envPerRequestEnabled !== undefined) {
-      perRequestEnabled = envPerRequestEnabled;
     }
 
     const envScopes = process.env[A365_ENV_VARS.AUTH_SCOPES]?.trim();
@@ -176,21 +133,6 @@ export class A365Configuration {
       );
     }
 
-    perRequestMaxTraces =
-      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES]) ?? perRequestMaxTraces;
-    perRequestMaxSpansPerTrace =
-      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE]) ??
-      perRequestMaxSpansPerTrace;
-    perRequestMaxConcurrentExports =
-      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS]) ??
-      perRequestMaxConcurrentExports;
-    perRequestFlushGraceMs =
-      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS]) ??
-      perRequestFlushGraceMs;
-    perRequestMaxTraceAgeMs =
-      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS]) ??
-      perRequestMaxTraceAgeMs;
-
     // Assign resolved values
     this.enabled = enabled;
     this.tokenResolver = options?.tokenResolver;
@@ -207,15 +149,6 @@ export class A365Configuration {
       enabled: options?.hosting?.enabled ?? false,
       adapter: options?.hosting?.adapter,
       enableOutputLogging: options?.hosting?.enableOutputLogging ?? true,
-    };
-
-    this._perRequest = {
-      enabled: perRequestEnabled,
-      maxTraces: perRequestMaxTraces,
-      maxSpansPerTrace: perRequestMaxSpansPerTrace,
-      maxConcurrentExports: perRequestMaxConcurrentExports,
-      flushGraceMs: perRequestFlushGraceMs,
-      maxTraceAgeMs: perRequestMaxTraceAgeMs,
     };
 
     // Warn when A365-scoped options are set but A365 is not enabled
@@ -238,15 +171,5 @@ export class A365Configuration {
           "Set `a365.enabled: true` or `ENABLE_A365_OBSERVABILITY_EXPORTER=true` to enable.",
       );
     }
-  }
-
-  /** @internal Internal-only toggle for partner-specific per-request export behavior. */
-  public isPerRequestExportEnabled(): boolean {
-    return this._perRequest.enabled;
-  }
-
-  /** @internal Internal-only per-request processor guardrails. */
-  public getPerRequestOptions(): InternalPerRequestOptions {
-    return this._perRequest;
   }
 }

--- a/src/a365/configuration/A365Configuration.ts
+++ b/src/a365/configuration/A365Configuration.ts
@@ -8,6 +8,15 @@ import type {
 } from "./A365ConfigurationOptions.js";
 import { getA365Logger } from "../logging.js";
 
+type InternalPerRequestOptions = {
+  enabled: boolean;
+  maxTraces: number;
+  maxSpansPerTrace: number;
+  maxConcurrentExports: number;
+  flushGraceMs: number;
+  maxTraceAgeMs: number;
+};
+
 /**
  * Parse an environment variable as a boolean.
  * Recognizes 'true', '1', 'yes', 'on' (case-insensitive) as true and
@@ -28,19 +37,37 @@ function parseEnvBoolean(envValue: string | undefined): boolean | undefined {
   return undefined;
 }
 
+function parsePositiveInt(envValue: string | undefined): number | undefined {
+  if (!envValue) return undefined;
+  const parsed = Number.parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
 /**
  * Environment variable names for A365 configuration.
  * These match the upstream Agent365-nodejs conventions.
  */
 export const A365_ENV_VARS = {
   EXPORTER_ENABLED: "ENABLE_A365_OBSERVABILITY_EXPORTER",
+  PER_REQUEST_EXPORT_ENABLED: "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
   AUTH_SCOPES: "A365_OBSERVABILITY_SCOPES_OVERRIDE",
   DOMAIN: "A365_OBSERVABILITY_DOMAIN_OVERRIDE",
   CLUSTER_CATEGORY: "CLUSTER_CATEGORY",
   LOG_LEVEL: "A365_OBSERVABILITY_LOG_LEVEL",
+  PER_REQUEST_MAX_TRACES: "A365_PER_REQUEST_MAX_TRACES",
+  PER_REQUEST_MAX_SPANS_PER_TRACE: "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
+  PER_REQUEST_MAX_CONCURRENT_EXPORTS: "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
+  PER_REQUEST_FLUSH_GRACE_MS: "A365_PER_REQUEST_FLUSH_GRACE_MS",
+  PER_REQUEST_MAX_TRACE_AGE_MS: "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
 } as const;
 
 const DEFAULT_AUTH_SCOPE = "https://api.powerplatform.com/.default";
+const DEFAULT_PER_REQUEST_MAX_TRACES = 1000;
+const DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE = 5000;
+const DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS = 20;
+const DEFAULT_PER_REQUEST_FLUSH_GRACE_MS = 250;
+const DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS = 30 * 60 * 1000;
 
 const VALID_CLUSTER_CATEGORIES: ReadonlySet<string> = new Set([
   "local",
@@ -95,12 +122,21 @@ export class A365Configuration {
     enableOutputLogging: boolean;
   };
 
+  /** Internal per-request export options. */
+  private readonly _perRequest: InternalPerRequestOptions;
+
   constructor(options?: A365Options) {
     // 1. Set defaults
     let enabled = false;
     let clusterCategory: ClusterCategory = "prod";
     let domainOverride: string | undefined = options?.domainOverride;
     let authScopes: string[] = options?.authScopes ?? [DEFAULT_AUTH_SCOPE];
+    let perRequestEnabled = false;
+    let perRequestMaxTraces = DEFAULT_PER_REQUEST_MAX_TRACES;
+    let perRequestMaxSpansPerTrace = DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE;
+    let perRequestMaxConcurrentExports = DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS;
+    let perRequestFlushGraceMs = DEFAULT_PER_REQUEST_FLUSH_GRACE_MS;
+    let perRequestMaxTraceAgeMs = DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS;
 
     // 2. Apply programmatic options
     if (options) {
@@ -112,6 +148,13 @@ export class A365Configuration {
     const envEnabled = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
     if (envEnabled !== undefined) {
       enabled = envEnabled;
+    }
+
+    const envPerRequestEnabled = parseEnvBoolean(
+      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED],
+    );
+    if (envPerRequestEnabled !== undefined) {
+      perRequestEnabled = envPerRequestEnabled;
     }
 
     const envScopes = process.env[A365_ENV_VARS.AUTH_SCOPES]?.trim();
@@ -133,6 +176,21 @@ export class A365Configuration {
       );
     }
 
+    perRequestMaxTraces =
+      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES]) ?? perRequestMaxTraces;
+    perRequestMaxSpansPerTrace =
+      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE]) ??
+      perRequestMaxSpansPerTrace;
+    perRequestMaxConcurrentExports =
+      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS]) ??
+      perRequestMaxConcurrentExports;
+    perRequestFlushGraceMs =
+      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS]) ??
+      perRequestFlushGraceMs;
+    perRequestMaxTraceAgeMs =
+      parsePositiveInt(process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS]) ??
+      perRequestMaxTraceAgeMs;
+
     // Assign resolved values
     this.enabled = enabled;
     this.tokenResolver = options?.tokenResolver;
@@ -149,6 +207,15 @@ export class A365Configuration {
       enabled: options?.hosting?.enabled ?? false,
       adapter: options?.hosting?.adapter,
       enableOutputLogging: options?.hosting?.enableOutputLogging ?? true,
+    };
+
+    this._perRequest = {
+      enabled: perRequestEnabled,
+      maxTraces: perRequestMaxTraces,
+      maxSpansPerTrace: perRequestMaxSpansPerTrace,
+      maxConcurrentExports: perRequestMaxConcurrentExports,
+      flushGraceMs: perRequestFlushGraceMs,
+      maxTraceAgeMs: perRequestMaxTraceAgeMs,
     };
 
     // Warn when A365-scoped options are set but A365 is not enabled
@@ -171,5 +238,15 @@ export class A365Configuration {
           "Set `a365.enabled: true` or `ENABLE_A365_OBSERVABILITY_EXPORTER=true` to enable.",
       );
     }
+  }
+
+  /** @internal Internal-only toggle for partner-specific per-request export behavior. */
+  public isPerRequestExportEnabled(): boolean {
+    return this._perRequest.enabled;
+  }
+
+  /** @internal Internal-only per-request processor guardrails. */
+  public getPerRequestOptions(): InternalPerRequestOptions {
+    return this._perRequest;
   }
 }

--- a/src/a365/configuration/internalPerRequest.ts
+++ b/src/a365/configuration/internalPerRequest.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type InternalPerRequestOptions = {
+  enabled: boolean;
+  maxTraces: number;
+  maxSpansPerTrace: number;
+  maxConcurrentExports: number;
+  flushGraceMs: number;
+  maxTraceAgeMs: number;
+};
+
+export const INTERNAL_A365_ENV_VARS = {
+  PER_REQUEST_EXPORT_ENABLED: "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
+  PER_REQUEST_MAX_TRACES: "A365_PER_REQUEST_MAX_TRACES",
+  PER_REQUEST_MAX_SPANS_PER_TRACE: "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
+  PER_REQUEST_MAX_CONCURRENT_EXPORTS: "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
+  PER_REQUEST_FLUSH_GRACE_MS: "A365_PER_REQUEST_FLUSH_GRACE_MS",
+  PER_REQUEST_MAX_TRACE_AGE_MS: "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
+} as const;
+
+const DEFAULT_PER_REQUEST_MAX_TRACES = 1000;
+const DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE = 5000;
+const DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS = 20;
+const DEFAULT_PER_REQUEST_FLUSH_GRACE_MS = 250;
+const DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS = 30 * 60 * 1000;
+
+function parseEnvBoolean(envValue: string | undefined): boolean | undefined {
+  if (!envValue) return undefined;
+  const normalized = envValue.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parsePositiveInt(envValue: string | undefined): number | undefined {
+  if (!envValue) return undefined;
+  const parsed = Number.parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+export function resolveInternalPerRequestOptions(): InternalPerRequestOptions {
+  return {
+    enabled:
+      parseEnvBoolean(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED]) ?? false,
+    maxTraces:
+      parsePositiveInt(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACES]) ??
+      DEFAULT_PER_REQUEST_MAX_TRACES,
+    maxSpansPerTrace:
+      parsePositiveInt(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE]) ??
+      DEFAULT_PER_REQUEST_MAX_SPANS_PER_TRACE,
+    maxConcurrentExports:
+      parsePositiveInt(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS]) ??
+      DEFAULT_PER_REQUEST_MAX_CONCURRENT_EXPORTS,
+    flushGraceMs:
+      parsePositiveInt(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS]) ??
+      DEFAULT_PER_REQUEST_FLUSH_GRACE_MS,
+    maxTraceAgeMs:
+      parsePositiveInt(process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS]) ??
+      DEFAULT_PER_REQUEST_MAX_TRACE_AGE_MS,
+  };
+}

--- a/src/a365/exporter/Agent365Exporter.ts
+++ b/src/a365/exporter/Agent365Exporter.ts
@@ -18,6 +18,7 @@ import {
   truncateSpan,
 } from "./utils.js";
 import { getA365Logger } from "../logging.js";
+import { getExportToken } from "../context/tokenContext.js";
 
 const DEFAULT_MAX_RETRIES = 3;
 
@@ -158,9 +159,15 @@ export class Agent365Exporter implements SpanExporter {
   }
 
   private async resolveToken(agentId: string, tenantId: string): Promise<string | null> {
-    if (!this.options.tokenResolver) return null;
-    const result = this.options.tokenResolver(agentId, tenantId, this.options.authScopes);
-    return result instanceof Promise ? result : result;
+    if (this.options.tokenResolver) {
+      const result = this.options.tokenResolver(agentId, tenantId, this.options.authScopes);
+      const resolved = result instanceof Promise ? await result : result;
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return getExportToken() ?? null;
   }
 
   private async postWithRetries(

--- a/src/a365/processors/PerRequestSpanProcessor.ts
+++ b/src/a365/processors/PerRequestSpanProcessor.ts
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { context, trace, type Context, type Span } from "@opentelemetry/api";
+import type { ReadableSpan, SpanProcessor, SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import { getA365Logger } from "../logging.js";
+
+type TraceBuffer = {
+  spans: ReadableSpan[];
+  openCount: number;
+  rootEnded: boolean;
+  rootCtx?: Context;
+  startedAtMs: number;
+  rootEndedAtMs?: number;
+  droppedSpans: number;
+};
+
+type FlushReason = "trace_completed" | "root_ended_grace" | "max_trace_age" | "force_flush";
+
+export interface PerRequestSpanProcessorOptions {
+  maxBufferedTraces?: number;
+  maxSpansPerTrace?: number;
+  maxConcurrentExports?: number;
+  flushGraceMs?: number;
+  maxTraceAgeMs?: number;
+}
+
+const DEFAULT_MAX_BUFFERED_TRACES = 1000;
+const DEFAULT_MAX_SPANS_PER_TRACE = 5000;
+const DEFAULT_MAX_CONCURRENT_EXPORTS = 20;
+const DEFAULT_FLUSH_GRACE_MS = 250;
+const DEFAULT_MAX_TRACE_AGE_MS = 30 * 60 * 1000;
+
+function isRootSpan(span: ReadableSpan): boolean {
+  return !span.parentSpanContext;
+}
+
+function isRootSpanFromContext(ctx: Context): boolean {
+  const parentSpan = trace.getSpan(ctx);
+  return !parentSpan;
+}
+
+/**
+ * Buffers spans per trace and exports once the request completes.
+ */
+export class PerRequestSpanProcessor implements SpanProcessor {
+  private traces = new Map<string, TraceBuffer>();
+  private sweepTimer?: NodeJS.Timeout;
+  private isSweeping = false;
+
+  private readonly maxBufferedTraces: number;
+  private readonly maxSpansPerTrace: number;
+  private readonly maxConcurrentExports: number;
+  private readonly flushGraceMs: number;
+  private readonly maxTraceAgeMs: number;
+
+  private inFlightExports = 0;
+  private exportWaiters: Array<() => void> = [];
+  private readonly logger = getA365Logger();
+
+  constructor(
+    private readonly exporter: SpanExporter,
+    options?: PerRequestSpanProcessorOptions,
+  ) {
+    this.maxBufferedTraces = options?.maxBufferedTraces ?? DEFAULT_MAX_BUFFERED_TRACES;
+    this.maxSpansPerTrace = options?.maxSpansPerTrace ?? DEFAULT_MAX_SPANS_PER_TRACE;
+    this.maxConcurrentExports = options?.maxConcurrentExports ?? DEFAULT_MAX_CONCURRENT_EXPORTS;
+    this.flushGraceMs = options?.flushGraceMs ?? DEFAULT_FLUSH_GRACE_MS;
+    this.maxTraceAgeMs = options?.maxTraceAgeMs ?? DEFAULT_MAX_TRACE_AGE_MS;
+  }
+
+  onStart(span: Span, ctx: Context): void {
+    const traceId = span.spanContext().traceId;
+    let buf = this.traces.get(traceId);
+    if (!buf) {
+      if (this.traces.size >= this.maxBufferedTraces) {
+        this.logger.warn(
+          `[PerRequestSpanProcessor] Dropping new trace due to maxBufferedTraces=${this.maxBufferedTraces} traceId=${traceId}`,
+        );
+        return;
+      }
+
+      buf = {
+        spans: [],
+        openCount: 0,
+        rootEnded: false,
+        rootCtx: undefined,
+        startedAtMs: Date.now(),
+        droppedSpans: 0,
+      };
+      this.traces.set(traceId, buf);
+      this.ensureSweepTimer();
+    }
+
+    buf.openCount += 1;
+
+    if (isRootSpanFromContext(ctx)) {
+      buf.rootCtx = ctx;
+    } else {
+      buf.rootCtx ??= ctx;
+    }
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const traceId = span.spanContext().traceId;
+    const buf = this.traces.get(traceId);
+    if (!buf) return;
+
+    if (buf.spans.length >= this.maxSpansPerTrace) {
+      buf.droppedSpans += 1;
+    } else {
+      buf.spans.push(span);
+    }
+
+    buf.openCount -= 1;
+    if (buf.openCount < 0) {
+      buf.openCount = 0;
+    }
+
+    if (isRootSpan(span)) {
+      buf.rootEnded = true;
+      buf.rootEndedAtMs = Date.now();
+      if (buf.openCount === 0) {
+        void this.flushTrace(traceId, "trace_completed");
+      }
+    } else if (buf.rootEnded && buf.openCount === 0) {
+      void this.flushTrace(traceId, "trace_completed");
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all([...this.traces.keys()].map((id) => this.flushTrace(id, "force_flush")));
+  }
+
+  async shutdown(): Promise<void> {
+    await this.forceFlush();
+    this.stopSweepTimerIfIdle();
+    await this.exporter.shutdown?.();
+  }
+
+  private ensureSweepTimer(): void {
+    if (this.sweepTimer) return;
+
+    const intervalMs = Math.max(10, Math.min(this.flushGraceMs, 250));
+    this.sweepTimer = setInterval(() => {
+      void this.sweep();
+    }, intervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  private stopSweepTimerIfIdle(): void {
+    if (this.traces.size !== 0 || !this.sweepTimer) return;
+    clearInterval(this.sweepTimer);
+    this.sweepTimer = undefined;
+  }
+
+  private async sweep(): Promise<void> {
+    if (this.isSweeping) return;
+    this.isSweeping = true;
+    try {
+      if (this.traces.size === 0) {
+        this.stopSweepTimerIfIdle();
+        return;
+      }
+
+      const now = Date.now();
+      const toFlush: Array<{ traceId: string; reason: FlushReason }> = [];
+
+      for (const [traceId, traceBuffer] of this.traces.entries()) {
+        if (now - traceBuffer.startedAtMs >= this.maxTraceAgeMs) {
+          toFlush.push({ traceId, reason: "max_trace_age" });
+          continue;
+        }
+
+        if (
+          traceBuffer.rootEnded &&
+          traceBuffer.openCount > 0 &&
+          traceBuffer.rootEndedAtMs &&
+          now - traceBuffer.rootEndedAtMs >= this.flushGraceMs
+        ) {
+          toFlush.push({ traceId, reason: "root_ended_grace" });
+        }
+      }
+
+      await Promise.all(toFlush.map((item) => this.flushTrace(item.traceId, item.reason)));
+      this.stopSweepTimerIfIdle();
+    } finally {
+      this.isSweeping = false;
+    }
+  }
+
+  private async flushTrace(traceId: string, reason: FlushReason): Promise<void> {
+    const traceBuffer = this.traces.get(traceId);
+    if (!traceBuffer) return;
+
+    this.traces.delete(traceId);
+    this.stopSweepTimerIfIdle();
+
+    const spans = traceBuffer.spans;
+    if (spans.length === 0 || !traceBuffer.rootCtx) {
+      return;
+    }
+
+    await this.acquireExportSlot();
+    try {
+      await new Promise<void>((resolve) => {
+        context.with(traceBuffer.rootCtx as Context, () => {
+          try {
+            this.exporter.export(spans, (result) => {
+              if (result.code !== 0) {
+                this.logger.error(
+                  `[PerRequestSpanProcessor] Export failed traceId=${traceId} reason=${reason} code=${result.code}`,
+                  result.error,
+                );
+              }
+              resolve();
+            });
+          } catch (err) {
+            this.logger.error(
+              `[PerRequestSpanProcessor] Export threw traceId=${traceId} reason=${reason}`,
+              err,
+            );
+            resolve();
+          }
+        });
+      });
+    } finally {
+      this.releaseExportSlot();
+    }
+  }
+
+  private async acquireExportSlot(): Promise<void> {
+    if (this.maxConcurrentExports <= 0) return;
+    if (this.inFlightExports < this.maxConcurrentExports) {
+      this.inFlightExports += 1;
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.exportWaiters.push(() => {
+        this.inFlightExports += 1;
+        resolve();
+      });
+    });
+  }
+
+  private releaseExportSlot(): void {
+    if (this.maxConcurrentExports <= 0) return;
+    this.inFlightExports = Math.max(0, this.inFlightExports - 1);
+    const next = this.exportWaiters.shift();
+    if (next) next();
+  }
+}

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -30,6 +30,7 @@ import {
 } from "../azureMonitor/index.js";
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
 import { A365Configuration, Agent365Exporter, A365SpanProcessor } from "../a365/index.js";
+import { resolveInternalPerRequestOptions } from "../a365/configuration/internalPerRequest.js";
 import { PerRequestSpanProcessor } from "../a365/processors/PerRequestSpanProcessor.js";
 import type {
   MicrosoftOpenTelemetryOptions,
@@ -152,12 +153,12 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
       authScopes: a365Config.authScopes,
       tokenResolver: a365Config.tokenResolver,
     });
+    const perRequestOptions = resolveInternalPerRequestOptions();
     // A365SpanProcessor copies baggage (tenant, agent, session, etc.) to span attributes
     if (a365Config.baggage.enrichSpans) {
       spanProcessors.push(new A365SpanProcessor());
     }
-    if (a365Config.isPerRequestExportEnabled()) {
-      const perRequestOptions = a365Config.getPerRequestOptions();
+    if (perRequestOptions.enabled) {
       spanProcessors.push(
         new PerRequestSpanProcessor(a365Exporter, {
           maxBufferedTraces: perRequestOptions.maxTraces,

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -29,11 +29,7 @@ import {
   validateAzureMonitorConfig,
 } from "../azureMonitor/index.js";
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
-import {
-  A365Configuration,
-  Agent365Exporter,
-  A365SpanProcessor,
-} from "../a365/index.js";
+import { A365Configuration, Agent365Exporter, A365SpanProcessor } from "../a365/index.js";
 import { PerRequestSpanProcessor } from "../a365/processors/PerRequestSpanProcessor.js";
 import type {
   MicrosoftOpenTelemetryOptions,

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -29,7 +29,12 @@ import {
   validateAzureMonitorConfig,
 } from "../azureMonitor/index.js";
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
-import { A365Configuration, Agent365Exporter, A365SpanProcessor } from "../a365/index.js";
+import {
+  A365Configuration,
+  Agent365Exporter,
+  A365SpanProcessor,
+} from "../a365/index.js";
+import { PerRequestSpanProcessor } from "../a365/processors/PerRequestSpanProcessor.js";
 import type {
   MicrosoftOpenTelemetryOptions,
   InstrumentationOptions,
@@ -155,7 +160,20 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     if (a365Config.baggage.enrichSpans) {
       spanProcessors.push(new A365SpanProcessor());
     }
-    spanProcessors.push(new BatchSpanProcessor(a365Exporter));
+    if (a365Config.isPerRequestExportEnabled()) {
+      const perRequestOptions = a365Config.getPerRequestOptions();
+      spanProcessors.push(
+        new PerRequestSpanProcessor(a365Exporter, {
+          maxBufferedTraces: perRequestOptions.maxTraces,
+          maxSpansPerTrace: perRequestOptions.maxSpansPerTrace,
+          maxConcurrentExports: perRequestOptions.maxConcurrentExports,
+          flushGraceMs: perRequestOptions.flushGraceMs,
+          maxTraceAgeMs: perRequestOptions.maxTraceAgeMs,
+        }),
+      );
+    } else {
+      spanProcessors.push(new BatchSpanProcessor(a365Exporter));
+    }
   } else if (a365ConsoleExportFallback) {
     // A365 options provided but exporter disabled — fall back to console export
     // so developers can validate spans locally (matches upstream A365 SDK behavior

--- a/test/internal/unit/a365/a365Configuration.test.ts
+++ b/test/internal/unit/a365/a365Configuration.test.ts
@@ -6,6 +6,10 @@ import {
   A365Configuration,
   A365_ENV_VARS,
 } from "../../../../src/a365/configuration/A365Configuration.js";
+import {
+  INTERNAL_A365_ENV_VARS,
+  resolveInternalPerRequestOptions,
+} from "../../../../src/a365/configuration/internalPerRequest.js";
 import { _resetA365LoggerForTest } from "../../../../src/a365/logging.js";
 
 describe("A365Configuration", () => {
@@ -191,52 +195,60 @@ describe("A365Configuration", () => {
       assert.strictEqual(A365_ENV_VARS.LOG_LEVEL, "A365_OBSERVABILITY_LOG_LEVEL");
     });
 
-    it("should have correct per-request env var names", () => {
-      assert.strictEqual(
-        A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED,
-        "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
-      );
-      assert.strictEqual(A365_ENV_VARS.PER_REQUEST_MAX_TRACES, "A365_PER_REQUEST_MAX_TRACES");
-      assert.strictEqual(
-        A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE,
-        "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
-      );
-      assert.strictEqual(
-        A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS,
-        "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
-      );
-      assert.strictEqual(
-        A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS,
-        "A365_PER_REQUEST_FLUSH_GRACE_MS",
-      );
-      assert.strictEqual(
-        A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS,
-        "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
-      );
+    it("should not expose internal per-request env var names", () => {
+      assert.ok(!("PER_REQUEST_EXPORT_ENABLED" in A365_ENV_VARS));
+      assert.ok(!("PER_REQUEST_MAX_TRACES" in A365_ENV_VARS));
+      assert.ok(!("PER_REQUEST_MAX_SPANS_PER_TRACE" in A365_ENV_VARS));
+      assert.ok(!("PER_REQUEST_MAX_CONCURRENT_EXPORTS" in A365_ENV_VARS));
+      assert.ok(!("PER_REQUEST_FLUSH_GRACE_MS" in A365_ENV_VARS));
+      assert.ok(!("PER_REQUEST_MAX_TRACE_AGE_MS" in A365_ENV_VARS));
     });
   });
 
-  describe("per-request export configuration (internal)", () => {
+  describe("per-request export configuration (internal helper)", () => {
+    it("should have correct per-request env var names", () => {
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED,
+        "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
+      );
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACES,
+        "A365_PER_REQUEST_MAX_TRACES",
+      );
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE,
+        "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
+      );
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS,
+        "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
+      );
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS,
+        "A365_PER_REQUEST_FLUSH_GRACE_MS",
+      );
+      assert.strictEqual(
+        INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS,
+        "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
+      );
+    });
+
     it("should default to per-request export disabled", () => {
-      const config = new A365Configuration();
-      assert.strictEqual(config.isPerRequestExportEnabled(), false);
+      assert.strictEqual(resolveInternalPerRequestOptions().enabled, false);
     });
 
     it("should enable per-request export via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "true";
-      const config = new A365Configuration();
-      assert.strictEqual(config.isPerRequestExportEnabled(), true);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "true";
+      assert.strictEqual(resolveInternalPerRequestOptions().enabled, true);
     });
 
     it("should disable per-request export via env var false", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "false";
-      const config = new A365Configuration();
-      assert.strictEqual(config.isPerRequestExportEnabled(), false);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "false";
+      assert.strictEqual(resolveInternalPerRequestOptions().enabled, false);
     });
 
     it("should have correct per-request default guard-rail values", () => {
-      const config = new A365Configuration();
-      const opts = config.getPerRequestOptions();
+      const opts = resolveInternalPerRequestOptions();
       assert.strictEqual(opts.maxTraces, 1000);
       assert.strictEqual(opts.maxSpansPerTrace, 5000);
       assert.strictEqual(opts.maxConcurrentExports, 20);
@@ -245,42 +257,37 @@ describe("A365Configuration", () => {
     });
 
     it("should override per-request max traces via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "42";
-      const config = new A365Configuration();
-      assert.strictEqual(config.getPerRequestOptions().maxTraces, 42);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "42";
+      assert.strictEqual(resolveInternalPerRequestOptions().maxTraces, 42);
     });
 
     it("should override per-request max spans per trace via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "100";
-      const config = new A365Configuration();
-      assert.strictEqual(config.getPerRequestOptions().maxSpansPerTrace, 100);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "100";
+      assert.strictEqual(resolveInternalPerRequestOptions().maxSpansPerTrace, 100);
     });
 
     it("should override per-request max concurrent exports via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS] = "5";
-      const config = new A365Configuration();
-      assert.strictEqual(config.getPerRequestOptions().maxConcurrentExports, 5);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS] = "5";
+      assert.strictEqual(resolveInternalPerRequestOptions().maxConcurrentExports, 5);
     });
 
     it("should override per-request flush grace ms via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS] = "750";
-      const config = new A365Configuration();
-      assert.strictEqual(config.getPerRequestOptions().flushGraceMs, 750);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS] = "750";
+      assert.strictEqual(resolveInternalPerRequestOptions().flushGraceMs, 750);
     });
 
     it("should override per-request max trace age ms via env var", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS] = "60000";
-      const config = new A365Configuration();
-      assert.strictEqual(config.getPerRequestOptions().maxTraceAgeMs, 60000);
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS] = "60000";
+      assert.strictEqual(resolveInternalPerRequestOptions().maxTraceAgeMs, 60000);
     });
 
     it("should ignore zero or negative per-request numeric env vars", () => {
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "0";
-      process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "-1";
-      const config = new A365Configuration();
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "0";
+      process.env[INTERNAL_A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "-1";
+      const opts = resolveInternalPerRequestOptions();
       // Invalid values ignored — defaults preserved
-      assert.strictEqual(config.getPerRequestOptions().maxTraces, 1000);
-      assert.strictEqual(config.getPerRequestOptions().maxSpansPerTrace, 5000);
+      assert.strictEqual(opts.maxTraces, 1000);
+      assert.strictEqual(opts.maxSpansPerTrace, 5000);
     });
   });
 });

--- a/test/internal/unit/a365/a365Configuration.test.ts
+++ b/test/internal/unit/a365/a365Configuration.test.ts
@@ -190,5 +190,97 @@ describe("A365Configuration", () => {
       assert.strictEqual(A365_ENV_VARS.CLUSTER_CATEGORY, "CLUSTER_CATEGORY");
       assert.strictEqual(A365_ENV_VARS.LOG_LEVEL, "A365_OBSERVABILITY_LOG_LEVEL");
     });
+
+    it("should have correct per-request env var names", () => {
+      assert.strictEqual(
+        A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED,
+        "ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT",
+      );
+      assert.strictEqual(A365_ENV_VARS.PER_REQUEST_MAX_TRACES, "A365_PER_REQUEST_MAX_TRACES");
+      assert.strictEqual(
+        A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE,
+        "A365_PER_REQUEST_MAX_SPANS_PER_TRACE",
+      );
+      assert.strictEqual(
+        A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS,
+        "A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS",
+      );
+      assert.strictEqual(
+        A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS,
+        "A365_PER_REQUEST_FLUSH_GRACE_MS",
+      );
+      assert.strictEqual(
+        A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS,
+        "A365_PER_REQUEST_MAX_TRACE_AGE_MS",
+      );
+    });
+  });
+
+  describe("per-request export configuration (internal)", () => {
+    it("should default to per-request export disabled", () => {
+      const config = new A365Configuration();
+      assert.strictEqual(config.isPerRequestExportEnabled(), false);
+    });
+
+    it("should enable per-request export via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "true";
+      const config = new A365Configuration();
+      assert.strictEqual(config.isPerRequestExportEnabled(), true);
+    });
+
+    it("should disable per-request export via env var false", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_EXPORT_ENABLED] = "false";
+      const config = new A365Configuration();
+      assert.strictEqual(config.isPerRequestExportEnabled(), false);
+    });
+
+    it("should have correct per-request default guard-rail values", () => {
+      const config = new A365Configuration();
+      const opts = config.getPerRequestOptions();
+      assert.strictEqual(opts.maxTraces, 1000);
+      assert.strictEqual(opts.maxSpansPerTrace, 5000);
+      assert.strictEqual(opts.maxConcurrentExports, 20);
+      assert.strictEqual(opts.flushGraceMs, 250);
+      assert.strictEqual(opts.maxTraceAgeMs, 30 * 60 * 1000);
+    });
+
+    it("should override per-request max traces via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "42";
+      const config = new A365Configuration();
+      assert.strictEqual(config.getPerRequestOptions().maxTraces, 42);
+    });
+
+    it("should override per-request max spans per trace via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "100";
+      const config = new A365Configuration();
+      assert.strictEqual(config.getPerRequestOptions().maxSpansPerTrace, 100);
+    });
+
+    it("should override per-request max concurrent exports via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_CONCURRENT_EXPORTS] = "5";
+      const config = new A365Configuration();
+      assert.strictEqual(config.getPerRequestOptions().maxConcurrentExports, 5);
+    });
+
+    it("should override per-request flush grace ms via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_FLUSH_GRACE_MS] = "750";
+      const config = new A365Configuration();
+      assert.strictEqual(config.getPerRequestOptions().flushGraceMs, 750);
+    });
+
+    it("should override per-request max trace age ms via env var", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACE_AGE_MS] = "60000";
+      const config = new A365Configuration();
+      assert.strictEqual(config.getPerRequestOptions().maxTraceAgeMs, 60000);
+    });
+
+    it("should ignore zero or negative per-request numeric env vars", () => {
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_TRACES] = "0";
+      process.env[A365_ENV_VARS.PER_REQUEST_MAX_SPANS_PER_TRACE] = "-1";
+      const config = new A365Configuration();
+      // Invalid values ignored — defaults preserved
+      assert.strictEqual(config.getPerRequestOptions().maxTraces, 1000);
+      assert.strictEqual(config.getPerRequestOptions().maxSpansPerTrace, 5000);
+    });
   });
 });

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -714,9 +714,7 @@ describe("Agent365Exporter", () => {
 
     it("falls back to OTel context token when no tokenResolver is configured", async () => {
       // Import inline to avoid top-level circular dependency confusion
-      const { runWithExportToken } = await import(
-        "../../../../src/a365/context/tokenContext.js"
-      );
+      const { runWithExportToken } = await import("../../../../src/a365/context/tokenContext.js");
 
       const exporter = new Agent365Exporter({}); // no tokenResolver
 
@@ -734,9 +732,7 @@ describe("Agent365Exporter", () => {
     });
 
     it("prefers tokenResolver result over OTel context token", async () => {
-      const { runWithExportToken } = await import(
-        "../../../../src/a365/context/tokenContext.js"
-      );
+      const { runWithExportToken } = await import("../../../../src/a365/context/tokenContext.js");
 
       const exporter = new Agent365Exporter({ tokenResolver: () => "resolver-token" });
 

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -3,7 +3,8 @@
 
 import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { ExportResultCode } from "@opentelemetry/core";
-import { SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
+import { context as otelContext, SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { Agent365Exporter } from "../../../../src/a365/exporter/Agent365Exporter.js";
 import {
@@ -625,6 +626,72 @@ describe("Agent365Exporter", () => {
       assert.strictEqual(result, ExportResultCode.FAILED);
       // DEFAULT_MAX_RETRIES = 3, so 1 initial + 3 retries = 4 total
       assert.strictEqual(fetchSpy.mock.calls.length, 4);
+    });
+  });
+
+  describe("token context fallback", () => {
+    let contextManager: AsyncLocalStorageContextManager;
+
+    beforeEach(() => {
+      contextManager = new AsyncLocalStorageContextManager();
+      contextManager.enable();
+      otelContext.setGlobalContextManager(contextManager);
+    });
+
+    afterEach(() => {
+      otelContext.disable();
+    });
+
+    it("falls back to OTel context token when no tokenResolver is configured", async () => {
+      // Import inline to avoid top-level circular dependency confusion
+      const { runWithExportToken } = await import(
+        "../../../../src/a365/context/tokenContext.js"
+      );
+
+      const exporter = new Agent365Exporter({}); // no tokenResolver
+
+      let exportResult!: number;
+      await runWithExportToken("context-token-abc", async () => {
+        exportResult = await new Promise<number>((resolve) => {
+          exporter.export([makeSpan()], (r) => resolve(r.code));
+        });
+      });
+
+      assert.strictEqual(exportResult, ExportResultCode.SUCCESS);
+      // Verify the Bearer token was sourced from context
+      const authHeader: string = fetchSpy.mock.calls[0][1].headers["authorization"];
+      assert.strictEqual(authHeader, "Bearer context-token-abc");
+    });
+
+    it("prefers tokenResolver result over OTel context token", async () => {
+      const { runWithExportToken } = await import(
+        "../../../../src/a365/context/tokenContext.js"
+      );
+
+      const exporter = new Agent365Exporter({ tokenResolver: () => "resolver-token" });
+
+      await runWithExportToken("context-token-should-not-be-used", async () => {
+        await new Promise<void>((resolve) => {
+          exporter.export([makeSpan()], () => resolve());
+        });
+      });
+
+      const authHeader: string = fetchSpy.mock.calls[0][1].headers["authorization"];
+      assert.strictEqual(authHeader, "Bearer resolver-token");
+    });
+
+    it("skips export and warns when no token is available", async () => {
+      // No tokenResolver, no context token
+      const exporter = new Agent365Exporter({});
+
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      // Export "succeeds" (no spans sent) but fetch was never called
+      assert.strictEqual(fetchSpy.mock.calls.length, 0);
+      // Result is still SUCCESS because the group is skipped, not an error
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
     });
   });
 });

--- a/test/internal/unit/a365/perRequestSpanProcessor.test.ts
+++ b/test/internal/unit/a365/perRequestSpanProcessor.test.ts
@@ -241,14 +241,16 @@ describe("PerRequestSpanProcessor", () => {
       const root = tracer.startSpan("root");
       const rootCtx = trace.setSpan(otelContext.active(), root);
       const child = tracer.startSpan("child", {}, rootCtx);
-      child.end(); // child ends
-      root.end(); // root ends
-      // openCount should be 0 after both end, so the trace_completed path fires directly
+      root.end(); // root ends while child is still open
 
-      // Force any pending microtasks
+      expect(exporter.callCount).toBe(0);
+
+      vi.advanceTimersByTime(flushGraceMs);
       await vi.runAllTimersAsync();
 
       expect(exporter.callCount).toBe(1);
+
+      child.end(); // trace already swept, ending child should be a no-op
     });
 
     it("flushes stale trace after maxTraceAgeMs via sweep", async () => {
@@ -297,6 +299,14 @@ describe("PerRequestSpanProcessor", () => {
     it("queues exports when maxConcurrentExports is reached", async () => {
       // Use a manual-resolve exporter to hold the first export slot open
       let resolveFirstExport!: () => void;
+      let resolveFirstExportStarted!: () => void;
+      const firstExportStarted = new Promise<void>((resolve) => {
+        resolveFirstExportStarted = resolve;
+      });
+      let resolveSecondExportStarted!: () => void;
+      const secondExportStarted = new Promise<void>((resolve) => {
+        resolveSecondExportStarted = resolve;
+      });
       let exportCount = 0;
       const batches: ReadableSpan[][] = [];
 
@@ -305,11 +315,13 @@ describe("PerRequestSpanProcessor", () => {
           batches.push([...spans]);
           const idx = ++exportCount;
           if (idx === 1) {
+            resolveFirstExportStarted();
             // Hold first slot open until manually released
             new Promise<void>((resolve) => {
               resolveFirstExport = resolve;
             }).then(() => cb({ code: ExportResultCode.SUCCESS }));
           } else {
+            resolveSecondExportStarted();
             cb({ code: ExportResultCode.SUCCESS });
           }
         },
@@ -327,14 +339,12 @@ describe("PerRequestSpanProcessor", () => {
       root1.end();
       root2.end();
 
-      // Drain microtasks — export 1 starts (slot taken), export 2 queues
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-
+      await firstExportStarted;
       expect(exportCount).toBe(1);
 
       // Release the first export
       resolveFirstExport();
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      await secondExportStarted;
 
       expect(exportCount).toBe(2);
     });

--- a/test/internal/unit/a365/perRequestSpanProcessor.test.ts
+++ b/test/internal/unit/a365/perRequestSpanProcessor.test.ts
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { context as otelContext, trace } from "@opentelemetry/api";
+import { ExportResultCode } from "@opentelemetry/core";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import type { ExportResult } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import { PerRequestSpanProcessor } from "../../../../src/a365/processors/PerRequestSpanProcessor.js";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+type MockExporter = SpanExporter & {
+  batches: ReadableSpan[][];
+  callCount: number;
+  resultCode: ExportResultCode;
+};
+
+function makeMockExporter(resultCode = ExportResultCode.SUCCESS): MockExporter {
+  const batches: ReadableSpan[][] = [];
+  let callCount = 0;
+  return {
+    batches,
+    get callCount() {
+      return callCount;
+    },
+    set callCount(v) {
+      callCount = v;
+    },
+    resultCode,
+    export(spans: ReadableSpan[], cb: (result: ExportResult) => void) {
+      batches.push([...spans]);
+      callCount++;
+      cb({ code: resultCode });
+    },
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Build a provider that runs spans through a `PerRequestSpanProcessor`.
+ * Returns the provider and its tracer for span creation.
+ */
+function buildProvider(
+  processor: PerRequestSpanProcessor,
+): { provider: BasicTracerProvider; tracer: ReturnType<BasicTracerProvider["getTracer"]> } {
+  const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+  return { provider, tracer: provider.getTracer("test") };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("PerRequestSpanProcessor", () => {
+  let contextManager: AsyncLocalStorageContextManager;
+
+  beforeEach(() => {
+    contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    otelContext.setGlobalContextManager(contextManager);
+  });
+
+  afterEach(async () => {
+    otelContext.disable();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("basic buffering and export", () => {
+    it("exports all spans when root ends and no open children remain", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+      child.end();
+      root.end();
+
+      await provider.shutdown();
+
+      expect(exporter.callCount).toBe(1);
+      expect(exporter.batches[0]).toHaveLength(2);
+      const names = exporter.batches[0].map((s) => s.name);
+      expect(names).toContain("root");
+      expect(names).toContain("child");
+    });
+
+    it("exports after last child ends when root already ended", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter, { flushGraceMs: 0 });
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+
+      // End root first, child still open
+      root.end();
+      expect(exporter.callCount).toBe(0);
+
+      // Now end child — processor should detect both root ended and openCount hits 0
+      child.end();
+
+      await provider.shutdown();
+
+      expect(exporter.callCount).toBe(1);
+      expect(exporter.batches[0]).toHaveLength(2);
+    });
+
+    it("does not export a root-only span until root ends", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      // Root has not ended — nothing exported yet
+      expect(exporter.callCount).toBe(0);
+
+      root.end();
+      await provider.shutdown();
+
+      expect(exporter.callCount).toBe(1);
+    });
+
+    it("two independent traces are exported separately", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root1 = tracer.startSpan("root1");
+      const root2 = tracer.startSpan("root2");
+      root1.end();
+      root2.end();
+
+      await provider.shutdown();
+
+      expect(exporter.callCount).toBe(2);
+      // Each batch contains exactly 1 span
+      expect(exporter.batches[0]).toHaveLength(1);
+      expect(exporter.batches[1]).toHaveLength(1);
+    });
+  });
+
+  describe("guard-rail limits", () => {
+    it("drops new traces when maxBufferedTraces is reached", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter, { maxBufferedTraces: 1 });
+      const { provider, tracer } = buildProvider(processor);
+
+      // First trace fills the buffer
+      const root1 = tracer.startSpan("root1");
+      // Second trace should be silently dropped (buffer full)
+      const root2 = tracer.startSpan("root2");
+
+      root1.end(); // export fires for trace 1
+      root2.end(); // trace 2 was never buffered, nothing to export
+
+      await provider.shutdown();
+
+      expect(exporter.callCount).toBe(1);
+      expect(exporter.batches[0][0].name).toBe("root1");
+    });
+
+    it("drops spans that exceed maxSpansPerTrace", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter, { maxSpansPerTrace: 2 });
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child1 = tracer.startSpan("child1", {}, rootCtx);
+      const child2 = tracer.startSpan("child2", {}, rootCtx);
+      const child3 = tracer.startSpan("child3", {}, rootCtx);
+
+      child1.end();
+      child2.end();
+      child3.end(); // should be dropped — buffer full at maxSpansPerTrace=2
+      root.end(); // root itself will be the 3rd span — also dropped
+
+      await provider.shutdown();
+
+      // Only 2 spans should have been exported
+      expect(exporter.batches[0]).toHaveLength(2);
+    });
+  });
+
+  describe("forceFlush and shutdown", () => {
+    it("forceFlush exports all buffered traces immediately", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+      child.end();
+      // Root still open — normally nothing exported yet
+
+      await processor.forceFlush();
+      // After force flush the buffered trace should be exported
+      expect(exporter.callCount).toBe(1);
+
+      root.end(); // ends after flush — trace already gone, no-op
+      await provider.shutdown();
+    });
+
+    it("shutdown flushes pending traces and calls exporter.shutdown", async () => {
+      const exporter = makeMockExporter();
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+      child.end();
+
+      await provider.shutdown(); // triggers processor.shutdown internally
+
+      expect(exporter.callCount).toBe(1);
+      expect(exporter.shutdown).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("sweep timer: grace period flush", () => {
+    it("flushes trace via grace period when children outlive root", async () => {
+      vi.useFakeTimers();
+
+      const exporter = makeMockExporter();
+      const flushGraceMs = 500;
+      const processor = new PerRequestSpanProcessor(exporter, {
+        flushGraceMs,
+        maxTraceAgeMs: 60_000,
+      });
+      const { tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+      child.end(); // child ends
+      root.end(); // root ends
+      // openCount should be 0 after both end, so the trace_completed path fires directly
+
+      // Force any pending microtasks
+      await vi.runAllTimersAsync();
+
+      expect(exporter.callCount).toBe(1);
+    });
+
+    it("flushes stale trace after maxTraceAgeMs via sweep", async () => {
+      vi.useFakeTimers();
+
+      const exporter = makeMockExporter();
+      const maxTraceAgeMs = 1000;
+      const processor = new PerRequestSpanProcessor(exporter, {
+        maxTraceAgeMs,
+        flushGraceMs: 500,
+      });
+      const { tracer } = buildProvider(processor);
+
+      // Start a trace but never end it
+      const root = tracer.startSpan("root");
+      const rootCtx = trace.setSpan(otelContext.active(), root);
+      const child = tracer.startSpan("child", {}, rootCtx);
+      child.end();
+      // root still open — no export yet
+      expect(exporter.callCount).toBe(0);
+
+      // Advance past maxTraceAgeMs so sweep picks it up
+      vi.advanceTimersByTime(maxTraceAgeMs + 100);
+      await vi.runAllTimersAsync();
+
+      expect(exporter.callCount).toBe(1);
+    });
+  });
+
+  describe("export failure handling", () => {
+    it("continues without throwing on exporter failure", async () => {
+      const exporter = makeMockExporter(ExportResultCode.FAILED);
+      const processor = new PerRequestSpanProcessor(exporter);
+      const { provider, tracer } = buildProvider(processor);
+
+      const root = tracer.startSpan("root");
+      root.end();
+
+      // shutdown should not throw even when export fails
+      await expect(provider.shutdown()).resolves.not.toThrow();
+      expect(exporter.callCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe("concurrent export limit", () => {
+    it("queues exports when maxConcurrentExports is reached", async () => {
+      // Use a manual-resolve exporter to hold the first export slot open
+      let resolveFirstExport!: () => void;
+      let exportCount = 0;
+      const batches: ReadableSpan[][] = [];
+
+      const slowExporter: SpanExporter = {
+        export(spans: ReadableSpan[], cb: (result: ExportResult) => void) {
+          batches.push([...spans]);
+          const idx = ++exportCount;
+          if (idx === 1) {
+            // Hold first slot open until manually released
+            new Promise<void>((resolve) => {
+              resolveFirstExport = resolve;
+            }).then(() => cb({ code: ExportResultCode.SUCCESS }));
+          } else {
+            cb({ code: ExportResultCode.SUCCESS });
+          }
+        },
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const processor = new PerRequestSpanProcessor(slowExporter, {
+        maxConcurrentExports: 1,
+      });
+      const { tracer } = buildProvider(processor);
+
+      // End two root spans to trigger two independent exports
+      const root1 = tracer.startSpan("root1");
+      const root2 = tracer.startSpan("root2");
+      root1.end();
+      root2.end();
+
+      // Drain microtasks — export 1 starts (slot taken), export 2 queues
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+      expect(exportCount).toBe(1);
+
+      // Release the first export
+      resolveFirstExport();
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+      expect(exportCount).toBe(2);
+    });
+  });
+});

--- a/test/internal/unit/a365/perRequestSpanProcessor.test.ts
+++ b/test/internal/unit/a365/perRequestSpanProcessor.test.ts
@@ -44,9 +44,10 @@ function makeMockExporter(resultCode = ExportResultCode.SUCCESS): MockExporter {
  * Build a provider that runs spans through a `PerRequestSpanProcessor`.
  * Returns the provider and its tracer for span creation.
  */
-function buildProvider(
-  processor: PerRequestSpanProcessor,
-): { provider: BasicTracerProvider; tracer: ReturnType<BasicTracerProvider["getTracer"]> } {
+function buildProvider(processor: PerRequestSpanProcessor): {
+  provider: BasicTracerProvider;
+  tracer: ReturnType<BasicTracerProvider["getTracer"]>;
+} {
   const provider = new BasicTracerProvider({ spanProcessors: [processor] });
   return { provider, tracer: provider.getTracer("test") };
 }


### PR DESCRIPTION
Ports the per-request trace buffering and flush-on-completion behavior from @microsoft/agents-a365-observability into this distro as an internal compatibility path.

Per Issue #40, the processor is NOT part of the public API. It is activated exclusively via the ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT env var and wired internally in distro.ts when that flag is set.

Changes:
- src/a365/processors/PerRequestSpanProcessor.ts (new): buffers spans per trace ID, exports the whole trace once the root span ends and all children have completed. Sweep timer handles grace-period and max-age eviction.
- src/a365/configuration/A365Configuration.ts: adds internal per-request env vars (ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT, A365_PER_REQUEST_*) and exposes them via internal-only getPerRequestOptions().
- src/distro/distro.ts: uses PerRequestSpanProcessor instead of BatchSpanProcessor when perRequest.enabled is true.
- src/a365/exporter/Agent365Exporter.ts: resolveToken() falls back to getExportToken() from OTel context to support per-request token flow.
- MIGRATION_A365.md: adds section 7 with concrete self-service guidance for users who need to reproduce per-request behavior via public APIs.
- tests: perRequestSpanProcessor.test.ts (new), a365Configuration.test.ts and agent365Exporter.test.ts extended with per-request coverage.

Fixes #56. See also #40.