### PR TITLE
fix(a365): register A365SpanProcessor for console fallback path

### DIFF
--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -144,6 +144,12 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   // ── A365 exporter (enabled via options.a365 or env vars) ──────────
   const a365Config = new A365Configuration(options?.a365);
   const a365ConsoleExportFallback = !a365Config.enabled && !!options?.a365;
+  if (a365Config.enabled || a365ConsoleExportFallback) {
+    // A365SpanProcessor copies baggage (tenant, agent, session, etc.) and
+    // telemetry.sdk.* attributes to span attributes — needed regardless of
+    // whether the A365 exporter or console fallback is active.
+    spanProcessors.push(new A365SpanProcessor());
+  }
   if (a365Config.enabled) {
     const a365Exporter = new Agent365Exporter({
       clusterCategory: a365Config.clusterCategory,
@@ -151,8 +157,6 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
       authScopes: a365Config.authScopes,
       tokenResolver: a365Config.tokenResolver,
     });
-    // A365SpanProcessor copies baggage (tenant, agent, session, etc.) to span attributes
-    spanProcessors.push(new A365SpanProcessor());
     spanProcessors.push(new BatchSpanProcessor(a365Exporter));
   } else if (a365ConsoleExportFallback) {
     // A365 options provided but exporter disabled — fall back to console export

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -987,6 +987,49 @@ describe("Main functions", () => {
     await shutdownMicrosoftOpenTelemetry();
   });
 
+  it("registers A365SpanProcessor when A365 exporter is disabled but a365 options are provided", async () => {
+    process.env.ENABLE_A365_OBSERVABILITY_EXPORTER = "false";
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      a365: {
+        enabled: false,
+        tokenResolver: () => "token",
+      },
+    });
+
+    const internalSdk = _getSdkInstance();
+    assert.isDefined(internalSdk);
+
+    const tracerProvider = (internalSdk as any)["_tracerProvider"];
+    const activeSpanProcessor = tracerProvider?.["_activeSpanProcessor"];
+    const registeredProcessors = activeSpanProcessor?.["_spanProcessors"] || [];
+
+    const a365SpanProcessor = registeredProcessors.find(
+      (processor: any) => processor.constructor?.name === "A365SpanProcessor",
+    );
+
+    assert.isDefined(
+      a365SpanProcessor,
+      "Expected A365SpanProcessor to be registered even when A365 exporter is disabled",
+    );
+
+    // Should also have a ConsoleSpanExporter fallback
+    const consoleProcessor = registeredProcessors.find(
+      (processor: any) =>
+        processor.constructor?.name === "SimpleSpanProcessor" &&
+        processor["_exporter"]?.constructor?.name === "ConsoleSpanExporter",
+    );
+
+    assert.isDefined(
+      consoleProcessor,
+      "Expected ConsoleSpanExporter fallback when A365 exporter is disabled",
+    );
+
+    delete process.env.ENABLE_A365_OBSERVABILITY_EXPORTER;
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
   it("preserves BatchSpanProcessor defaults when A365 exporter tuning is omitted", async () => {
     useMicrosoftOpenTelemetry({
       azureMonitor: { enabled: false },


### PR DESCRIPTION
A365SpanProcessor was only added when a365Config.enabled was true. When the A365 exporter is disabled but a365 options are provided (console fallback), the processor was skipped, causing telemetry.sdk.* attributes and baggage-to-span enrichment to be missing from spans.

Fixes #53 