### PR TITLE
fix(langchain): split request/response model and emit gen_ai.response.id

### DIFF
--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -188,6 +188,7 @@ export class LangChainTracer extends BaseTracer {
         }
       }
       Utils.setModelAttribute(run, span);
+      Utils.setResponseIdAttribute(run, span);
       Utils.setProviderNameAttribute(run, span);
       Utils.setSessionIdAttribute(run, span);
       Utils.setTokenAttributes(run, span);

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -12,6 +12,8 @@ import {
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
   ATTR_GEN_AI_TOOL_CALL_ID,
@@ -438,26 +440,102 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
   }
 }
 
-// Model - Helper to extract model name from run
-export function getModel(run: Run): string | undefined {
+// Model - Helper to extract the request-side model identifier from a LangChain
+// run. Reads only the LangChain-generic fields:
+//   - `extra.metadata.ls_model_name` (LangChain-set request model identifier)
+//   - `extra.invocation_params.model` / `extra.invocation_params.model_name`
+export function getRequestModel(run: Run): string | undefined {
+  const invocationParams = run.extra?.invocation_params as Record<string, unknown> | undefined;
   return [
-    // v1: response_metadata directly on message
-    run.outputs?.generations?.[0]?.[0]?.message?.response_metadata?.model_name,
-    // v0: response_metadata nested under kwargs
-    run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.response_metadata?.model_name,
-    // Metadata paths (both v0 and v1)
+    // LangChain-set request-side identifier (both v0 and v1)
     run.extra?.metadata?.ls_model_name,
-    run.extra?.invocation_params?.model,
-    run.extra?.invocation_params?.model_name,
+    // Generic request model from invocation params
+    invocationParams?.model,
+    invocationParams?.model_name,
   ]
     .map((v) => (v != null ? String(v).trim() : ""))
     .find((v) => v.length > 0);
 }
 
-// Model - Set model attribute on span
+// Model - Helper to extract the response-side model (the model that actually
+// served the request).
+export function getResponseModel(run: Run): string | undefined {
+  const llmOutput = run.outputs?.llmOutput as Record<string, unknown> | undefined;
+  return [
+    // v1: response_metadata directly on message
+    run.outputs?.generations?.[0]?.[0]?.message?.response_metadata?.model_name,
+    // v0: response_metadata nested under kwargs
+    run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.response_metadata?.model_name,
+    // LLMResult.llmOutput.model_name (common for Chat models)
+    llmOutput?.model_name,
+    llmOutput?.model,
+  ]
+    .map((v) => (v != null ? String(v).trim() : ""))
+    .find((v) => v.length > 0);
+}
+
+// Model - Helper kept for backwards compatibility (e.g. span naming). Prefers
+// the request model so the resolved request-side identifier is used, falling
+// back to the response model only when the request side is not available.
+export function getModel(run: Run): string | undefined {
+  return getRequestModel(run) ?? getResponseModel(run);
+}
+
+// Model - Set request and response model attributes on the span using only
+// LangChain-generic identifiers.
 export function setModelAttribute(run: Run, span: Span) {
-  const model = getModel(run);
-  if (model) span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, model);
+  const requestModel = getRequestModel(run);
+  const responseModel = getResponseModel(run);
+
+  if (requestModel) {
+    span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, requestModel);
+  } else if (responseModel) {
+    // Preserve prior behavior of always populating gen_ai.request.model when at
+    // least one model identifier is available, so spans aren't left without any
+    // model attribution when invocation params are missing.
+    span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, responseModel);
+  }
+
+  if (responseModel) {
+    span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, responseModel);
+  }
+}
+
+// Response identifier - Helper to extract the unique response id returned by
+// the underlying provider (e.g. OpenAI chat completion id). LangChain.js
+// typically surfaces this as the AIMessage id (top-level for v1, nested
+// under kwargs for v0) and some providers also include it under
+// response_metadata.id or on LLMResult.llmOutput.id.
+export function getResponseId(run: Run): string | undefined {
+  const message = run.outputs?.generations?.[0]?.[0]?.message as
+    | Record<string, unknown>
+    | undefined;
+  const messageKwargs = message?.kwargs as Record<string, unknown> | undefined;
+  const responseMetadata =
+    (message?.response_metadata as Record<string, unknown> | undefined) ??
+    (messageKwargs?.response_metadata as Record<string, unknown> | undefined);
+  const llmOutput = run.outputs?.llmOutput as Record<string, unknown> | undefined;
+  return [
+    // v1: AIMessage.id directly on the message
+    message?.id,
+    // v0: AIMessage.id nested under kwargs
+    messageKwargs?.id,
+    // Provider-supplied response id surfaced via response_metadata
+    responseMetadata?.id,
+    // LLMResult.llmOutput.id (some providers)
+    llmOutput?.id,
+  ]
+    .map((v) => (v != null ? String(v).trim() : ""))
+    .find((v) => v.length > 0);
+}
+
+// Response identifier - Set the gen_ai.response.id attribute on the span when
+// a provider-supplied response id is available on the run.
+export function setResponseIdAttribute(run: Run, span: Span): void {
+  const responseId = getResponseId(run);
+  if (responseId) {
+    span.setAttribute(ATTR_GEN_AI_RESPONSE_ID, responseId);
+  }
 }
 
 // Provider

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -481,19 +481,46 @@ export function getModel(run: Run): string | undefined {
   return getRequestModel(run) ?? getResponseModel(run);
 }
 
