### PR TITLE
fix: enable GenAI instrumentations by default for all users

### DIFF
--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -302,9 +302,9 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   // Initialize GenAI instrumentations after providers are registered so any
   // tracer they capture is backed by the active SDK provider.
   // When A365 defaults were applied, use the resolved config so GenAI
-  // instrumentations are active by default even if the caller omitted
-  // instrumentationOptions. Otherwise honour the caller's original options
-  // to avoid initializing GenAI when it was not requested.
+  // instrumentations honour any A365-specific overrides. Otherwise pass the
+  // caller's original options (GenAI instrumentations are enabled by default
+  // unless explicitly disabled).
   initializeGenAIInstrumentations(
     applyA365Defaults ? config.instrumentationOptions : options?.instrumentationOptions,
   );
@@ -331,13 +331,13 @@ export function _getSdkInstance(): NodeSDK | undefined {
 
 function initializeGenAIInstrumentations(options?: InstrumentationOptions): void {
   const openAIOptions = options?.openaiAgents;
-  if (openAIOptions && openAIOptions.enabled !== false) {
-    void initializeOpenAIAgentsInstrumentation(openAIOptions);
+  if (openAIOptions?.enabled !== false) {
+    void initializeOpenAIAgentsInstrumentation(openAIOptions ?? {});
   }
 
   const langChainOptions = options?.langchain;
-  if (langChainOptions && langChainOptions.enabled !== false) {
-    void initializeLangChainInstrumentation(langChainOptions);
+  if (langChainOptions?.enabled !== false) {
+    void initializeLangChainInstrumentation(langChainOptions ?? {});
   }
 }
 

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -1212,4 +1212,39 @@ describe("Main functions", () => {
 
     await shutdownMicrosoftOpenTelemetry();
   });
+
+  it("initializes GenAI instrumentations by default when instrumentationOptions is omitted", async () => {
+    const openaiSpy = vi.spyOn(OpenAIAgentsTraceInstrumentor, "instrument");
+    const langchainSpy = vi.spyOn(LangChainTraceInstrumentor, "instrument");
+
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(openaiSpy).toHaveBeenCalled();
+      expect(langchainSpy).toHaveBeenCalled();
+    });
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("initializes GenAI instrumentations by default when instrumentationOptions is empty", async () => {
+    const openaiSpy = vi.spyOn(OpenAIAgentsTraceInstrumentor, "instrument");
+    const langchainSpy = vi.spyOn(LangChainTraceInstrumentor, "instrument");
+
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      instrumentationOptions: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(openaiSpy).toHaveBeenCalled();
+      expect(langchainSpy).toHaveBeenCalled();
+    });
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
 });


### PR DESCRIPTION
Previously, langchain and openai-agents instrumentations were only initialized when the user explicitly passed instrumentationOptions with those keys set. This was inconsistent with the intended default behavior where all instrumentations are enabled unless explicitly disabled.

Changed the condition from requiring a truthy options object to only skipping when explicitly disabled (enabled === false). Passes an empty default config when the user omits the option entirely.