### PR TITLE
fix(a365): resolve logger lazily in Agent365Exporter so late configureA365Logger calls take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bugs Fixed
+- Fix `Agent365Exporter` not emitting `[EVENT]:` export outcome logs to a logger configured via `configureA365Logger` after the exporter was constructed. The exporter previously cached the logger snapshot at construction time, so the distro-bootstrapped exporter never picked up partner-supplied loggers. ([#50](https://github.com/microsoft/opentelemetry-distro-javascript/issues/50))
+
 ## [0.1.0-alpha.6] - 2026-04-24
 
 ### Breaking Changes

--- a/src/a365/exporter/Agent365Exporter.ts
+++ b/src/a365/exporter/Agent365Exporter.ts
@@ -79,7 +79,10 @@ interface OTLPStatus {
 export class Agent365Exporter implements SpanExporter {
   private closed = false;
   private readonly options: ResolvedExporterOptions;
-  private readonly logger = getA365Logger();
+
+  private get logger() {
+    return getA365Logger();
+  }
 
   constructor(options?: Agent365ExporterOptions) {
     this.options = new ResolvedExporterOptions(options);

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -540,6 +540,41 @@ describe("Agent365Exporter", () => {
     });
   });
 
+  describe("late-configured logger", () => {
+    it("should emit event logs when logger is configured after exporter construction", async () => {
+      const exporter = new Agent365Exporter({ tokenResolver: () => "tok" });
+
+      const customLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      configureA365Logger({ logger: customLogger, logLevel: "info|warn|error" });
+
+      await new Promise<void>((resolve) => {
+        exporter.export([makeSpan()], () => resolve());
+      });
+
+      const infoLines = customLogger.info.mock.calls.map((call) => String(call[0]));
+      assert.ok(
+        infoLines.some(
+          (line) =>
+            line.includes("[EVENT]: export-group succeeded in") &&
+            line.includes("Spans exported successfully"),
+        ),
+        "Expected export-group success event log",
+      );
+      assert.ok(
+        infoLines.some(
+          (line) =>
+            line.includes("[EVENT]: agent365-export succeeded in") &&
+            line.includes("All spans exported successfully"),
+        ),
+        "Expected agent365-export success event log",
+      );
+    });
+  });
+
   describe("retry", () => {
     it("should retry on 500 errors", async () => {
       let callCount = 0;


### PR DESCRIPTION
## Summary

Fixes #50.

Agent365Exporter was capturing its logger once in a private readonly field at construction time:

`ts
private readonly logger = getA365Logger();
`

Because the distro instantiates the exporter inside setupTelemetry() (src/distro/distro.ts:148) **before** partner application code runs, any later call to configureA365Logger({ logger, logLevel }) was invisible to the exporter. The cached wrapper kept routing to the default (silent, `logLevel: ""none""`) logger, so the `[EVENT]: export-group succeeded ...` / `[EVENT]: agent365-export succeeded ...` lines that partner teams rely on for telemetry/metrics integration never reached their logger.

## Change

Convert the field to a getter that re-resolves `getA365Logger()` on every log call, so the exporter always honors the currently-configured logger and log level.

`ts
private get logger() {
  return getA365Logger();
}
`

## Verification

- Added regression test `late-configured logger > should emit event logs when logger is configured after exporter construction` in `test/internal/unit/a365/agent365Exporter.test.ts`.
- All 85 a365 unit tests pass locally (`npx vitest run --config vitest.unit.config.ts test/internal/unit/a365`).
- Manually reproduced before/after with a small script that constructs the exporter, then calls `configureA365Logger` with a custom sink. Without the fix the partner logger receives 0 lines; with the fix it receives both the `Exporting N spans` line and the `[EVENT]: agent365-export succeeded` line.