+// Detects whether a LangChain run originated from `AzureChatOpenAI`. We look at
+// the serialized constructor id array (e.g. ["langchain", "chat_models",
+// "azure_openai", "AzureChatOpenAI"]) which LangChain JS surfaces alongside
+// every callback run. Used to scope the AzureChatOpenAI-specific request model
+// workaround in `setModelAttribute`.
+function isAzureChatOpenAIRun(run: Run): boolean {
+  if (!run.serialized || typeof run.serialized !== "object" || Array.isArray(run.serialized)) {
+    return false;
+  }
+  const id = (run.serialized as Record<string, unknown>).id;
+  return Array.isArray(id) && id.some((segment) => segment === "AzureChatOpenAI");
+}
+
 // Model - Set request and response model attributes on the span using only
 // LangChain-generic identifiers.
+//
+// Note on request-model priority: for `AzureChatOpenAI` runs we deliberately
+// prefer the response-side model for `gen_ai.request.model`. LangChain JS does
+// not surface the configured deployment for `AzureChatOpenAI` through
+// `getLsParams()` or `invocationParams()` — `extra.metadata.ls_model_name`
+// falls back to the `BaseChatOpenAI` default of `"gpt-3.5-turbo"`, which would
+// otherwise be emitted as the request model regardless of what the caller
+// actually configured. The server-reported model (e.g.
+// `gpt-4o-mini-2024-07-18`) is a much closer approximation of the requested
+// model than that hardcoded default. See
+// https://github.com/langchain-ai/langchainjs/issues/10874.
+//
+// For all other clients (notably plain `ChatOpenAI` / Foundry deployments) the
+// request-side identifier is correct and is preferred so the deployment alias
+// or `model` kwarg is reported as `gen_ai.request.model`.
 export function setModelAttribute(run: Run, span: Span) {
   const requestModel = getRequestModel(run);
   const responseModel = getResponseModel(run);
 
-  if (requestModel) {
-    span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, requestModel);
-  } else if (responseModel) {
-    // Preserve prior behavior of always populating gen_ai.request.model when at
-    // least one model identifier is available, so spans aren't left without any
-    // model attribution when invocation params are missing.
-    span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, responseModel);
+  const effectiveRequestModel = isAzureChatOpenAIRun(run)
+    ? (responseModel ?? requestModel)
+    : (requestModel ?? responseModel);
+
+  if (effectiveRequestModel) {
+    span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, effectiveRequestModel);
   }
 
   if (responseModel) {

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -506,6 +506,13 @@ export function setModelAttribute(run: Run, span: Span) {
 // typically surfaces this as the AIMessage id (top-level for v1, nested
 // under kwargs for v0) and some providers also include it under
 // response_metadata.id or on LLMResult.llmOutput.id.
+//
+// Only primitive string / number values are accepted: in some LangChain
+// serialization paths an `id` field can be an array of class hierarchy names
+// (e.g. `["langchain", "schema", "messages", "AIMessage"]`) which must not be
+// emitted as a response id. Provider-supplied sources (`response_metadata.id`
+// and `llmOutput.id`) are checked first because they are unambiguously the
+// transport-level response identifier.
 export function getResponseId(run: Run): string | undefined {
   const message = run.outputs?.generations?.[0]?.[0]?.message as
     | Record<string, unknown>
@@ -515,18 +522,25 @@ export function getResponseId(run: Run): string | undefined {
     (message?.response_metadata as Record<string, unknown> | undefined) ??
     (messageKwargs?.response_metadata as Record<string, unknown> | undefined);
   const llmOutput = run.outputs?.llmOutput as Record<string, unknown> | undefined;
-  return [
-    // v1: AIMessage.id directly on the message
-    message?.id,
-    // v0: AIMessage.id nested under kwargs
-    messageKwargs?.id,
+  const candidates: unknown[] = [
     // Provider-supplied response id surfaced via response_metadata
     responseMetadata?.id,
     // LLMResult.llmOutput.id (some providers)
     llmOutput?.id,
-  ]
-    .map((v) => (v != null ? String(v).trim() : ""))
-    .find((v) => v.length > 0);
+    // v1: AIMessage.id directly on the message
+    message?.id,
+    // v0: AIMessage.id nested under kwargs
+    messageKwargs?.id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) return trimmed;
+    } else if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return String(candidate);
+    }
+  }
+  return undefined;
 }
 
 // Response identifier - Set the gen_ai.response.id attribute on the span when

