### PR TITLE
fix: correct repository URLs from Azure to microsoft org and add API docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/%40microsoft%2Fopentelemetry)](https://www.npmjs.com/package/@microsoft/opentelemetry)
 [![license](https://img.shields.io/npm/l/%40microsoft%2Fopentelemetry)](https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/LICENSE)
+[![API Docs](https://img.shields.io/badge/API%20Docs-TypeDoc-blue)](https://microsoft.github.io/opentelemetry-distro-javascript/)
 
 Microsoft OpenTelemetry distribution for Node.js — one import, one call, full observability across Azure Monitor, OTLP-compatible backends, and A365.
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Azure/opentelemetry-distro-javascript"
+    "url": "https://github.com/microsoft/opentelemetry-distro-javascript"
   },
   "keywords": [
     "node",

--- a/samples/README.md
+++ b/samples/README.md
@@ -78,17 +78,17 @@ Or pass the connection string directly:
 APPLICATIONINSIGHTS_CONNECTION_STRING="<your connection string>" node dist/basicConnection.js
 ```
 
-[basicconnection]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/basicConnection.ts
-[cloudrole]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/cloudRole.ts
-[custommetric]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/customMetric.ts
-[customtrace]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/customTrace.ts
-[livemetrics]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/liveMetrics.ts
-[offlinestorage]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/offlineStorage.ts
-[otlpexporter]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/otlpExporter.ts
-[redactquerystrings]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/redactQueryStrings.ts
-[sampling]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/sampling.ts
-[langchaininstrumentation]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/langchainInstrumentation.ts
-[openaiinstrumentation]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/openaiInstrumentation.ts
-[a365export]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/a365Export.ts
-[a365manualscopes]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/a365ManualScopes.ts
-[a365hostingmiddleware]: https://github.com/Azure/opentelemetry-distro-javascript/blob/main/samples/src/a365HostingMiddleware.ts
+[basicconnection]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/basicConnection.ts
+[cloudrole]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/cloudRole.ts
+[custommetric]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/customMetric.ts
+[customtrace]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/customTrace.ts
+[livemetrics]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/liveMetrics.ts
+[offlinestorage]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/offlineStorage.ts
+[otlpexporter]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/otlpExporter.ts
+[redactquerystrings]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/redactQueryStrings.ts
+[sampling]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/sampling.ts
+[langchaininstrumentation]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/langchainInstrumentation.ts
+[openaiinstrumentation]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/openaiInstrumentation.ts
+[a365export]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/a365Export.ts
+[a365manualscopes]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/a365ManualScopes.ts
+[a365hostingmiddleware]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/a365HostingMiddleware.ts

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Azure/opentelemetry-distro-javascript"
+    "url": "https://github.com/microsoft/opentelemetry-distro-javascript"
   },
   "author": "Microsoft Corporation",
   "license": "MIT",


### PR DESCRIPTION
The repository.url fields in package.json and samples/package.json pointed to github.com/Azure/ instead of github.com/microsoft/. Updated all 16 occurrences across package.json, samples/package.json, and samples/README.md. Also added an API Docs badge to the main README linking to the TypeDoc site at microsoft.github.io.