### PR TITLE
feat(a365): expose ability to configure env var only values via code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+- A365: `a365.enabled: true` now registers only the `A365SpanProcessor`. Set `a365.enableObservabilityExporter: true` (or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`) to also add the A365 HTTP exporter. ([#84](https://github.com/microsoft/opentelemetry-distro-javascript/issues/84))
+- A365: `ENABLE_A365_OBSERVABILITY_EXPORTER` env var now toggles only the HTTP exporter, not the master `a365.enabled` flag.
+
+### Features Added
+- Add `a365.enableObservabilityExporter`, `a365.observabilityScopeOverride`, and `a365.logLevel` code options as equivalents of `ENABLE_A365_OBSERVABILITY_EXPORTER`, `A365_OBSERVABILITY_SCOPES_OVERRIDE`, and `A365_OBSERVABILITY_LOG_LEVEL`. Programmatic values win over env vars. ([#84](https://github.com/microsoft/opentelemetry-distro-javascript/issues/84))
+
 ## [0.1.0-beta.1] - 2026-04-27
 
 First beta release. Promotes all functionality from the 0.1.0-alpha series.

--- a/src/a365/configuration/A365Configuration.ts
+++ b/src/a365/configuration/A365Configuration.ts
@@ -81,9 +81,30 @@ export class A365Configuration {
   /** OAuth scopes for A365 service authentication. */
   public readonly authScopes: string[];
 
+  /**
+   * Whether the A365 HTTP exporter (`Agent365Exporter`) should be added to
+   * the pipeline. The `A365SpanProcessor` is still registered when
+   * {@link enabled} is `true`, regardless of this flag.
+   *
+   * Resolved from {@link A365Options.enableObservabilityExporter} (programmatic)
+   * or the `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable; defaults
+   * to `false`.
+   */
+  public readonly enableObservabilityExporter: boolean;
+
+  /**
+   * Resolved log level for A365 observability components.
+   *
+   * `undefined` when neither the `logLevel` option nor the
+   * `A365_OBSERVABILITY_LOG_LEVEL` environment variable is set; in that case
+   * the A365 logger keeps its default ("none").
+   */
+  public readonly logLevel?: string;
+
   constructor(options?: A365Options) {
     // 1. Set defaults
     let enabled = false;
+    let enableObservabilityExporter = false;
     let clusterCategory: ClusterCategory = "prod";
     let domainOverride: string | undefined = options?.domainOverride;
     let authScopes: string[] = options?.authScopes ?? [DEFAULT_AUTH_SCOPE];
@@ -91,22 +112,36 @@ export class A365Configuration {
     // 2. Apply programmatic options
     if (options) {
       enabled = options.enabled ?? enabled;
+      enableObservabilityExporter =
+        options.enableObservabilityExporter ?? enableObservabilityExporter;
       clusterCategory = options.clusterCategory ?? clusterCategory;
     }
 
     // 3. Apply environment variable overrides (highest precedence)
-    // The exporter env var is a secondary toggle that only takes effect when
-    // A365 is configured in code (options provided). It must not bootstrap
-    // A365 mode on its own — matching upstream Agent365-nodejs behavior where
-    // the env var is only read inside Builder.build().
-    const envEnabled = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
-    if (envEnabled !== undefined && options !== undefined) {
-      enabled = envEnabled;
+    // ENABLE_A365_OBSERVABILITY_EXPORTER controls just the HTTP exporter, not
+    // the master `enabled` toggle. It is a secondary toggle that only takes
+    // effect when A365 is configured in code (options provided), matching the
+    // Python distro behavior (see microsoft/opentelemetry-distro-python#87).
+    const envExporter = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
+    if (
+      envExporter !== undefined &&
+      options !== undefined &&
+      options.enableObservabilityExporter === undefined
+    ) {
+      enableObservabilityExporter = envExporter;
     }
 
     const envScopes = process.env[A365_ENV_VARS.AUTH_SCOPES]?.trim();
     if (envScopes) {
       authScopes = envScopes.split(/\s+/).filter(Boolean);
+    }
+
+    // observabilityScopeOverride wins over authScopes / env var so callers can
+    // narrow the resolved scope set to a single explicit value (mirrors the
+    // Python distro's a365_observability_scope_override kwarg).
+    const scopeOverride = options?.observabilityScopeOverride?.trim();
+    if (scopeOverride) {
+      authScopes = [scopeOverride];
     }
 
     const envDomain = process.env[A365_ENV_VARS.DOMAIN]?.trim();
@@ -123,12 +158,26 @@ export class A365Configuration {
       );
     }
 
+    // Log level: programmatic option wins over the env var so callers can
+    // explicitly opt out of (or override) host-level configuration. The
+    // default ("none") is applied inside the A365 logger module when no
+    // value is supplied here, so leave `logLevel` undefined in that case.
+    let logLevel: string | undefined = options?.logLevel?.trim() || undefined;
+    if (logLevel === undefined) {
+      const envLogLevel = process.env[A365_ENV_VARS.LOG_LEVEL]?.trim();
+      if (envLogLevel) {
+        logLevel = envLogLevel;
+      }
+    }
+
     // Assign resolved values
     this.enabled = enabled;
+    this.enableObservabilityExporter = enableObservabilityExporter;
     this.tokenResolver = options?.tokenResolver;
     this.clusterCategory = clusterCategory;
     this.domainOverride = domainOverride;
     this.authScopes = authScopes;
+    this.logLevel = logLevel;
 
     // Warn when A365-scoped options are set but A365 is not enabled
     if (!this.enabled) {

--- a/src/a365/configuration/A365ConfigurationOptions.ts
+++ b/src/a365/configuration/A365ConfigurationOptions.ts
@@ -48,4 +48,42 @@ export interface A365Options {
 
   /** OAuth scopes for A365 service authentication. */
   authScopes?: string[];
+
+  /**
+   * Single-string override for the A365 observability authentication scope.
+   *
+   * Equivalent to the `A365_OBSERVABILITY_SCOPES_OVERRIDE` environment
+   * variable; when supplied, it becomes the sole entry of the resolved
+   * {@link authScopes} array. Mirrors the Python distro's
+   * `a365_observability_scope_override` kwarg
+   * (microsoft/opentelemetry-distro-python#87).
+   *
+   * Precedence (highest to lowest): this option > env var > {@link authScopes}.
+   */
+  observabilityScopeOverride?: string;
+
+  /**
+   * Enable the A365 HTTP observability exporter (`Agent365Exporter`).
+   *
+   * Defaults to `false`. When `false` (and {@link enabled} is `true`), the
+   * `A365SpanProcessor` is still registered for baggage/attribute enrichment
+   * of downstream exporters (Azure Monitor, OTLP, console, …) but no data is
+   * sent to the A365 observability service.
+   *
+   * Equivalent to the `ENABLE_A365_OBSERVABILITY_EXPORTER` environment
+   * variable. The programmatic value wins when both are set.
+   *
+   * Has no effect when {@link enabled} is `false`.
+   */
+  enableObservabilityExporter?: boolean;
+
+  /**
+   * Log level for A365 observability components.
+   *
+   * Accepts `none`, `info`, `warn`, `error`, or a `|`-separated combination
+   * (e.g. `"warn|error"`). Defaults to `none` when neither this option nor
+   * the `A365_OBSERVABILITY_LOG_LEVEL` environment variable is set. When set,
+   * this option overrides the environment variable.
+   */
+  logLevel?: string;
 }

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -30,6 +30,7 @@ import {
 } from "../azureMonitor/index.js";
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
 import { A365Configuration, Agent365Exporter, A365SpanProcessor } from "../a365/index.js";
+import { configureA365Logger } from "../a365/logging.js";
 import type {
   MicrosoftOpenTelemetryOptions,
   InstrumentationOptions,
@@ -137,6 +138,13 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   patchOpenTelemetryInstrumentationEnable();
   const a365Config = new A365Configuration(options?.a365);
 
+  // Apply the resolved A365 log level (programmatic option > env var) so the
+  // A365 logger filter reflects user-supplied configuration instead of being
+  // pinned to whatever the env var was at module-load time.
+  if (a365Config.logLevel !== undefined) {
+    configureA365Logger({ logLevel: a365Config.logLevel });
+  }
+
   // Azure Monitor is enabled when configured programmatically or via JSON config.
   // An explicit `enabled: false` always wins, even if a connection string is present.
   // Connection-string validation is delegated to the Azure Monitor module.
@@ -230,15 +238,19 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   //    is provided) ───────────────────────────────────────────────────────────
   if (a365Config.enabled) {
     // A365SpanProcessor copies baggage (tenant, agent, session, etc.) and
-    // telemetry.sdk.* attributes to span attributes.
+    // telemetry.sdk.* attributes to span attributes. Always registered when
+    // A365 is enabled, even if the HTTP exporter is suppressed, so downstream
+    // exporters (Azure Monitor, OTLP, …) still receive the enriched spans.
     spanProcessors.push(new A365SpanProcessor());
-    const a365Exporter = new Agent365Exporter({
-      clusterCategory: a365Config.clusterCategory,
-      domainOverride: a365Config.domainOverride,
-      authScopes: a365Config.authScopes,
-      tokenResolver: a365Config.tokenResolver,
-    });
-    spanProcessors.push(new BatchSpanProcessor(a365Exporter));
+    if (a365Config.enableObservabilityExporter) {
+      const a365Exporter = new Agent365Exporter({
+        clusterCategory: a365Config.clusterCategory,
+        domainOverride: a365Config.domainOverride,
+        authScopes: a365Config.authScopes,
+        tokenResolver: a365Config.tokenResolver,
+      });
+      spanProcessors.push(new BatchSpanProcessor(a365Exporter));
+    }
   }
 
   // Merge views: use Azure Monitor views when available (they cover the same
@@ -254,7 +266,10 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     (options?.logRecordProcessors?.length ?? 0) > 0;
   const consoleEnabled =
     options?.enableConsoleExporters ??
-    (!azureMonitorEnabled && !isOtlpEnabled() && !a365Config.enabled && !hasCustomProcessors);
+    (!azureMonitorEnabled &&
+      !isOtlpEnabled() &&
+      !(a365Config.enabled && a365Config.enableObservabilityExporter) &&
+      !hasCustomProcessors);
   if (consoleEnabled) {
     spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
     metricReaders.push(

--- a/test/internal/unit/a365/a365Configuration.test.ts
+++ b/test/internal/unit/a365/a365Configuration.test.ts
@@ -61,19 +61,66 @@ describe("A365Configuration", () => {
       const config = new A365Configuration({ tokenResolver: resolver });
       assert.strictEqual(config.tokenResolver, resolver);
     });
+
+    it("should apply log level", () => {
+      const config = new A365Configuration({ logLevel: "warn|error" });
+      assert.strictEqual(config.logLevel, "warn|error");
+    });
+
+    it("should apply observabilityScopeOverride as a single scope", () => {
+      const config = new A365Configuration({
+        observabilityScopeOverride: "api://custom/.default",
+      });
+      assert.deepStrictEqual(config.authScopes, ["api://custom/.default"]);
+    });
+
+    it("observabilityScopeOverride wins over authScopes and env var", () => {
+      process.env[A365_ENV_VARS.AUTH_SCOPES] = "envScope1 envScope2";
+      const config = new A365Configuration({
+        authScopes: ["progScope"],
+        observabilityScopeOverride: "api://override/.default",
+      });
+      assert.deepStrictEqual(config.authScopes, ["api://override/.default"]);
+    });
+
+    it("should default enableObservabilityExporter to false", () => {
+      const config = new A365Configuration({ enabled: true });
+      assert.strictEqual(config.enableObservabilityExporter, false);
+    });
+
+    it("should apply enableObservabilityExporter=true", () => {
+      const config = new A365Configuration({ enabled: true, enableObservabilityExporter: true });
+      assert.strictEqual(config.enabled, true);
+      assert.strictEqual(config.enableObservabilityExporter, true);
+    });
+
+    it("should leave log level undefined when neither option nor env is set", () => {
+      delete process.env[A365_ENV_VARS.LOG_LEVEL];
+      const config = new A365Configuration();
+      assert.strictEqual(config.logLevel, undefined);
+    });
   });
 
   describe("environment variable overrides", () => {
-    it("should override enabled from env", () => {
+    it("should set enableObservabilityExporter from env", () => {
       process.env[A365_ENV_VARS.EXPORTER_ENABLED] = "true";
-      const config = new A365Configuration({ enabled: false });
-      assert.strictEqual(config.enabled, true);
+      const config = new A365Configuration({ enabled: true });
+      assert.strictEqual(config.enableObservabilityExporter, true);
     });
 
-    it("should override enabled=false from env", () => {
+    it("should set enableObservabilityExporter=false from env", () => {
       process.env[A365_ENV_VARS.EXPORTER_ENABLED] = "false";
-      const config = new A365Configuration({ enabled: true });
+      const config = new A365Configuration({ enabled: true, enableObservabilityExporter: true });
+      // Programmatic value wins over env
+      assert.strictEqual(config.enableObservabilityExporter, true);
+    });
+
+    it("should not bootstrap A365 mode from EXPORTER_ENABLED env var alone", () => {
+      process.env[A365_ENV_VARS.EXPORTER_ENABLED] = "true";
+      // No options -> env var ignored
+      const config = new A365Configuration();
       assert.strictEqual(config.enabled, false);
+      assert.strictEqual(config.enableObservabilityExporter, false);
     });
 
     it("should override auth scopes from env (space-separated)", () => {
@@ -108,9 +155,15 @@ describe("A365Configuration", () => {
 
     it("should ignore unrecognized boolean env var values", () => {
       process.env[A365_ENV_VARS.EXPORTER_ENABLED] = "maybe";
-      const config = new A365Configuration();
+      const config = new A365Configuration({ enabled: true });
       // Unrecognized value is ignored, default stands
-      assert.strictEqual(config.enabled, false);
+      assert.strictEqual(config.enableObservabilityExporter, false);
+    });
+
+    it("should pick up log level from env when option is unset", () => {
+      process.env[A365_ENV_VARS.LOG_LEVEL] = "info|warn";
+      const config = new A365Configuration();
+      assert.strictEqual(config.logLevel, "info|warn");
     });
   });
 
@@ -131,6 +184,12 @@ describe("A365Configuration", () => {
       });
 
       assert.strictEqual(config.enabled, true);
+    });
+
+    it("programmatic log level overrides the env var", () => {
+      process.env[A365_ENV_VARS.LOG_LEVEL] = "info";
+      const config = new A365Configuration({ logLevel: "error" });
+      assert.strictEqual(config.logLevel, "error");
     });
   });
 

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -988,6 +988,45 @@ describe("Main functions", () => {
     await shutdownMicrosoftOpenTelemetry();
   });
 
+  it("registers A365SpanProcessor but not Agent365Exporter when a365.enableObservabilityExporter is false (default)", async () => {
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      a365: {
+        enabled: true,
+        // enableObservabilityExporter omitted -> defaults to false
+        tokenResolver: () => "token",
+      },
+    });
+
+    const internalSdk = _getSdkInstance();
+    assert.isDefined(internalSdk);
+
+    const tracerProvider = (internalSdk as any)["_tracerProvider"];
+    const activeSpanProcessor = tracerProvider?.["_activeSpanProcessor"];
+    const registeredProcessors = activeSpanProcessor?.["_spanProcessors"] || [];
+
+    const a365SpanProcessor = registeredProcessors.find(
+      (processor: any) => processor.constructor?.name === "A365SpanProcessor",
+    );
+    assert.isDefined(
+      a365SpanProcessor,
+      "A365SpanProcessor should still be registered for span enrichment",
+    );
+
+    const a365Exporter = registeredProcessors.find(
+      (processor: any) =>
+        processor.constructor?.name === "BatchSpanProcessor" &&
+        processor["_exporter"]?.constructor?.name === "Agent365Exporter",
+    );
+    assert.isUndefined(
+      a365Exporter,
+      "Agent365Exporter should be suppressed when a365.enableObservabilityExporter is false",
+    );
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
   it("does not register A365 components when a365.enabled is false", async () => {
     useMicrosoftOpenTelemetry({
       azureMonitor: { enabled: false },
@@ -1140,6 +1179,7 @@ describe("Main functions", () => {
       enableConsoleExporters: false,
       a365: {
         enabled: true,
+        enableObservabilityExporter: true,
         tokenResolver: () => "token",
       },
     });
@@ -1161,6 +1201,69 @@ describe("Main functions", () => {
     assert.strictEqual(batchProcessor["_exportTimeoutMillis"], 30000);
 
     await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("propagates a365.observabilityScopeOverride to the Agent365Exporter authScopes", async () => {
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      a365: {
+        enabled: true,
+        enableObservabilityExporter: true,
+        observabilityScopeOverride: "api://override-scope/.default",
+        tokenResolver: () => "token",
+      },
+    });
+
+    const internalSdk = _getSdkInstance();
+    assert.isDefined(internalSdk);
+
+    const tracerProvider = (internalSdk as any)["_tracerProvider"];
+    const activeSpanProcessor = tracerProvider?.["_activeSpanProcessor"];
+    const registeredProcessors = activeSpanProcessor?.["_spanProcessors"] || [];
+
+    const batchProcessor = registeredProcessors.find(
+      (processor: any) =>
+        processor.constructor?.name === "BatchSpanProcessor" &&
+        processor["_exporter"]?.constructor?.name === "Agent365Exporter",
+    );
+
+    assert.isDefined(batchProcessor, "Expected an Agent365 BatchSpanProcessor");
+    const exporter = batchProcessor["_exporter"];
+    assert.deepStrictEqual(exporter?.["options"]?.authScopes, ["api://override-scope/.default"]);
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("applies a365.logLevel to the A365 logger filter via configureA365Logger", async () => {
+    const { _resetA365LoggerForTest, getA365Logger } = await import("../../../src/a365/logging.js");
+    _resetA365LoggerForTest();
+
+    const customLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { configureA365Logger } = await import("../../../src/a365/logging.js");
+    configureA365Logger({ logger: customLogger });
+
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      a365: {
+        enabled: true,
+        logLevel: "warn|error",
+        tokenResolver: () => "token",
+      },
+    });
+
+    const logger = getA365Logger();
+    logger.info("dropped");
+    logger.warn("kept");
+    logger.error("kept");
+
+    assert.strictEqual(customLogger.info.mock.calls.length, 0, "info should be filtered out");
+    assert.strictEqual(customLogger.warn.mock.calls.length, 1, "warn should pass the filter");
+    assert.strictEqual(customLogger.error.mock.calls.length, 1, "error should pass the filter");
+
+    await shutdownMicrosoftOpenTelemetry();
+    _resetA365LoggerForTest();
   });
 
   it("initializes OpenAI Agents instrumentation when enabled", async () => {


### PR DESCRIPTION
Fixes #84.

This pull request introduces several breaking changes and new features to the A365 observability configuration, focusing on more granular control over the A365 HTTP exporter, authentication scopes, and logging. The changes clarify the distinction between enabling A365 enrichment and enabling the HTTP exporter, add new configuration options (with programmatic options overriding environment variables), and ensure these behaviors are well-tested.

**Breaking changes and new features:**

**A365 Exporter & Configuration Behavior**
- The `a365.enabled` flag now only registers the `A365SpanProcessor` for span enrichment; the HTTP exporter (`Agent365Exporter`) is registered only if `a365.enableObservabilityExporter` is set to `true`. The environment variable `ENABLE_A365_OBSERVABILITY_EXPORTER` now only controls the exporter, not the master enable flag. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R11) [[2]](diffhunk://#diff-04c557127e54d82376c04e7e721bd8c72816e2aff2db7d53fb9280d0f45261d2R84-R146) [[3]](diffhunk://#diff-04c557127e54d82376c04e7e721bd8c72816e2aff2db7d53fb9280d0f45261d2R161-R180) [[4]](diffhunk://#diff-322d81e2fcc8d8f8f05437392e08dfa4f4d860e16e6a500317141352f8bb43f6L233-R245) [[5]](diffhunk://#diff-322d81e2fcc8d8f8f05437392e08dfa4f4d860e16e6a500317141352f8bb43f6L257-R272)

**New Configuration Options**
- Added `a365.enableObservabilityExporter`, `a365.observabilityScopeOverride`, and `a365.logLevel` as programmatic options, each with corresponding environment variable equivalents. Programmatic values always take precedence. [[1]](diffhunk://#diff-661b54c4188c6b72599278f6e9ba5c8ceb0271077e931de5134d99ac09864662R51-R88) [[2]](diffhunk://#diff-04c557127e54d82376c04e7e721bd8c72816e2aff2db7d53fb9280d0f45261d2R84-R146) [[3]](diffhunk://#diff-04c557127e54d82376c04e7e721bd8c72816e2aff2db7d53fb9280d0f45261d2R161-R180) [[4]](diffhunk://#diff-322d81e2fcc8d8f8f05437392e08dfa4f4d860e16e6a500317141352f8bb43f6R141-R147)

**Logging Improvements**
- The resolved log level from `a365.logLevel` or `A365_OBSERVABILITY_LOG_LEVEL` is now applied at runtime to the A365 logger, ensuring logging respects user configuration rather than just environment at module load. [[1]](diffhunk://#diff-322d81e2fcc8d8f8f05437392e08dfa4f4d860e16e6a500317141352f8bb43f6R141-R147) [[2]](diffhunk://#diff-04c557127e54d82376c04e7e721bd8c72816e2aff2db7d53fb9280d0f45261d2R161-R180) [[3]](diffhunk://#diff-995e70dc49191c4b2a5f0329f9a62a1fdaf22a8950744f74c4b92a613c56ea2fR1206-R1268)

**Testing Enhancements**
- Expanded unit tests to cover all new configuration options, environment variable precedence, and correct registration (or suppression) of exporters and processors. Tests also verify the propagation of scope overrides and logging level. [[1]](diffhunk://#diff-41fb1607b5bb84d021e2436a2cc668e1c6182e821c7028ed92cd917780490aa3R64-R123) [[2]](diffhunk://#diff-41fb1607b5bb84d021e2436a2cc668e1c6182e821c7028ed92cd917780490aa3L111-R166) [[3]](diffhunk://#diff-41fb1607b5bb84d021e2436a2cc668e1c6182e821c7028ed92cd917780490aa3R188-R193) [[4]](diffhunk://#diff-995e70dc49191c4b2a5f0329f9a62a1fdaf22a8950744f74c4b92a613c56ea2fR991-R1029) [[5]](diffhunk://#diff-995e70dc49191c4b2a5f0329f9a62a1fdaf22a8950744f74c4b92a613c56ea2fR1182) [[6]](diffhunk://#diff-995e70dc49191c4b2a5f0329f9a62a1fdaf22a8950744f74c4b92a613c56ea2fR1206-R1268)

**Documentation**
- Updated `CHANGELOG.md` to clearly describe the breaking changes and new features, including migration notes for users.