--- a/src/genai/semconv.ts
+++ b/src/genai/semconv.ts
@@ -27,6 +27,7 @@ export const ATTR_ERROR_MESSAGE = "error.message" as const;
 export const ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name" as const;
 export const ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model" as const;
 export const ATTR_GEN_AI_RESPONSE_MODEL = "gen_ai.response.model" as const;
+export const ATTR_GEN_AI_RESPONSE_ID = "gen_ai.response.id" as const;
 export const ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name" as const;
 export const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions" as const;
 export const ATTR_GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages" as const;

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -481,9 +481,7 @@ describe("setModelAttribute", () => {
       "request model should use the server-reported model rather than the LangChain default",
     );
     assert.ok(
-      !calls.some(
-        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-3.5-turbo",
-      ),
+      !calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-3.5-turbo"),
       "request model must not fall back to the hardcoded ls_model_name default",
     );
   });

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -13,6 +13,7 @@ import {
   setOutputMessagesAttribute,
   setModelAttribute,
   setProviderNameAttribute,
+  setResponseIdAttribute,
   setSessionIdAttribute,
   setSystemInstructionsAttribute,
   setTokenAttributes,
@@ -25,6 +26,8 @@ import {
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
   ATTR_GEN_AI_TOOL_CALL_ID,
@@ -385,6 +388,117 @@ describe("setModelAttribute", () => {
     const span = makeSpan();
     const run = makeRun();
     setModelAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
+  it("populates both request and response model when response_metadata is the only source", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [{ message: { kwargs: { response_metadata: { model_name: "gpt-4o-2024-08-06" } } } }],
+        ],
+      },
+    });
+    setModelAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-4o-2024-08-06",
+      ),
+      "request model should fall back to response model when no request-side identifier exists",
+    );
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_MODEL && c[1] === "gpt-4o-2024-08-06",
+      ),
+      "response model should be set from response_metadata.model_name",
+    );
+  });
+
+  it("keeps request and response model separate when both are present", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      extra: { invocation_params: { model: "gpt-4o" } },
+      outputs: {
+        generations: [
+          [{ message: { kwargs: { response_metadata: { model_name: "gpt-4o-2024-08-06" } } } }],
+        ],
+      },
+    });
+    setModelAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-4o"),
+      "request model should come from invocation_params.model",
+    );
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_MODEL && c[1] === "gpt-4o-2024-08-06",
+      ),
+      "response model should come from response_metadata.model_name",
+    );
+  });
+
+  it("uses llmOutput.model_name as a response-model source", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { llmOutput: { model_name: "o4-mini-2025-04-16" } },
+    });
+    setModelAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_MODEL && c[1] === "o4-mini-2025-04-16",
+      ),
+    );
+  });
+});
+
+describe("setResponseIdAttribute", () => {
+  it("extracts response id from AIMessage.id (v1)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { generations: [[{ message: { id: "chatcmpl-abc123" } }]] },
+    });
+    setResponseIdAttribute(run, span);
+    assert.ok(
+      (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "chatcmpl-abc123",
+      ),
+    );
+  });
+
+  it("extracts response id from AIMessage kwargs.id (v0)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { generations: [[{ message: { kwargs: { id: "chatcmpl-xyz" } } }]] },
+    });
+    setResponseIdAttribute(run, span);
+    assert.ok(
+      (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "chatcmpl-xyz",
+      ),
+    );
+  });
+
+  it("extracts response id from llmOutput.id", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { llmOutput: { id: "resp-42" } },
+    });
+    setResponseIdAttribute(run, span);
+    assert.ok(
+      (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "resp-42",
+      ),
+    );
+  });
+
+  it("does nothing when no response id is found", () => {
+    const span = makeSpan();
+    const run = makeRun();
+    setResponseIdAttribute(run, span);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
   });
 });

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -495,6 +495,87 @@ describe("setResponseIdAttribute", () => {
     );
   });
 
