### PR TITLE
Update telemetry SDK name to microsoft-opentelemetry

### DIFF
--- a/src/a365/constants.ts
+++ b/src/a365/constants.ts
@@ -134,7 +134,7 @@ export class OpenTelemetryConstants {
   public static readonly TELEMETRY_SDK_NAME_KEY = "telemetry.sdk.name";
   public static readonly TELEMETRY_SDK_LANGUAGE_KEY = "telemetry.sdk.language";
   public static readonly TELEMETRY_SDK_VERSION_KEY = "telemetry.sdk.version";
-  public static readonly TELEMETRY_SDK_NAME_VALUE = "A365ObservabilitySDK";
+  public static readonly TELEMETRY_SDK_NAME_VALUE = "microsoft-opentelemetry";
   public static readonly TELEMETRY_SDK_LANGUAGE_VALUE = "nodejs";
   public static readonly TELEMETRY_SDK_VERSION_VALUE = MICROSOFT_OPENTELEMETRY_VERSION;
 }


### PR DESCRIPTION
Change `TELEMETRY_SDK_NAME_VALUE` from `A365ObservabilitySDK` to `microsoft-opentelemetry` to align with the package distribution name.

Sibling PRs:
- Python: https://github.com/microsoft/opentelemetry-distro-python/pull/138
- .NET: microsoft/opentelemetry-distro-dotnet (pending)