### PR TITLE
feat(a365): default to GenAI telemetry when A365 is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+- When A365 export is enabled (`a365.enabled=true` or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`), non-GenAI instrumentations are now disabled by default unless explicitly enabled in `instrumentationOptions`.
+
 ## [0.1.0-alpha.6] - 2026-04-24
 
 ### Breaking Changes

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -42,3 +42,11 @@ The distro package itself can include instrumentation implementations, but those
 2. Missing target SDKs remain non-fatal and log a clear warning.
 3. Startup/shutdown ordering is deterministic and validated with functional tests for both LangChain and OpenAI Agents.
 4. Public config semantics for `instrumentationOptions.langchain` and `instrumentationOptions.openaiAgents` remain unchanged.
+
+---
+
+## A365 + Azure Monitor Mixed-Exporter Instrumentation Defaults
+
+Currently, when A365 is enabled without Azure Monitor, non-GenAI instrumentations (http, azureSdk, mongoDb, etc.) are disabled by default so that only GenAI telemetry is collected. When both A365 and Azure Monitor are active, instrumentations are left enabled so Azure Monitor receives the infra/log data it expects. OTLP does not affect this behavior.
+
+**Pending:** Define a more granular strategy for the A365 + Azure Monitor scenario — for example, routing infra spans only to Azure Monitor while sending GenAI spans to both A365 and Azure Monitor. This may involve per-exporter span filtering or separate instrumentation pipelines.

--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ That's it — traces, metrics, and logs are collected automatically with built-i
 
 Most instrumentations use `InstrumentationConfig` shape (`{ enabled?: boolean, ... }`).
 
-- Built-in infra instrumentations (`http`, `azureSdk`, `azureFunctions`, `mongoDb`, `mySql`, `postgreSql`, `redis`, `redis4`) are enabled by default.
+- Built-in infra instrumentations (`http`, `azureSdk`, `mongoDb`, `mySql`, `postgreSql`, `redis`, `redis4`) are enabled by default.
 - Logging instrumentations (`bunyan`, `winston`) are disabled by default.
 - GenAI instrumentations (`openaiAgents`, `langchain`) are enabled by default.
+- When `a365.enabled` is `true`, non-GenAI instrumentations (`http`, `azureSdk`, DB/cache, and logging) are disabled by default unless explicitly set in `instrumentationOptions`.
 
 Set `enabled: true` or `enabled: false` explicitly for predictable behavior.
 
@@ -240,6 +241,29 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 | `clusterCategory` | `ClusterCategory` | `"prod"` | Cluster category for endpoint resolution (`local`, `dev`, `test`, `preprod`, `firstrelease`, `prod`, `gov`, `high`, `dod`, `mooncake`, `ex`, `rx`) |
 | `domainOverride` | `string` | — | Override the A365 observability service domain |
 | `authScopes` | `string[]` | `["https://api.powerplatform.com/.default"]` | OAuth scopes for A365 service authentication |
+
+When A365 export is enabled, the distro defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
+
+```typescript
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    tokenResolver: (agentId, tenantId) => getToken(agentId, tenantId),
+  },
+  instrumentationOptions: {
+    http: { enabled: true },
+    azureSdk: { enabled: true },
+    mongoDb: { enabled: true },
+    mySql: { enabled: true },
+    postgreSql: { enabled: true },
+    redis: { enabled: true },
+    redis4: { enabled: true },
+    bunyan: { enabled: true },
+    winston: { enabled: true },
+  },
+});
+```
+
 #### A365 hosting middleware setup
 
 Hosting middleware is configured separately from `a365` exporter options.

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -47,6 +47,76 @@ let sdk: NodeSDK;
 let disposeAzureMonitor: (() => void) | undefined;
 let isShutdown = false;
 
+const A365_DISABLED_INSTRUMENTATIONS_BY_DEFAULT: ReadonlyArray<keyof InstrumentationOptions> = [
+  "http",
+  "azureSdk",
+  "mongoDb",
+  "mySql",
+  "postgreSql",
+  "redis",
+  "redis4",
+  "bunyan",
+  "winston",
+];
+
+/**
+ * Redis and redis4 share the same underlying instrumentation. If a caller
+ * explicitly configures either key, treat both as explicitly configured so
+ * the other is not inadvertently disabled.
+ */
+const REDIS_LINKED_KEYS: ReadonlyArray<keyof InstrumentationOptions> = ["redis", "redis4"];
+
+/**
+ * When A365 export is enabled, default to GenAI-focused telemetry by disabling
+ * non-GenAI instrumentations unless callers explicitly configure them.
+ *
+ * @internal
+ */
+export function _applyA365InstrumentationDefaults(
+  instrumentationOptions: InstrumentationOptions,
+  userInstrumentationOptions: unknown,
+  a365Enabled: boolean,
+): void {
+  if (!a365Enabled) {
+    return;
+  }
+
+  const userOptionsRecord =
+    userInstrumentationOptions && typeof userInstrumentationOptions === "object"
+      ? (userInstrumentationOptions as Record<string, unknown>)
+      : undefined;
+
+  // Pre-compute whether any Redis-linked key was explicitly configured so
+  // that configuring `redis4` alone does not inadvertently disable `redis`
+  // (and vice-versa), which would break the underlying shared instrumentation.
+  const redisLinkedExplicit =
+    !!userOptionsRecord &&
+    REDIS_LINKED_KEYS.some((k) => Object.prototype.hasOwnProperty.call(userOptionsRecord, k));
+
+  for (const instrumentationKey of A365_DISABLED_INSTRUMENTATIONS_BY_DEFAULT) {
+    const isExplicitlyConfigured =
+      !!userOptionsRecord &&
+      Object.prototype.hasOwnProperty.call(userOptionsRecord, instrumentationKey);
+
+    // Treat redis/redis4 as a linked pair: if either was set by the caller,
+    // skip disabling both keys.
+    if (
+      isExplicitlyConfigured ||
+      (redisLinkedExplicit &&
+        REDIS_LINKED_KEYS.includes(instrumentationKey as (typeof REDIS_LINKED_KEYS)[number]))
+    ) {
+      continue;
+    }
+
+    const currentValue = instrumentationOptions[instrumentationKey];
+    if (currentValue && typeof currentValue === "object") {
+      (currentValue as Record<string, unknown>).enabled = false;
+    } else {
+      instrumentationOptions[instrumentationKey] = { enabled: false };
+    }
+  }
+}
+
 /**
  * Initialize Microsoft OpenTelemetry distribution.
  *
@@ -63,6 +133,7 @@ let isShutdown = false;
 export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOptions): void {
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
+  const a365Config = new A365Configuration(options?.a365);
 
   // Azure Monitor is enabled when configured programmatically or via JSON config.
   // An explicit `enabled: false` always wins, even if a connection string is present.
@@ -95,6 +166,17 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   // registerGlobal() to create a fresh one with the correct version.
   const globalOpentelemetryApiKey = Symbol.for("opentelemetry.js.api.1");
   delete (globalThis as Record<symbol, unknown>)[globalOpentelemetryApiKey];
+
+  // Apply A365 instrumentation defaults (disable non-GenAI instrumentations)
+  // when A365 is enabled and Azure Monitor is not. When both A365 and Azure
+  // Monitor are active, infra instrumentations must remain enabled so Azure
+  // Monitor receives the telemetry it expects.
+  const applyA365Defaults = a365Config.enabled && !azureMonitorEnabled;
+  _applyA365InstrumentationDefaults(
+    config.instrumentationOptions,
+    options?.instrumentationOptions,
+    applyA365Defaults,
+  );
 
   // ── Instrumentations, sampler, and views (always created) ─────────
   const instrumentations = createInstrumentations(config, {
@@ -142,7 +224,6 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   }
 
   // ── A365 exporter (enabled via options.a365 or env vars) ──────────
-  const a365Config = new A365Configuration(options?.a365);
   const a365ConsoleExportFallback = !a365Config.enabled && !!options?.a365;
   if (a365Config.enabled || a365ConsoleExportFallback) {
     // A365SpanProcessor copies baggage (tenant, agent, session, etc.) and
@@ -220,7 +301,13 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
 
   // Initialize GenAI instrumentations after providers are registered so any
   // tracer they capture is backed by the active SDK provider.
-  initializeGenAIInstrumentations(options?.instrumentationOptions);
+  // When A365 defaults were applied, use the resolved config so GenAI
+  // instrumentations are active by default even if the caller omitted
+  // instrumentationOptions. Otherwise honour the caller's original options
+  // to avoid initializing GenAI when it was not requested.
+  initializeGenAIInstrumentations(
+    applyA365Defaults ? config.instrumentationOptions : options?.instrumentationOptions,
+  );
 }
 
 /**

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -9,6 +9,7 @@ import {
   useMicrosoftOpenTelemetry,
   shutdownMicrosoftOpenTelemetry,
   _getSdkInstance,
+  _applyA365InstrumentationDefaults,
 } from "../../../src/distro/distro.js";
 import type { MeterProvider, ViewOptions } from "@opentelemetry/sdk-metrics";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
@@ -1028,6 +1029,85 @@ describe("Main functions", () => {
 
     delete process.env.ENABLE_A365_OBSERVABILITY_EXPORTER;
     await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("disables non-GenAI instrumentations by default when A365 is enabled", () => {
+    const instrumentationOptions = {
+      http: { enabled: true },
+      azureSdk: { enabled: true },
+      mongoDb: { enabled: true },
+      mySql: { enabled: true },
+      postgreSql: { enabled: true },
+      redis: { enabled: true },
+      redis4: { enabled: true },
+      openaiAgents: { enabled: true },
+      langchain: { enabled: true },
+    };
+
+    _applyA365InstrumentationDefaults(instrumentationOptions, undefined, true);
+
+    assert.strictEqual(instrumentationOptions.http.enabled, false);
+    assert.strictEqual(instrumentationOptions.azureSdk.enabled, false);
+    assert.strictEqual(instrumentationOptions.mongoDb.enabled, false);
+    assert.strictEqual(instrumentationOptions.mySql.enabled, false);
+    assert.strictEqual(instrumentationOptions.postgreSql.enabled, false);
+    assert.strictEqual(instrumentationOptions.redis.enabled, false);
+    assert.strictEqual(instrumentationOptions.redis4.enabled, false);
+    assert.strictEqual(instrumentationOptions.openaiAgents.enabled, true);
+    assert.strictEqual(instrumentationOptions.langchain.enabled, true);
+  });
+
+  it("preserves explicit instrumentation overrides when A365 is enabled", () => {
+    const instrumentationOptions = {
+      http: { enabled: true },
+      azureSdk: { enabled: true },
+      mongoDb: { enabled: true },
+      mySql: { enabled: true },
+      postgreSql: { enabled: true },
+      redis: { enabled: false },
+      redis4: { enabled: true },
+      openaiAgents: { enabled: true },
+      langchain: { enabled: true },
+    };
+    const userOverrides = {
+      http: { enabled: true },
+      redis: { enabled: false },
+    };
+
+    _applyA365InstrumentationDefaults(instrumentationOptions, userOverrides, true);
+
+    assert.strictEqual(instrumentationOptions.http.enabled, true);
+    assert.strictEqual(instrumentationOptions.redis.enabled, false);
+    assert.strictEqual(instrumentationOptions.azureSdk.enabled, false);
+    assert.strictEqual(instrumentationOptions.mongoDb.enabled, false);
+    assert.strictEqual(instrumentationOptions.openaiAgents.enabled, true);
+    assert.strictEqual(instrumentationOptions.langchain.enabled, true);
+  });
+
+  it("preserves a redis4-only explicit override when A365 is enabled", () => {
+    const instrumentationOptions = {
+      http: { enabled: true },
+      azureSdk: { enabled: true },
+      mongoDb: { enabled: true },
+      mySql: { enabled: true },
+      postgreSql: { enabled: true },
+      redis: { enabled: true },
+      redis4: { enabled: true },
+      openaiAgents: { enabled: true },
+      langchain: { enabled: true },
+    };
+    const userOverrides = {
+      redis4: { enabled: true },
+    };
+
+    _applyA365InstrumentationDefaults(instrumentationOptions, userOverrides, true);
+
+    // redis and redis4 are a linked pair — configuring either preserves both
+    assert.strictEqual(instrumentationOptions.redis.enabled, true);
+    assert.strictEqual(instrumentationOptions.redis4.enabled, true);
+    assert.strictEqual(instrumentationOptions.azureSdk.enabled, false);
+    assert.strictEqual(instrumentationOptions.openaiAgents.enabled, true);
+    assert.strictEqual(instrumentationOptions.langchain.enabled, true);
   });
 
   it("preserves BatchSpanProcessor defaults when A365 exporter tuning is omitted", async () => {


### PR DESCRIPTION
Disable non-GenAI instrumentations by default when A365 export is enabled unless callers explicitly override instrumentationOptions.

Add unit coverage for default behavior and override preservation, and document the change in README and CHANGELOG.

Fixes #43 
Fixes #34 