### PR TITLE
fix(a365): make ENABLE_A365_OBSERVABILITY_EXPORTER a secondary toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 First beta release. Promotes all functionality from the 0.1.0-alpha series.
 
 ### Breaking Changes
-- When A365 export is enabled (`a365.enabled=true` or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`), non-GenAI instrumentations are now disabled by default unless explicitly enabled in `instrumentationOptions`. ([#79](https://github.com/microsoft/opentelemetry-distro-javascript/pull/79))
+- When A365 is enabled through configured A365 options, non-GenAI instrumentations are now disabled by default unless explicitly enabled in `instrumentationOptions`. `ENABLE_A365_OBSERVABILITY_EXPORTER` no longer activates A365 on its own; it only toggles the exporter within an already-configured A365 setup. ([#79](https://github.com/microsoft/opentelemetry-distro-javascript/pull/79))
 - Align GenAI instrumentations with A365 observability schema: use structured message format, update span kinds and attributes (`gen_ai.agent.name`, `gen_ai.conversation.id`, `error.type`), and remove `isContentRecordingEnabled` option (content is now always recorded). ([#75](https://github.com/microsoft/opentelemetry-distro-javascript/pull/75))
 
 ### Features Added
 - Add ESM loader entrypoint (`@microsoft/opentelemetry/loader`) and document ESM support. ([#74](https://github.com/microsoft/opentelemetry-distro-javascript/pull/74))
 
 ### Bugs Fixed
+- `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable no longer activates A365 on its own. A365 options must be provided in code; the env var only toggles the exporter within an already-configured A365 setup. ([#43](https://github.com/microsoft/opentelemetry-distro-javascript/issues/43))
 - Fix `Agent365Exporter` not emitting `[EVENT]:` export outcome logs to a logger configured via `configureA365Logger` after the exporter was constructed. The exporter previously cached the logger snapshot at construction time, so the distro-bootstrapped exporter never picked up partner-supplied loggers. ([#81](https://github.com/microsoft/opentelemetry-distro-javascript/pull/81))
 - Register `A365SpanProcessor` for console fallback path so `telemetry.sdk.*` attributes and baggage-to-span enrichment are present when the A365 exporter is disabled. ([#78](https://github.com/microsoft/opentelemetry-distro-javascript/pull/78))
 - Restore `AgenticTokenCache` that was accidentally removed in #66. ([#77](https://github.com/microsoft/opentelemetry-distro-javascript/pull/77))

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -217,7 +217,7 @@ A365 core variables:
 
 | Variable | Description |
 |---|---|
-| `ENABLE_A365_OBSERVABILITY_EXPORTER` | Enable/disable A365 export |
+| `ENABLE_A365_OBSERVABILITY_EXPORTER` | Secondary toggle for A365 export; only takes effect when `a365` options are provided in code. Cannot activate A365 on its own. |
 | `A365_OBSERVABILITY_SCOPES_OVERRIDE` | Space-separated OAuth scopes |
 | `A365_OBSERVABILITY_DOMAIN_OVERRIDE` | Override A365 service domain |
 | `CLUSTER_CATEGORY` | Cluster category: `prod`, `dev`, `test` |

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ useMicrosoftOpenTelemetry({
 Behavior:
 
 - `enableConsoleExporters: true`: always enable console exporters (traces, metrics, logs).
-- `enableConsoleExporters: false`: do not auto-add the standard console exporters, except for the A365 span console fallback when `a365` options are provided but `a365.enabled` is `false` or omitted.
-- Omitted: console exporters auto-enable only when no other exporter path is active; if `a365` options are provided but `a365.enabled` is `false` or omitted, the A365 span console fallback can still be added.
+- `enableConsoleExporters: false`: do not auto-add the standard console exporters.
+- Omitted: console exporters auto-enable only when no other exporter path is active.
 
 ### `azureMonitor` options
 

--- a/src/a365/configuration/A365Configuration.ts
+++ b/src/a365/configuration/A365Configuration.ts
@@ -95,8 +95,12 @@ export class A365Configuration {
     }
 
     // 3. Apply environment variable overrides (highest precedence)
+    // The exporter env var is a secondary toggle that only takes effect when
+    // A365 is configured in code (options provided). It must not bootstrap
+    // A365 mode on its own — matching upstream Agent365-nodejs behavior where
+    // the env var is only read inside Builder.build().
     const envEnabled = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
-    if (envEnabled !== undefined) {
+    if (envEnabled !== undefined && options !== undefined) {
       enabled = envEnabled;
     }
 
@@ -141,7 +145,8 @@ export class A365Configuration {
     if (hasNonTrivialOptions) {
       getA365Logger().warn(
         "A365 configuration options are set but A365 is not enabled. " +
-          "Set `a365.enabled: true` or `ENABLE_A365_OBSERVABILITY_EXPORTER=true` to enable.",
+          "Set `a365.enabled: true` or set `ENABLE_A365_OBSERVABILITY_EXPORTER=true` " +
+          "(the env var only takes effect when a365 options are provided in code).",
       );
     }
   }

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -126,7 +126,9 @@ export function _applyA365InstrumentationDefaults(
  *   `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is set; explicitly disable
  *   with `options.azureMonitor.enabled = false`)
  * - OTLP HTTP (when `OTEL_EXPORTER_OTLP_ENDPOINT` is set)
- * - A365 (when `options.a365.enabled` is true or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`)
+ * - A365 (when the resolved A365 config has `enabled=true`; the
+ *   `ENABLE_A365_OBSERVABILITY_EXPORTER` env var is only considered when
+ *   `options.a365` is provided)
  *
  * @param options - Microsoft OpenTelemetry configuration options
  */
@@ -223,15 +225,13 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     }
   }
 
-  // ── A365 exporter (enabled via options.a365 or env vars) ──────────
-  const a365ConsoleExportFallback = !a365Config.enabled && !!options?.a365;
-  if (a365Config.enabled || a365ConsoleExportFallback) {
-    // A365SpanProcessor copies baggage (tenant, agent, session, etc.) and
-    // telemetry.sdk.* attributes to span attributes — needed regardless of
-    // whether the A365 exporter or console fallback is active.
-    spanProcessors.push(new A365SpanProcessor());
-  }
+  // ── A365 exporter (enabled when the resolved A365 config has enabled=true;
+  //    ENABLE_A365_OBSERVABILITY_EXPORTER is only considered when options.a365
+  //    is provided) ───────────────────────────────────────────────────────────
   if (a365Config.enabled) {
+    // A365SpanProcessor copies baggage (tenant, agent, session, etc.) and
+    // telemetry.sdk.* attributes to span attributes.
+    spanProcessors.push(new A365SpanProcessor());
     const a365Exporter = new Agent365Exporter({
       clusterCategory: a365Config.clusterCategory,
       domainOverride: a365Config.domainOverride,
@@ -239,11 +239,6 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
       tokenResolver: a365Config.tokenResolver,
     });
     spanProcessors.push(new BatchSpanProcessor(a365Exporter));
-  } else if (a365ConsoleExportFallback) {
-    // A365 options provided but exporter disabled — fall back to console export
-    // so developers can validate spans locally (matches upstream A365 SDK behavior
-    // when ENABLE_A365_OBSERVABILITY_EXPORTER=false).
-    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
   }
 
   // Merge views: use Azure Monitor views when available (they cover the same
@@ -261,10 +256,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     options?.enableConsoleExporters ??
     (!azureMonitorEnabled && !isOtlpEnabled() && !a365Config.enabled && !hasCustomProcessors);
   if (consoleEnabled) {
-    // Skip span console exporter when A365 fallback already added one
-    if (!a365ConsoleExportFallback) {
-      spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
-    }
+    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
     metricReaders.push(
       new PeriodicExportingMetricReader({
         exporter: new ConsoleMetricExporter(),

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -988,8 +988,7 @@ describe("Main functions", () => {
     await shutdownMicrosoftOpenTelemetry();
   });
 
-  it("registers A365SpanProcessor when A365 exporter is disabled but a365 options are provided", async () => {
-    process.env.ENABLE_A365_OBSERVABILITY_EXPORTER = "false";
+  it("does not register A365 components when a365.enabled is false", async () => {
     useMicrosoftOpenTelemetry({
       azureMonitor: { enabled: false },
       enableConsoleExporters: false,
@@ -1010,21 +1009,46 @@ describe("Main functions", () => {
       (processor: any) => processor.constructor?.name === "A365SpanProcessor",
     );
 
-    assert.isDefined(
+    assert.isUndefined(
       a365SpanProcessor,
-      "Expected A365SpanProcessor to be registered even when A365 exporter is disabled",
+      "A365SpanProcessor should not be registered when a365.enabled is false",
     );
 
-    // Should also have a ConsoleSpanExporter fallback
-    const consoleProcessor = registeredProcessors.find(
+    const a365Exporter = registeredProcessors.find(
       (processor: any) =>
-        processor.constructor?.name === "SimpleSpanProcessor" &&
-        processor["_exporter"]?.constructor?.name === "ConsoleSpanExporter",
+        processor.constructor?.name === "BatchSpanProcessor" &&
+        processor["_exporter"]?.constructor?.name === "Agent365Exporter",
     );
 
-    assert.isDefined(
-      consoleProcessor,
-      "Expected ConsoleSpanExporter fallback when A365 exporter is disabled",
+    assert.isUndefined(
+      a365Exporter,
+      "Agent365Exporter should not be registered when a365.enabled is false",
+    );
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("ENABLE_A365_OBSERVABILITY_EXPORTER env var alone does not activate A365", async () => {
+    process.env.ENABLE_A365_OBSERVABILITY_EXPORTER = "true";
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+    });
+
+    const internalSdk = _getSdkInstance();
+    assert.isDefined(internalSdk);
+
+    const tracerProvider = (internalSdk as any)["_tracerProvider"];
+    const activeSpanProcessor = tracerProvider?.["_activeSpanProcessor"];
+    const registeredProcessors = activeSpanProcessor?.["_spanProcessors"] || [];
+
+    const a365SpanProcessor = registeredProcessors.find(
+      (processor: any) => processor.constructor?.name === "A365SpanProcessor",
+    );
+
+    assert.isUndefined(
+      a365SpanProcessor,
+      "A365SpanProcessor should not be registered when only env var is set without a365 options",
     );
 
     delete process.env.ENABLE_A365_OBSERVABILITY_EXPORTER;


### PR DESCRIPTION
The ENABLE_A365_OBSERVABILITY_EXPORTER env var was incorrectly able to activate A365 mode on its own without a365 options provided in code. This could silently disable HTTP instrumentation and create a broken exporter with no tokenResolver.

The env var now only takes effect when a365 options are provided programmatically, matching upstream Agent365-nodejs behavior where the env var is only read inside Builder.build().

Also removed the console-fallback path: when a365.enabled=false, A365 is fully off and normal distro defaults apply.
