### PR TITLE
Remove hostDetector from default resource detectors

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -62,9 +62,9 @@ export function parseResourceDetectorsFromEnvVar(): Array<ResourceDetector> {
       return [resourceDetector];
     });
   } else {
-    // leaving out the process detector as that can add many resource attributes
+    // leaving out the process and host detectors as they can add many resource attributes
     // with large values. Also not enabling service instance attributes by default
     // as this is still experimental.
-    return [envDetector, hostDetector, osDetector];
+    return [envDetector, osDetector];
   }
 }

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -552,7 +552,7 @@ describe("Main functions", () => {
     });
   });
 
-  it("should not use process resource detector if OTEL_NODE_RESOURCE_DETECTORS not specified", () => {
+  it("should not use process or host resource detector if OTEL_NODE_RESOURCE_DETECTORS not specified", () => {
     const config: MicrosoftOpenTelemetryOptions = {
       azureMonitor: {
         azureMonitorExporterOptions: {
@@ -571,6 +571,7 @@ describe("Main functions", () => {
     assert.isDefined(resource, "Resource should be defined on tracer provider");
     Object.keys(resource || {}).forEach((attr) => {
       assert.isTrue(!attr.includes("process"));
+      assert.isTrue(!attr.startsWith("host."), `Unexpected host attribute: ${attr}`);
     });
   });
 


### PR DESCRIPTION
Host attributes (host.name, host.id, etc.) are no longer added by default. Customers can opt back in via OTEL_NODE_RESOURCE_DETECTORS=env,host,os.