### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,22 @@
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-11
+
+### Bugs Fixed
+- Fix `getCallerBaggagePairs` to resolve `userId` across all channels [#116](https://github.com/microsoft/opentelemetry-distro-javascript/pull/116)
+- Import OpenAI agent types from `@openai/agents` to avoid version drift [#122](https://github.com/microsoft/opentelemetry-distro-javascript/pull/122)
+
+### Other Changes
+- Accept beta versions of azure monitor exporter but not preview versions [#110](https://github.com/microsoft/opentelemetry-distro-javascript/pull/110)
+- Add explicit `enableConsoleExporters` to migration guide validation section [#121](https://github.com/microsoft/opentelemetry-distro-javascript/pull/121)
+- Promote A365 sub-owners in CODEOWNERS [#123](https://github.com/microsoft/opentelemetry-distro-javascript/pull/123)
+
+## [1.0.1] - 2026-05-01
+
 ### Other Changes
 - Lazy-load LangChain tracer to avoid eager import of `@langchain/core` before instrumentation hooks register. Removed noise when openai and langchain packages are not installed [#98](https://github.com/microsoft/opentelemetry-distro-javascript/pull/98)
-- Accept beta versions of azure monitor exporter but not preview versions [#110](https://github.com/microsoft/opentelemetry-distro-javascript/pull/110)
+- Add Fabric/ADX getting started guide and sample app [#100](https://github.com/microsoft/opentelemetry-distro-javascript/pull/100)
 
 ## [1.0.0] - 2026-04-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/opentelemetry",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/opentelemetry",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/opentelemetry",
   "author": "Microsoft Corporation",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microsoft OpenTelemetry distribution for JavaScript/TypeScript",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ import type { A365Options } from "./a365/index.js";
 /**
  * Microsoft OpenTelemetry distribution version.
  */
-export const MICROSOFT_OPENTELEMETRY_VERSION = "1.0.1";
+export const MICROSOFT_OPENTELEMETRY_VERSION = "1.0.2";
 
 /**
  * Microsoft OpenTelemetry Options


### PR DESCRIPTION
This pull request updates the package to version 1.0.2 and updates the changelog to reflect recent bug fixes and other changes. The main focus is on fixing issues with `getCallerBaggagePairs`, improving type imports for OpenAI agents, and updating documentation and ownership information.

### Version Updates

* Bump package version to `1.0.2` in `package.json` and `MICROSOFT_OPENTELEMETRY_VERSION` constant in `src/types.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL14-R14)

### Changelog and Documentation

* Add `1.0.2` release notes in `CHANGELOG.md`, including:
  - Fix for `getCallerBaggagePairs` resolving `userId` across all channels.
  - Import OpenAI agent types from `@openai/agents` to avoid version drift.
  - Add explicit `enableConsoleExporters` to migration guide validation section.
  - Promote A365 sub-owners in `CODEOWNERS`.
* Move previous `1.0.1` changes into their own section in `CHANGELOG.md`.