### PR TITLE
Codeowners promote a365

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
 # Default owners for all files
-* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
-
-# A365 co-owners
-/src/a365/ @fpfp100 @juliomenendez @alexlu4250 @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
+* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # Default owners for all files
-* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250 @ajmfehr @gwharris7 @sellakumaran @biswapm
+* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss
 
+# A365 co-owners
+/src/a365/ @fpfp100 @juliomenendez @alexlu4250 @ajmfehr @gwharris7 @sellakumaran @biswapm @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for all files
-* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250 @ajmfehr
+* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250 @ajmfehr @gwharris7 @sellakumaran @biswapm
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for all files
-* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250
+* @hectorhdzg @JacksonWeber @lzchen @MSNev @rads-1996 @jeremydvoss @fpfp100 @juliomenendez @alexlu4250 @ajmfehr
 


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, expanding the list of default code owners to include several additional team members. No other functional or structural changes are present.

- Added `@fpfp100`, `@juliomenendez`, `@alexlu4250`, `@ajmfehr`, `@gwharris7`, `@sellakumaran`, and `@biswapm` to the default owners for all files in `.github/CODEOWNERS`.