### PR TITLE
docs: fix issues #102, #104, #105, #106, #107

### DIFF
--- a/A365_DOCUMENTATION.md
+++ b/A365_DOCUMENTATION.md
@@ -83,3 +83,16 @@ configureA365Hosting(adapter, {
 ```
 
 Set `enableOutputLogging: false` if response content should not be captured.
+
+## Shutdown
+
+Call `shutdownMicrosoftOpenTelemetry()` during graceful shutdown to flush pending telemetry and release resources:
+
+```typescript
+import { shutdownMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
+
+process.on("SIGTERM", async () => {
+  await shutdownMicrosoftOpenTelemetry();
+  process.exit(0);
+});
+```

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -15,11 +15,14 @@ Reference docs: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/
 | `npm install @microsoft/agents-a365-observability` | `npm install @microsoft/opentelemetry` |
 | `import { ... } from "@microsoft/agents-a365-observability"` | `import { ... } from "@microsoft/opentelemetry"` |
 
-If you used hosting helpers:
+If you used hosting helpers, extension packages, or the runtime package, remove them and use the single distro package:
 
 | Before | After |
 |---|---|
 | `@microsoft/agents-a365-observability-hosting` | `@microsoft/opentelemetry` |
+| `@microsoft/agents-a365-observability-extensions-openai` | `@microsoft/opentelemetry` (auto-instrumented) |
+| `@microsoft/agents-a365-observability-extensions-langchain` | `@microsoft/opentelemetry` (auto-instrumented) |
+| `@microsoft/agents-a365-runtime` | `@microsoft/opentelemetry` |
 
 ---
 
@@ -39,7 +42,7 @@ new Builder({
 ### After
 
 ```typescript
-import { useMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
+import { useMicrosoftOpenTelemetry, shutdownMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
 
 useMicrosoftOpenTelemetry({
   a365: {
@@ -48,7 +51,12 @@ useMicrosoftOpenTelemetry({
     clusterCategory: "prod",
   },
 });
+
+// On graceful shutdown (e.g. SIGTERM handler, process.on('beforeExit'), etc.)
+await shutdownMicrosoftOpenTelemetry();
 ```
+
+> **Important:** Call `shutdownMicrosoftOpenTelemetry()` during graceful shutdown to flush pending telemetry and release resources. Without this, buffered spans and metrics may be lost.
 
 ---
 
@@ -195,11 +203,13 @@ To switch from a custom resolver to the built-in cache, replace your custom logi
 
 ### Custom instance
 
+> **Breaking change:** The default auth scope has changed from `https://api.powerplatform.com/.default` to `api://9b975845-388f-4429-889e-eab1ef63949c/.default`. If you previously hardcoded the old scope, update it. For OBO (on-behalf-of) flows, use `api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite`. For S2S (service-to-service) flows, use `api://9b975845-388f-4429-889e-eab1ef63949c`. If you omit `authScopes`, the built-in default is used automatically.
+
 ```typescript
 import { AgenticTokenCache, useMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
 
 const tokenCache = new AgenticTokenCache({
-  authScopes: ["https://api.powerplatform.com/.default"],
+  authScopes: ["api://9b975845-388f-4429-889e-eab1ef63949c/.default"],
 });
 
 useMicrosoftOpenTelemetry({
@@ -220,12 +230,13 @@ If you use A365 scopes or baggage propagation, see [A365_DOCUMENTATION.md](./A36
 Quick example:
 
 ```typescript
-import { BaggageScope } from "@microsoft/opentelemetry";
+import { BaggageBuilder } from "@microsoft/opentelemetry";
 
-const baggage = new BaggageScope({
-  tenantId: "my-tenant",
-  channelId: "my-channel",
-});
+const baggage = new BaggageBuilder()
+  .agentId("my-agent")
+  .tenantId("my-tenant")
+  .channelId("my-channel")
+  .build();
 
 baggage.run(() => {
   // Baggage automatically propagated to child spans
@@ -388,31 +399,26 @@ new ObservabilityHostingManager().configure(adapter, {
 
 ## 12) Logging level migration
 
-| Old | New |
-|---|---|
-| `A365_OBSERVABILITY_LOG_LEVEL=none` | `OTEL_LOG_LEVEL=NONE` |
-| `A365_OBSERVABILITY_LOG_LEVEL=info` | `OTEL_LOG_LEVEL=INFO` |
-| `A365_OBSERVABILITY_LOG_LEVEL=warn` | `OTEL_LOG_LEVEL=WARN` |
-| `A365_OBSERVABILITY_LOG_LEVEL=error` | `OTEL_LOG_LEVEL=ERROR` |
+> **Note:** `A365_OBSERVABILITY_LOG_LEVEL` is **still supported** and controls internal A365 component logging (exporter, span processor, token cache). It is independent of the OpenTelemetry SDK log level.
 
-Before:
+| Variable | Purpose |
+|---|---|
+| `A365_OBSERVABILITY_LOG_LEVEL` | Controls A365 internal component logging (`none`, `info`, `warn`, `error`, or pipe-separated combination). **Still supported.** |
+| `OTEL_LOG_LEVEL` | Controls OpenTelemetry SDK diagnostic logging (`NONE`, `INFO`, `WARN`, `ERROR`). |
+| `AZURE_LOG_LEVEL` | Controls Azure SDK logging (`info`, `warning`, `error`, `verbose`). |
+
+If you were using `A365_OBSERVABILITY_LOG_LEVEL` for A365-specific logging, **no change is needed** — it continues to work.
+
+To also enable OpenTelemetry SDK diagnostics and Azure SDK logging, add the corresponding variables:
 
 ```bash
 # Linux / macOS
-export A365_OBSERVABILITY_LOG_LEVEL=info
+export A365_OBSERVABILITY_LOG_LEVEL=info   # A365 internal logging (still supported)
+export OTEL_LOG_LEVEL=INFO                  # OpenTelemetry SDK diagnostics
+export AZURE_LOG_LEVEL=info                 # Azure SDK logging
 
 # Windows cmd
 set A365_OBSERVABILITY_LOG_LEVEL=info
-```
-
-After:
-
-```bash
-# Linux / macOS
-export OTEL_LOG_LEVEL=INFO
-export AZURE_LOG_LEVEL=info
-
-# Windows cmd
 set OTEL_LOG_LEVEL=INFO
 set AZURE_LOG_LEVEL=info
 ```
@@ -490,6 +496,7 @@ For the full troubleshooting guide, see the [official troubleshooting documentat
 - [ ] Replace `@microsoft/agents-a365-observability` with `@microsoft/opentelemetry`
 - [ ] Replace hosting imports: `@microsoft/agents-a365-observability-hosting` → `@microsoft/opentelemetry`
 - [ ] Replace `new Builder(...).build()` with `useMicrosoftOpenTelemetry({ a365: { ... } })`
+- [ ] Add `await shutdownMicrosoftOpenTelemetry()` to your graceful shutdown path
 - [ ] Set `service.name` and `service.version` via `resource` option or `OTEL_RESOURCE_ATTRIBUTES`
 
 **Auto-instrumentation:**

--- a/README.md
+++ b/README.md
@@ -238,11 +238,15 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `boolean` | `false` | Enable A365 observability export |
+| `enabled` | `boolean` | `false` | Enable A365 observability. Registers the `A365SpanProcessor` for baggage/attribute enrichment of downstream exporters (Azure Monitor, OTLP, console). Does **not** send data to the A365 service on its own — set `enableObservabilityExporter` for that |
+| `enableObservabilityExporter` | `boolean` | `false` | Enable the A365 HTTP exporter (`Agent365Exporter`) to send spans to the A365 observability service. Requires `enabled: true`. Equivalent to `ENABLE_A365_OBSERVABILITY_EXPORTER` env var |
 | `tokenResolver` | `(agentId, tenantId, authScopes?) => string \| Promise<string>` | — | Token resolver for A365 service authentication |
 | `clusterCategory` | `ClusterCategory` | `"prod"` | Cluster category for endpoint resolution (`local`, `dev`, `test`, `preprod`, `firstrelease`, `prod`, `gov`, `high`, `dod`, `mooncake`, `ex`, `rx`) |
 | `domainOverride` | `string` | — | Override the A365 observability service domain |
-| `authScopes` | `string[]` | `["https://api.powerplatform.com/.default"]` | OAuth scopes for A365 service authentication |
+| `authScopes` | `string[]` | `["api://9b975845-388f-4429-889e-eab1ef63949c/.default"]` | OAuth scopes for A365 service authentication |
+| `observabilityScopeOverride` | `string` | — | Single-string scope override (highest precedence). Equivalent to `A365_OBSERVABILITY_SCOPES_OVERRIDE` env var |
+| `logLevel` | `string` | `"none"` | A365 internal log level: `none`, `info`, `warn`, `error`, or pipe-separated combination. Overrides `A365_OBSERVABILITY_LOG_LEVEL` env var |
+| `useS2SEndpoint` | `boolean` | `false` | Use the S2S (service-to-service) endpoint path for export |
 
 When A365 export is enabled, the distro defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
 
@@ -310,8 +314,16 @@ new ObservabilityHostingManager().configure(adapter as unknown as { use(...m: un
 });
 ```
 
+#### A365 exporter tuning
 
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `maxQueueSize` | `number` | `2048` | Maximum span queue size before drops occur |
+| `scheduledDelayMilliseconds` | `number` | `5000` | Delay (ms) between automatic batch flush attempts |
+| `exporterTimeoutMilliseconds` | `number` | `90000` | Maximum time (ms) for the entire export call |
 | `httpRequestTimeoutMilliseconds` | `number` | `30000` | HTTP request timeout (ms) when sending spans to A365 service |
+| `maxExportBatchSize` | `number` | `512` | Maximum number of spans per export batch |
+| `maxPayloadBytes` | `number` | — | Maximum estimated payload size (bytes) per HTTP chunk |
 
 Example:
 
@@ -320,12 +332,10 @@ useMicrosoftOpenTelemetry({
   a365: {
     enabled: true,
     tokenResolver: (agentId, tenantId) => getToken(agentId, tenantId),
-    exporterOptions: {
-      maxQueueSize: 4096,
-      maxExportBatchSize: 1024,
-      scheduledDelayMilliseconds: 10000,
-      httpRequestTimeoutMilliseconds: 15000,
-    },
+    maxQueueSize: 4096,
+    maxExportBatchSize: 1024,
+    scheduledDelayMilliseconds: 10000,
+    httpRequestTimeoutMilliseconds: 15000,
   },
 });
 ```


### PR DESCRIPTION
Fixes #102: Add missing agentId to BaggageScope example in MIGRATION_A365.md
Fixes #104: Fix exporterOptions nesting in README (settings are flat on a365)
Fixes #105: Update auth scope from powerplatform to correct app URI
Fixes #106: Clarify A365_OBSERVABILITY_LOG_LEVEL is still supported
Fixes #107: Add old extension/runtime packages to removal list
Fixes #108: provide shutdownMicrosoftOpenTelemetry() example from both the migration and public doc
