### PR TITLE
Exporter not preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Other Changes
 - Lazy-load LangChain tracer to avoid eager import of `@langchain/core` before instrumentation hooks register. Removed noise when openai and langchain packages are not installed [#98](https://github.com/microsoft/opentelemetry-distro-javascript/pull/98)
+- Accept beta versions of azure monitor exporter but not preview versions [#xxx](https://github.com/microsoft/opentelemetry-distro-javascript/pull/xxx)
 
 ## [1.0.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 - Lazy-load LangChain tracer to avoid eager import of `@langchain/core` before instrumentation hooks register. Removed noise when openai and langchain packages are not installed [#98](https://github.com/microsoft/opentelemetry-distro-javascript/pull/98)
-- Accept beta versions of azure monitor exporter but not preview versions [#xxx](https://github.com/microsoft/opentelemetry-distro-javascript/pull/xxx)
+- Accept beta versions of azure monitor exporter but not preview versions [#110](https://github.com/microsoft/opentelemetry-distro-javascript/pull/110)
 
 ## [1.0.0] - 2026-04-30
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.39",
+    "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.39 <1.0.1-c",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.9",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.39",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.39",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.9",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.39 <1.0.1-c",
+    "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.39 <1.0.0-c",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.9",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Adding the ^ to the exporter dependency broke tests because pnpm prefers deprecated preview versions over beta. Fixing this to include future beta versions but not past preview versions.