### PR TITLE
Restore CODEOWNERS sub-owners for A365 and LangChain paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,5 @@
 * @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
 
 # A365 co-owners
-/src/a365/ @fpfp100 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
+/src/a365/ @fpfp100 @juliomenendez @alexlu4250 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
 
-# LangChain instrumentation co-owners
-/src/genai/instrumentations/langchain/ @fpfp100 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # Default owners for all files
-* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996
+* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
+
+# A365 co-owners
+/src/a365/ @fpfp100 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
+
+# LangChain instrumentation co-owners
+/src/genai/instrumentations/langchain/ @fpfp100 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss


### PR DESCRIPTION
Re-add co-owners for /src/a365/ and /src/genai/instrumentations/langchain/ that were temporarily removed in #65, and include the default owners on those paths as well.