### PR TITLE
fix: import OpenAI agent types from @openai/agents to avoid version drift (#119)

### DIFF
--- a/src/genai/instrumentations/openai/openAIAgentsTraceProcessor.ts
+++ b/src/genai/instrumentations/openai/openAIAgentsTraceProcessor.ts
@@ -17,7 +17,7 @@ import type {
   MCPListToolsSpanData,
   Trace as AgentTrace,
   TracingProcessor,
-} from "@openai/agents-core";
+} from "@openai/agents";
 import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CALLER_AGENT_NAME,
@@ -43,7 +43,7 @@ type ContextToken = unknown;
 /**
  * OpenTelemetry-based trace processor for the OpenAI Agents SDK.
  *
- * Implements the `TracingProcessor` interface from `@openai/agents-core` so it
+ * Implements the `TracingProcessor` interface from `@openai/agents` so it
  * can be registered via `setTraceProcessors()`. Every OpenAI agent span
  * (agent invocation, function/tool call, LLM generation, response, handoff,
  * MCP list-tools) is mapped to an OTel span with GenAI semantic convention

--- a/src/genai/instrumentations/openai/utils.ts
+++ b/src/genai/instrumentations/openai/utils.ts
@@ -3,7 +3,7 @@
 // Vendored from microsoft/Agent365-nodejs packages/agents-a365-observability-extensions-openai
 
 import { SpanStatusCode } from "@opentelemetry/api";
-import type { Span as AgentsSpan, SpanData } from "@openai/agents-core";
+import type { Span as AgentsSpan, SpanData } from "@openai/agents";
 import {
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_PROVIDER_NAME,

--- a/test/internal/functional/openai.test.ts
+++ b/test/internal/functional/openai.test.ts
@@ -17,7 +17,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import type { Span as AgentsSpan, SpanData } from "@openai/agents-core";
+import type { Span as AgentsSpan, SpanData } from "@openai/agents";
 import { OpenAIAgentsTraceProcessor } from "../../../src/genai/instrumentations/openai/openAIAgentsTraceProcessor.js";
 import {
   ATTR_GEN_AI_AGENT_NAME,

--- a/test/internal/unit/a365/hosting/turnContextUtils.test.ts
+++ b/test/internal/unit/a365/hosting/turnContextUtils.test.ts
@@ -119,9 +119,7 @@ describe("TurnContextUtils", () => {
       };
       const pairs = getCallerBaggagePairs(ctx);
       const obj = Object.fromEntries(pairs);
-      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe(
-        "bef730f4-d6f5-4ffb-b759-26ffa449ed7e",
-      );
+      expect(obj[OpenTelemetryConstants.USER_ID_KEY]).toBe("bef730f4-d6f5-4ffb-b759-26ffa449ed7e");
     });
 
     it("should prefer aadObjectId over agenticUserId and from.id", () => {

--- a/test/internal/unit/genai/openai/openAIAgentsTraceProcessor.test.ts
+++ b/test/internal/unit/genai/openai/openAIAgentsTraceProcessor.test.ts
@@ -4,8 +4,8 @@
 import { assert, beforeEach, describe, it, vi } from "vitest";
 import type { Tracer, Span as OtelSpan } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
-import type { Span as AgentsSpan, SpanData } from "@openai/agents-core";
-import type { Trace as AgentTrace } from "@openai/agents-core";
+import type { Span as AgentsSpan, SpanData } from "@openai/agents";
+import type { Trace as AgentTrace } from "@openai/agents";
 import { OpenAIAgentsTraceProcessor } from "../../../../../src/genai/instrumentations/openai/openAIAgentsTraceProcessor.js";
 
 function makeMockOtelSpan(): OtelSpan & { attrs: Record<string, unknown>; _name: string } {

--- a/test/internal/unit/genai/openai/utils.test.ts
+++ b/test/internal/unit/genai/openai/utils.test.ts
@@ -3,7 +3,7 @@
 
 import { assert, describe, it } from "vitest";
 import { SpanStatusCode } from "@opentelemetry/api";
-import type { Span as AgentsSpan, SpanData } from "@openai/agents-core";
+import type { Span as AgentsSpan, SpanData } from "@openai/agents";
 import {
   safeJsonDumps,
   getSpanName,


### PR DESCRIPTION
## Summary
Fixes #119.

The instrumentation source imported types directly from `@openai/agents-core`, which is only a transitive dependency (pinned by `@openai/agents`). Two failure modes resulted:

1. **TS2307 `Cannot find module '@openai/agents-core'`** — when consumers (or `pnpm install --config.auto-install-peers=true`) didn't have `@openai/agents-core` declared as a direct dependency, TypeScript couldn't resolve the import (pnpm's strict module resolution).
2. **`TracingProcessor` / `Trace` type-incompatibility (`Property '#private' in type 'Trace' refers to a different member`)** — when `@openai/agents-core` got installed at a different version than the one pinned by `@openai/agents`, two copies coexisted and their nominal types didn't match.

## Fix
`@openai/agents` re-exports everything from `@openai/agents-core`. Importing through `@openai/agents` keeps a single source of truth and removes the possibility of version drift. No runtime behavior change — these are type-only imports.

Five files updated (src + tests). Build and unit tests (764) pass.

## Verification
Reproduced both customer scenarios in a fresh pnpm workspace:
- Scenario 2 (`pnpm install --config.auto-install-peers=true` then build): the two reported `Cannot find module '@openai/agents-core'` errors are gone.
- Scenario 3 (`pnpm add -D @openai/agents-core@latest` causing 0.8.5 + 0.9.1 to coexist): no remaining `TracingProcessor`/`Trace` type errors.
