### PR TITLE
fix: respect Retry-After header on 429/503 responses in Agent365Exporter

### DIFF
--- a/src/a365/exporter/Agent365Exporter.ts
+++ b/src/a365/exporter/Agent365Exporter.ts
@@ -276,7 +276,10 @@ export class Agent365Exporter implements SpanExporter {
           (response.status >= 500 && response.status < 600)
         ) {
           if (attempt < DEFAULT_MAX_RETRIES) {
-            const sleepMs = 200 * (attempt + 1) + Math.floor(Math.random() * 100);
+            const defaultBackoffMs = 200 * (attempt + 1) + Math.floor(Math.random() * 100);
+            const retryAfterMs = parseRetryAfterMs(response.headers);
+            const sleepMs =
+              retryAfterMs !== null ? Math.max(retryAfterMs, defaultBackoffMs) : defaultBackoffMs;
             this.logger.warn(
               `[Agent365Exporter] Transient error ${response.status}, retrying after ${sleepMs}ms`,
             );
@@ -447,4 +450,32 @@ export class Agent365Exporter implements SpanExporter {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Parse the Retry-After header value into milliseconds.
+ * Supports both delay-seconds (e.g. "120") and HTTP-date formats (RFC 7231 §7.1.3).
+ * Returns null if the header is absent or unparseable.
+ */
+function parseRetryAfterMs(headers: Pick<Headers, "get">): number | null {
+  // fetch Headers.get() is case-insensitive, but Map.get() (used in tests) is not.
+  const value = headers.get("retry-after") ?? headers.get("Retry-After");
+  if (value == null) return null;
+
+  const trimmed = value.trim();
+
+  // Try numeric (delay-seconds)
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = parseInt(trimmed, 10);
+    return seconds * 1000;
+  }
+
+  // Try HTTP-date
+  const dateMs = Date.parse(trimmed);
+  if (!isNaN(dateMs)) {
+    const delayMs = dateMs - Date.now();
+    return delayMs > 0 ? delayMs : 0;
+  }
+
+  return null;
 }

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -745,6 +745,171 @@ describe("Agent365Exporter", () => {
       // DEFAULT_MAX_RETRIES = 3, so 1 initial + 3 retries = 4 total
       assert.strictEqual(fetchSpy.mock.calls.length, 4);
     });
+
+    it("should respect Retry-After header (seconds) on 429", async () => {
+      const sleepCalls: number[] = [];
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
+        if (ms && ms > 0) sleepCalls.push(ms);
+        // Execute immediately for test speed
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      let callCount = 0;
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            status: 429,
+            headers: new Map([
+              ["x-ms-correlation-id", "corr"],
+              ["retry-after", "5"],
+            ]),
+          });
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: new Map([["x-ms-correlation-id", "corr"]]),
+        });
+      });
+
+      const exporter = new Agent365Exporter({ tokenResolver: () => "tok" });
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(callCount, 2);
+      // Retry-After of 5s = 5000ms, which exceeds the default backoff (~200-300ms)
+      assert.ok(
+        sleepCalls.some((ms) => ms >= 5000),
+        `Expected a sleep >= 5000ms, got: ${sleepCalls}`,
+      );
+    });
+
+    it("should respect Retry-After header (seconds) on 503", async () => {
+      const sleepCalls: number[] = [];
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
+        if (ms && ms > 0) sleepCalls.push(ms);
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      let callCount = 0;
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            status: 503,
+            headers: new Map([
+              ["x-ms-correlation-id", "corr"],
+              ["retry-after", "10"],
+            ]),
+          });
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: new Map([["x-ms-correlation-id", "corr"]]),
+        });
+      });
+
+      const exporter = new Agent365Exporter({ tokenResolver: () => "tok" });
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(callCount, 2);
+      assert.ok(
+        sleepCalls.some((ms) => ms >= 10000),
+        `Expected a sleep >= 10000ms, got: ${sleepCalls}`,
+      );
+    });
+
+    it("should respect Retry-After header (HTTP-date format)", async () => {
+      // Pin Date.now() so the HTTP-date assertion is deterministic
+      const fakeNow = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(fakeNow);
+
+      const sleepCalls: number[] = [];
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
+        if (ms && ms > 0) sleepCalls.push(ms);
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      // Set Retry-After to 8 seconds from the pinned "now"
+      const futureDate = new Date(fakeNow + 8000).toUTCString();
+
+      let callCount = 0;
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            status: 429,
+            headers: new Map([
+              ["x-ms-correlation-id", "corr"],
+              ["retry-after", futureDate],
+            ]),
+          });
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: new Map([["x-ms-correlation-id", "corr"]]),
+        });
+      });
+
+      const exporter = new Agent365Exporter({ tokenResolver: () => "tok" });
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(callCount, 2);
+      // toUTCString() has second-level precision so parsed delay can be 7000-8000ms;
+      // verify it lands in the expected range rather than matching some unrelated default.
+      assert.ok(
+        sleepCalls.some((ms) => ms >= 7000 && ms <= 9000),
+        `Expected a sleep in 7000-9000ms range, got: ${sleepCalls}`,
+      );
+    });
+
+    it("should use default backoff when Retry-After header is absent", async () => {
+      const sleepCalls: number[] = [];
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
+        if (ms && ms > 0) sleepCalls.push(ms);
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      let callCount = 0;
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            status: 429,
+            headers: new Map([["x-ms-correlation-id", "corr"]]),
+          });
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: new Map([["x-ms-correlation-id", "corr"]]),
+        });
+      });
+
+      const exporter = new Agent365Exporter({ tokenResolver: () => "tok" });
+      const result = await new Promise<number>((resolve) => {
+        exporter.export([makeSpan()], (r) => resolve(r.code));
+      });
+
+      assert.strictEqual(result, ExportResultCode.SUCCESS);
+      assert.strictEqual(callCount, 2);
+      // Default backoff for attempt 0 is 200 * 1 + random(0-99) = 200-299ms
+      assert.ok(
+        sleepCalls.every((ms) => ms < 1000),
+        `Expected default backoff < 1000ms, got: ${sleepCalls}`,
+      );
+    });
   });
 });
 

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -748,12 +748,14 @@ describe("Agent365Exporter", () => {
 
     it("should respect Retry-After header (seconds) on 429", async () => {
       const sleepCalls: number[] = [];
-      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
-        if (ms && ms > 0) sleepCalls.push(ms);
-        // Execute immediately for test speed
-        fn();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(
+        (fn: (...args: unknown[]) => void, ms?: number) => {
+          if (ms && ms > 0) sleepCalls.push(ms);
+          // Execute immediately for test speed
+          fn();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        },
+      );
 
       let callCount = 0;
       fetchSpy.mockImplementation(() => {
@@ -789,11 +791,13 @@ describe("Agent365Exporter", () => {
 
     it("should respect Retry-After header (seconds) on 503", async () => {
       const sleepCalls: number[] = [];
-      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
-        if (ms && ms > 0) sleepCalls.push(ms);
-        fn();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(
+        (fn: (...args: unknown[]) => void, ms?: number) => {
+          if (ms && ms > 0) sleepCalls.push(ms);
+          fn();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        },
+      );
 
       let callCount = 0;
       fetchSpy.mockImplementation(() => {
@@ -832,11 +836,13 @@ describe("Agent365Exporter", () => {
       vi.spyOn(Date, "now").mockReturnValue(fakeNow);
 
       const sleepCalls: number[] = [];
-      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
-        if (ms && ms > 0) sleepCalls.push(ms);
-        fn();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(
+        (fn: (...args: unknown[]) => void, ms?: number) => {
+          if (ms && ms > 0) sleepCalls.push(ms);
+          fn();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        },
+      );
 
       // Set Retry-After to 8 seconds from the pinned "now"
       const futureDate = new Date(fakeNow + 8000).toUTCString();
@@ -876,11 +882,13 @@ describe("Agent365Exporter", () => {
 
     it("should use default backoff when Retry-After header is absent", async () => {
       const sleepCalls: number[] = [];
-      vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: Function, ms?: number) => {
-        if (ms && ms > 0) sleepCalls.push(ms);
-        fn();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(
+        (fn: (...args: unknown[]) => void, ms?: number) => {
+          if (ms && ms > 0) sleepCalls.push(ms);
+          fn();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        },
+      );
 
       let callCount = 0;
       fetchSpy.mockImplementation(() => {


### PR DESCRIPTION
The exporter's postWithRetries method used a fixed exponential backoff schedule regardless of server guidance, ignoring the Retry-After header on 429 (Too Many Requests) and 503 (Service Unavailable) responses. During throttling or overload, this caused the exporter to retry sooner than the server requested, worsening the overload condition and risking permanent client blocking.

Now the exporter parses the Retry-After header (both delay-seconds and HTTP-date formats per RFC 7231) and uses the server-requested delay as a minimum, falling back to the existing exponential backoff when the header is absent or unparseable.