### PR TITLE
Fix getCallerBaggagePairs: resolve userId across all channels

### DIFF
--- a/src/a365/hosting/turnContextUtils.ts
+++ b/src/a365/hosting/turnContextUtils.ts
@@ -24,8 +24,10 @@ export function getCallerBaggagePairs(turnContext: TurnContextLike): Array<[stri
     return [];
   }
   const from = turnContext.activity.from;
+  // Fallback chain for userId: aadObjectId (Teams) → agenticUserId (A2A) → from.id (other channels)
+  const userId = from.aadObjectId || from.agenticUserId || from.id;
   const pairs: Array<[string, string | undefined]> = [
-    [OpenTelemetryConstants.USER_ID_KEY, from.aadObjectId],
+    [OpenTelemetryConstants.USER_ID_KEY, userId],
     [OpenTelemetryConstants.USER_NAME_KEY, from.name],
     [OpenTelemetryConstants.USER_EMAIL_KEY, from.agenticUserId],
     [OpenTelemetryConstants.GEN_AI_CALLER_AGENT_APPLICATION_ID_KEY, from.agenticAppBlueprintId],

--- a/src/a365/hosting/turnContextUtils.ts
+++ b/src/a365/hosting/turnContextUtils.ts
@@ -24,10 +24,8 @@ export function getCallerBaggagePairs(turnContext: TurnContextLike): Array<[stri
     return [];
   }
   const from = turnContext.activity.from;
-  // Fallback chain for userId: aadObjectId (Teams) → agenticUserId (A2A) → from.id (other channels)
-  const userId = from.aadObjectId || from.agenticUserId || from.id;
   const pairs: Array<[string, string | undefined]> = [
-    [OpenTelemetryConstants.USER_ID_KEY, userId],
+    [OpenTelemetryConstants.USER_ID_KEY, from.aadObjectId || from.agenticUserId || from.id],
     [OpenTelemetryConstants.USER_NAME_KEY, from.name],
     [OpenTelemetryConstants.USER_EMAIL_KEY, from.agenticUserId],
     [OpenTelemetryConstants.GEN_AI_CALLER_AGENT_APPLICATION_ID_KEY, from.agenticAppBlueprintId],

--- a/src/a365/hosting/types.ts
+++ b/src/a365/hosting/types.ts
@@ -20,6 +20,7 @@ export interface ActivityLike {
   channelIdSubChannel?: string | unknown;
   serviceUrl?: string;
   from?: {
+    id?: string;
     aadObjectId?: string;
     name?: string;
     role?: string;

--- a/test/internal/unit/a365/hosting/turnContextUtils.test.ts
+++ b/test/internal/unit/a365/hosting/turnContextUtils.test.ts
@@ -109,13 +109,19 @@ describe("TurnContextUtils", () => {
     it("should resolve userId to agenticUserId when it is a GUID (A2A with GUID)", () => {
       const ctx: TurnContextLike = {
         activity: {
-          from: { id: "29:1sH5NArUwkWAX", agenticUserId: "bef730f4-d6f5-4ffb-b759-26ffa449ed7e", name: "Agent" },
+          from: {
+            id: "29:1sH5NArUwkWAX",
+            agenticUserId: "bef730f4-d6f5-4ffb-b759-26ffa449ed7e",
+            name: "Agent",
+          },
         },
         turnState: new Map(),
       };
       const pairs = getCallerBaggagePairs(ctx);
       const obj = Object.fromEntries(pairs);
-      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("bef730f4-d6f5-4ffb-b759-26ffa449ed7e");
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe(
+        "bef730f4-d6f5-4ffb-b759-26ffa449ed7e",
+      );
     });
 
     it("should prefer aadObjectId over agenticUserId and from.id", () => {

--- a/test/internal/unit/a365/hosting/turnContextUtils.test.ts
+++ b/test/internal/unit/a365/hosting/turnContextUtils.test.ts
@@ -106,6 +106,18 @@ describe("TurnContextUtils", () => {
       expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("agent@contoso.com");
     });
 
+    it("should resolve userId to agenticUserId when it is a GUID (A2A with GUID)", () => {
+      const ctx: TurnContextLike = {
+        activity: {
+          from: { id: "29:1sH5NArUwkWAX", agenticUserId: "bef730f4-d6f5-4ffb-b759-26ffa449ed7e", name: "Agent" },
+        },
+        turnState: new Map(),
+      };
+      const pairs = getCallerBaggagePairs(ctx);
+      const obj = Object.fromEntries(pairs);
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("bef730f4-d6f5-4ffb-b759-26ffa449ed7e");
+    });
+
     it("should prefer aadObjectId over agenticUserId and from.id", () => {
       const ctx: TurnContextLike = {
         activity: {

--- a/test/internal/unit/a365/hosting/turnContextUtils.test.ts
+++ b/test/internal/unit/a365/hosting/turnContextUtils.test.ts
@@ -81,6 +81,48 @@ describe("TurnContextUtils", () => {
       expect(pairs).toEqual([]);
     });
 
+    it("should fall back to from.id when aadObjectId is undefined (non-Teams channel)", () => {
+      const ctx: TurnContextLike = {
+        activity: {
+          from: { id: "webchat-user-123", name: "Web User" },
+        },
+        turnState: new Map(),
+      };
+      const pairs = getCallerBaggagePairs(ctx);
+      const obj = Object.fromEntries(pairs);
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("webchat-user-123");
+      expect(obj[OpenTelemetryConstants.USER_NAME_KEY]).toBe("Web User");
+    });
+
+    it("should fall back to agenticUserId when aadObjectId is undefined (A2A)", () => {
+      const ctx: TurnContextLike = {
+        activity: {
+          from: { agenticUserId: "agent@contoso.com", name: "Upstream Agent" },
+        },
+        turnState: new Map(),
+      };
+      const pairs = getCallerBaggagePairs(ctx);
+      const obj = Object.fromEntries(pairs);
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("agent@contoso.com");
+    });
+
+    it("should prefer aadObjectId over agenticUserId and from.id", () => {
+      const ctx: TurnContextLike = {
+        activity: {
+          from: {
+            id: "fallback-id",
+            aadObjectId: "aad-oid",
+            agenticUserId: "agent@contoso.com",
+            name: "User",
+          },
+        },
+        turnState: new Map(),
+      };
+      const pairs = getCallerBaggagePairs(ctx);
+      const obj = Object.fromEntries(pairs);
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("aad-oid");
+    });
+
     it("should filter out undefined/empty values", () => {
       const ctx: TurnContextLike = {
         activity: { from: { name: "User", aadObjectId: "" } },


### PR DESCRIPTION
## Summary

- Port of microsoft/Agent365-dotnet#246
- **userId** baggage was only set from `aadObjectId`, which is `undefined` on non-Teams channels and A2A calls
- Added fallback chain: `aadObjectId → agenticUserId → from.id`
- Added `id` field to `ActivityLike.from` type definition

### Channel behavior after fix

| Field | Teams | Other channels (aadObjectId null) | A2A (user) | A2A (agent) |
|---|---|---|---|---|
| userId | aadObjectId | from.id | aadObjectId | agenticUserId |

## Test plan

- [x] Existing tests pass (19/19)
- [x] New test: non-Teams channel — userId falls back to from.id
- [x] New test: A2A — userId falls back to agenticUserId
- [x] New test: precedence — aadObjectId wins when all set

🤖 Generated with [Claude Code](https://claude.com/claude-code)