### PR TITLE
feat: report mot SDK version prefix to Azure Monitor and Quickpulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Other Changes
+- Set the `MICROSOFT_OPENTELEMETRY_VERSION` environment variable on import and report `mot${MICROSOFT_OPENTELEMETRY_VERSION}` from live metrics so the Azure Monitor exporter and Quickpulse both surface the `mot` SDK version prefix on `ai.internal.sdkVersion`. See [Azure/azure-sdk-for-js#38352](https://github.com/Azure/azure-sdk-for-js/pull/38352).
+
 ## [0.1.0-beta.1] - 2026-04-27
 
 First beta release. Promotes all functionality from the 0.1.0-alpha series.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.39",
+    "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.39",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.9",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",

--- a/src/azureMonitor/metrics/quickpulse/utils.ts
+++ b/src/azureMonitor/metrics/quickpulse/utils.ts
@@ -58,11 +58,10 @@ import { SDK_INFO, hrTimeToMilliseconds } from "@opentelemetry/core";
 import type { Histogram, ResourceMetrics } from "@opentelemetry/sdk-metrics";
 import { DataPointType } from "@opentelemetry/sdk-metrics";
 import {
-  APPLICATION_INSIGHTS_SHIM_VERSION,
   AZURE_MONITOR_AUTO_ATTACH,
-  AZURE_MONITOR_OPENTELEMETRY_VERSION,
   AZURE_MONITOR_PREFIX,
   AttachTypePrefix,
+  MICROSOFT_OPENTELEMETRY_VERSION,
 } from "../../../types.js";
 import type {
   RequestData,
@@ -95,11 +94,10 @@ export function getSdkVersion(): string {
 
 /** Get the internal SDK version type */
 export function getSdkVersionType(): string {
-  if (process.env[APPLICATION_INSIGHTS_SHIM_VERSION]) {
-    return `sha${process.env[APPLICATION_INSIGHTS_SHIM_VERSION]}`;
-  } else {
-    return `dst${AZURE_MONITOR_OPENTELEMETRY_VERSION}`;
-  }
+  // Always report the Microsoft OpenTelemetry distro version with the `mot`
+  // prefix so live metrics align with the Azure Monitor exporter's
+  // ai.internal.sdkVersion tag (see Azure/azure-sdk-for-js#38352).
+  return `mot${process.env["MICROSOFT_OPENTELEMETRY_VERSION"] ?? MICROSOFT_OPENTELEMETRY_VERSION}`;
 }
 
 /** Set the version prefix to a string in the format "{ResourceProvider}{OS}m_ */

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -83,6 +83,20 @@ describe("Main functions", () => {
     logs.disable();
   });
 
+  it("sets MICROSOFT_OPENTELEMETRY_VERSION env var on import so the Azure Monitor exporter reports the 'mot' sdkVersion prefix", async () => {
+    const { MICROSOFT_OPENTELEMETRY_VERSION, AZURE_MONITOR_OPENTELEMETRY_VERSION } = await import(
+      "../../../src/types.js"
+    );
+    assert.strictEqual(
+      process.env["MICROSOFT_OPENTELEMETRY_VERSION"],
+      MICROSOFT_OPENTELEMETRY_VERSION,
+    );
+    assert.strictEqual(
+      process.env["AZURE_MONITOR_DISTRO_VERSION"],
+      AZURE_MONITOR_OPENTELEMETRY_VERSION,
+    );
+  });
+
   it("useMicrosoftOpenTelemetry", () => {
     const config: MicrosoftOpenTelemetryOptions = {
       azureMonitor: {

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -84,9 +84,8 @@ describe("Main functions", () => {
   });
 
   it("sets MICROSOFT_OPENTELEMETRY_VERSION env var on import so the Azure Monitor exporter reports the 'mot' sdkVersion prefix", async () => {
-    const { MICROSOFT_OPENTELEMETRY_VERSION, AZURE_MONITOR_OPENTELEMETRY_VERSION } = await import(
-      "../../../src/types.js"
-    );
+    const { MICROSOFT_OPENTELEMETRY_VERSION, AZURE_MONITOR_OPENTELEMETRY_VERSION } =
+      await import("../../../src/types.js");
     assert.strictEqual(
       process.env["MICROSOFT_OPENTELEMETRY_VERSION"],
       MICROSOFT_OPENTELEMETRY_VERSION,


### PR DESCRIPTION
Set the MICROSOFT_OPENTELEMETRY_VERSION env var on distro import (already in place at src/distro/distro.ts:44) so the Azure Monitor exporter (Azure/azure-sdk-for-js#38352) tags ai.internal.sdkVersion with the 'mot' prefix once beta.40+ is published.

Also update getSdkVersionType() in the Quickpulse utils to always return 'mot' + MICROSOFT_OPENTELEMETRY_VERSION instead of 'dst' + AZURE_MONITOR_OPENTELEMETRY_VERSION so live metrics report the same SDK version prefix.

Loosen the @azure/monitor-opentelemetry-exporter pin to ^1.0.0-beta.39 so beta.40 is auto-picked-up.

Add a regression test that asserts MICROSOFT_OPENTELEMETRY_VERSION and AZURE_MONITOR_DISTRO_VERSION are populated in process.env once the distro module is imported.