### PR TITLE
chore: bump version to 0.1.0-beta.1 for first beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.1.0-beta.1] - 2026-04-27
+
+First beta release. Promotes all functionality from the 0.1.0-alpha series.
+
 ## [0.1.0-alpha.6] - 2026-04-24
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/opentelemetry",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/opentelemetry",
-      "version": "0.1.0-alpha.6",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/opentelemetry",
   "author": "Microsoft Corporation",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-beta.1",
   "description": "Microsoft OpenTelemetry distribution for JavaScript/TypeScript",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ import type { A365Options } from "./a365/index.js";
 /**
  * Microsoft OpenTelemetry distribution version.
  */
-export const MICROSOFT_OPENTELEMETRY_VERSION = "0.1.0-alpha.6";
+export const MICROSOFT_OPENTELEMETRY_VERSION = "0.1.0-beta.1";
 
 /**
  * Microsoft OpenTelemetry Options


### PR DESCRIPTION
Promote all 0.1.0-alpha functionality to beta. Updates package.json version, MICROSOFT_OPENTELEMETRY_VERSION constant, and CHANGELOG.