+  it("extracts response id from response_metadata.id (v1, top-level)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [[{ message: { response_metadata: { id: "chatcmpl-meta-v1" } } }]],
+      },
+    });
+    setResponseIdAttribute(run, span);
+    assert.ok(
+      (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "chatcmpl-meta-v1",
+      ),
+    );
+  });
+
+  it("extracts response id from response_metadata.id nested under kwargs (v0)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [[{ message: { kwargs: { response_metadata: { id: "chatcmpl-meta-v0" } } } }]],
+      },
+    });
+    setResponseIdAttribute(run, span);
+    assert.ok(
+      (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "chatcmpl-meta-v0",
+      ),
+    );
+  });
+
+  it("prefers response_metadata.id over message.id when both are present", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                id: "ignored-message-id",
+                response_metadata: { id: "preferred-metadata-id" },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setResponseIdAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "preferred-metadata-id",
+      ),
+    );
+    assert.ok(
+      !calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_ID && c[1] === "ignored-message-id",
+      ),
+    );
+  });
+
+  it("ignores non-primitive AIMessage.id values (e.g. serialization class arrays)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                // LangChain Serializable.id is sometimes an array of class
+                // hierarchy names; it must not be emitted as a response id.
+                id: ["langchain", "schema", "messages", "AIMessage"],
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setResponseIdAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
   it("does nothing when no response id is found", () => {
     const span = makeSpan();
     const run = makeRun();

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -416,9 +416,16 @@ describe("setModelAttribute", () => {
     );
   });
 
-  it("keeps request and response model separate when both are present", () => {
+  it("prefers response model over request-side identifier for AzureChatOpenAI runs", () => {
+    // LangChain JS hardcodes ls_model_name to "gpt-3.5-turbo" for AzureChatOpenAI
+    // (https://github.com/langchain-ai/langchainjs/issues/10874), so for that
+    // client the server-reported model is a closer approximation of the
+    // requested model than the request-side identifier.
     const span = makeSpan();
     const run = makeRun({
+      serialized: {
+        id: ["langchain", "chat_models", "azure_openai", "AzureChatOpenAI"],
+      },
       extra: { invocation_params: { model: "gpt-4o" } },
       outputs: {
         generations: [
@@ -429,14 +436,100 @@ describe("setModelAttribute", () => {
     setModelAttribute(run, span);
     const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
     assert.ok(
-      calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-4o"),
-      "request model should come from invocation_params.model",
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-4o-2024-08-06",
+      ),
+      "request model should prefer the response-side identifier for AzureChatOpenAI",
     );
     assert.ok(
       calls.some(
         (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_MODEL && c[1] === "gpt-4o-2024-08-06",
       ),
       "response model should come from response_metadata.model_name",
+    );
+  });
+
+  it("avoids the AzureChatOpenAI ls_model_name=gpt-3.5-turbo regression", () => {
+    // Regression test: AzureChatOpenAI sets ls_model_name to the BaseChatOpenAI
+    // default ("gpt-3.5-turbo") regardless of the configured deployment. The
+    // response-side model_name carries the actual served model, which we should
+    // emit as gen_ai.request.model to avoid misattributing the request.
+    const span = makeSpan();
+    const run = makeRun({
+      serialized: {
+        id: ["langchain", "chat_models", "azure_openai", "AzureChatOpenAI"],
+      },
+      extra: { metadata: { ls_model_name: "gpt-3.5-turbo" } },
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                kwargs: { response_metadata: { model_name: "gpt-4o-mini-2024-07-18" } },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setModelAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-4o-mini-2024-07-18",
+      ),
+      "request model should use the server-reported model rather than the LangChain default",
+    );
+    assert.ok(
+      !calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "gpt-3.5-turbo",
+      ),
+      "request model must not fall back to the hardcoded ls_model_name default",
+    );
+  });
+
+  it("keeps request and response model separate for non-Azure clients (e.g. ChatOpenAI)", () => {
+    // For plain ChatOpenAI / Foundry deployments the request-side identifier
+    // (deployment alias or `model` kwarg) is correct and must be used as-is for
+    // gen_ai.request.model. Only AzureChatOpenAI needs the response-model
+    // workaround.
+    const span = makeSpan();
+    const run = makeRun({
+      serialized: {
+        id: ["langchain", "chat_models", "openai", "ChatOpenAI"],
+      },
+      extra: { invocation_params: { model: "deployment-o4-mini" } },
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                kwargs: { response_metadata: { model_name: "o4-mini-2025-04-16" } },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setModelAttribute(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "deployment-o4-mini",
+      ),
+      "request model should come from invocation_params.model for non-Azure clients",
+    );
+    assert.ok(
+      calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_RESPONSE_MODEL && c[1] === "o4-mini-2025-04-16",
+      ),
+      "response model should come from response_metadata.model_name",
+    );
+    assert.ok(
+      !calls.some(
+        (c: unknown[]) => c[0] === ATTR_GEN_AI_REQUEST_MODEL && c[1] === "o4-mini-2025-04-16",
+      ),
+      "non-Azure runs must not overwrite the request model with the response model",
     );
   });
 


### PR DESCRIPTION
Vendor-neutral fix for the LangChain GenAI instrumentation:

- Split getModel into getRequestModel (LangChain-set request-side fields: extra.metadata.ls_model_name, extra.invocation_params.{model,model_name}) and getResponseModel (server-reported: response_metadata.model_name v0/v1, llmOutput.{model_name,model}).

- setModelAttribute now writes gen_ai.response.model from response sources and gen_ai.request.model from request sources, falling back to the response model only when no request-side identifier is available so spans are not left without any model attribution.

- Add getResponseId/setResponseIdAttribute and emit gen_ai.response.id from AIMessage.id (v0+v1), response_metadata.id, or llmOutput.id.

- Wire setResponseIdAttribute into the LangChain tracer.

- Add ATTR_GEN_AI_RESPONSE_ID semconv constant.

Previously, LangChainTraceInstrumentor read LLMResult.llmOutput.model_name (the response model) into gen_ai.request.model, conflating the two attributes and never populating gen_ai.response.model or gen_ai.response.id.