### PR TITLE
fix: pin @azure/monitor-opentelemetry-exporter to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.39",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.39",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.9",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Remove the ^ from @azure/monitor-opentelemetry-exporter dependency to pin it to exactly 1.0.0-beta.39. This is a temporary fix because pnpm ignores the ^ caret and resolves a preview version over beta, causing build failures.