### PR TITLE
Update message format to align with OTel spec

### DIFF
--- a/samples/src/a365ManualScopes.ts
+++ b/samples/src/a365ManualScopes.ts
@@ -136,7 +136,6 @@ async function callLLM(
 
     // LLM decided to call a tool
     scope.recordOutputMessages({
-      version: "0.1.0",
       messages: [
         {
           role: MessageRole.ASSISTANT,

--- a/src/a365/contracts.ts
+++ b/src/a365/contracts.ts
@@ -11,10 +11,11 @@
 import type { SpanKind, TimeInput, Link, Context, TraceState } from "@opentelemetry/api";
 
 // ---------------------------------------------------------------------------
-// Message schema version
+// Default finish reason (per OTel spec)
 // ---------------------------------------------------------------------------
 
-export const A365_MESSAGE_SCHEMA_VERSION = "0.1.0" as const;
+/** Default finish reason applied when none is provided (per OTel spec). */
+export const DEFAULT_FINISH_REASON = "stop" as const;
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -171,27 +172,26 @@ export interface ChatMessage {
   name?: string;
 }
 
-/** Versioned wrapper for input messages. */
 export interface InputMessages {
-  version: typeof A365_MESSAGE_SCHEMA_VERSION;
   messages: ChatMessage[];
 }
 
-/** An output message produced by a model (OTEL gen-ai semantic conventions). */
+/**
+ * An output message produced by a model (OTEL gen-ai semantic conventions).
+ * `finish_reason` defaults to `"stop"` per OTel spec when not provided.
+ */
 export interface OutputMessage extends ChatMessage {
   finish_reason?: FinishReason | string;
 }
 
-/** Versioned wrapper for output messages. */
 export interface OutputMessages {
-  version: typeof A365_MESSAGE_SCHEMA_VERSION;
   messages: OutputMessage[];
 }
 
-/** Accepted input for `recordInputMessages`. */
+/** Accepted input for `recordInputMessages`. Supports a single string, an array of strings (backward compat), or the structured wrapper. */
 export type InputMessagesParam = string | string[] | InputMessages;
 
-/** Accepted input for `recordOutputMessages`. */
+/** Accepted input for `recordOutputMessages`. Supports a single string, an array of strings (backward compat), or the structured wrapper. */
 export type OutputMessagesParam = string | string[] | OutputMessages;
 
 /** Accepted input for `OutputResponse.messages`. */

--- a/src/a365/exporter/utils.ts
+++ b/src/a365/exporter/utils.ts
@@ -17,8 +17,6 @@ import {
   GEN_AI_OPERATION_INVOKE_AGENT,
   GEN_AI_OPERATION_OUTPUT_MESSAGES,
 } from "../../genai/semconv.js";
-import { A365_MESSAGE_SCHEMA_VERSION } from "../contracts.js";
-
 // Message attribute keys that receive special truncation handling
 const MESSAGE_ATTR_KEYS: Set<string> = new Set([
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -198,23 +196,21 @@ function getSerializedSize(value: unknown): number {
 }
 
 /**
- * Build a versioned message wrapper indicating original messages were dropped.
+ * Build a sentinel message array indicating the original messages were dropped
+ * because the span exceeded the size limit.
  */
 function serializeOverflowSentinel(totalMessages: number): string {
-  return JSON.stringify({
-    version: A365_MESSAGE_SCHEMA_VERSION,
-    messages: [
-      {
-        role: MESSAGE_ROLE_SYSTEM,
-        parts: [
-          {
-            type: "text",
-            content: `[truncated: ${totalMessages} ${totalMessages === 1 ? "message" : "messages"} exceeded limit]`,
-          },
-        ],
-      },
-    ],
-  });
+  return JSON.stringify([
+    {
+      role: MESSAGE_ROLE_SYSTEM,
+      parts: [
+        {
+          type: "text",
+          content: `[truncated: ${totalMessages} ${totalMessages === 1 ? "message" : "messages"} exceeded limit]`,
+        },
+      ],
+    },
+  ]);
 }
 
 /**
@@ -265,10 +261,7 @@ function createBlobShrinkAction(
  */
 function collectShrinkActions(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<
-    string,
-    { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
-  >,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
 ): ShrinkAction[] {
   const actions: ShrinkAction[] = [];
 
@@ -279,8 +272,8 @@ function collectShrinkActions(
       if (!parsedMessages.has(key) && typeof attributes[key] === "string") {
         try {
           const parsed = JSON.parse(attributes[key] as string);
-          if (parsed && typeof parsed === "object" && Array.isArray(parsed.messages)) {
-            parsedMessages.set(key, parsed);
+          if (Array.isArray(parsed)) {
+            parsedMessages.set(key, { messages: parsed });
           }
         } catch {
           // Not valid JSON — will fall through to string trim
@@ -385,14 +378,11 @@ function collectShrinkActions(
 
 function flushParsedMessages(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<
-    string,
-    { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
-  >,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
 ): void {
   for (const [key, wrapper] of parsedMessages) {
     try {
-      attributes[key] = JSON.stringify(wrapper);
+      attributes[key] = JSON.stringify(wrapper.messages);
     } catch {
       // Leave the previous value intact
     }
@@ -401,16 +391,13 @@ function flushParsedMessages(
 
 function flushParsedMessage(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<
-    string,
-    { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
-  >,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
   key: string,
 ): void {
   const wrapper = parsedMessages.get(key);
   if (wrapper) {
     try {
-      attributes[key] = JSON.stringify(wrapper);
+      attributes[key] = JSON.stringify(wrapper.messages);
     } catch {
       // Leave the previous value intact
     }
@@ -420,10 +407,7 @@ function flushParsedMessage(
 function runShrinkPhase(
   span: OTLPSpanLike,
   attributes: Record<string, unknown>,
-  parsedMessages: Map<
-    string,
-    { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
-  >,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
   currentSize: number,
 ): number {
   let nextSize = currentSize;
@@ -588,7 +572,7 @@ export function truncateSpan<T extends OTLPSpanLike>(spanDict: T): T {
 
     const parsedMessages = new Map<
       string,
-      { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }
+      { messages: Array<{ parts: Array<Record<string, unknown>> }> }
     >();
 
     // Phase 1: iteratively shrink fields by size priority
@@ -614,8 +598,8 @@ export function truncateSpan<T extends OTLPSpanLike>(spanDict: T): T {
           } else if (typeof attributes[key] === "string") {
             try {
               const parsed = JSON.parse(attributes[key] as string);
-              if (parsed && Array.isArray(parsed.messages)) {
-                messageCount = parsed.messages.length;
+              if (Array.isArray(parsed)) {
+                messageCount = parsed.length;
               }
             } catch {
               /* not valid JSON */

--- a/src/a365/index.ts
+++ b/src/a365/index.ts
@@ -29,7 +29,7 @@ export {
   Modality,
   InvocationRole,
   InferenceOperationType,
-  A365_MESSAGE_SCHEMA_VERSION,
+  DEFAULT_FINISH_REASON,
 } from "./contracts.js";
 export type {
   ChatMessage,

--- a/src/a365/message-utils.ts
+++ b/src/a365/message-utils.ts
@@ -15,10 +15,10 @@ import type {
   InputMessagesParam,
   OutputMessagesParam,
 } from "./contracts.js";
-import { MessageRole, A365_MESSAGE_SCHEMA_VERSION } from "./contracts.js";
+import { MessageRole, DEFAULT_FINISH_REASON } from "./contracts.js";
 
 /**
- * Type guard that returns `true` when the input is a versioned wrapper
+ * Type guard that returns `true` when the input is a structured wrapper
  * object (`InputMessages` or `OutputMessages`).
  */
 export function isWrappedMessages(
@@ -28,8 +28,8 @@ export function isWrappedMessages(
     !Array.isArray(input) &&
     typeof input === "object" &&
     input !== null &&
-    "version" in input &&
-    "messages" in input
+    "messages" in input &&
+    Array.isArray((input as InputMessages).messages)
   );
 }
 
@@ -41,64 +41,67 @@ export function toInputMessages(messages: string[]): ChatMessage[] {
   }));
 }
 
-/** Converts plain output strings into OTEL output messages. */
+/**
+ * Converts plain output strings into OTEL output messages.
+ * `finish_reason` defaults to `"stop"` per OTel spec.
+ */
 export function toOutputMessages(messages: string[]): OutputMessage[] {
   return messages.map((content) => ({
     role: MessageRole.ASSISTANT,
     parts: [{ type: "text" as const, content }],
+    finish_reason: DEFAULT_FINISH_REASON,
   }));
 }
 
 /**
- * Normalizes an `InputMessagesParam` to a versioned `InputMessages` wrapper.
+ * Normalizes an `InputMessagesParam` to an `InputMessages` instance.
  * - `string` / `string[]` → converted to `ChatMessage[]` and wrapped
  * - `InputMessages` → returned as-is
  */
 export function normalizeInputMessages(param: InputMessagesParam): InputMessages {
   if (typeof param === "string" || Array.isArray(param)) {
     const arr = typeof param === "string" ? [param] : param;
-    return { version: A365_MESSAGE_SCHEMA_VERSION, messages: toInputMessages(arr) };
+    return { messages: toInputMessages(arr) };
   }
   return param;
 }
 
 /**
- * Normalizes an `OutputMessagesParam` to a versioned `OutputMessages` wrapper.
+ * Normalizes an `OutputMessagesParam` to an `OutputMessages` instance.
  * - `string` / `string[]` → converted to `OutputMessage[]` and wrapped
  * - `OutputMessages` → returned as-is
  */
 export function normalizeOutputMessages(param: OutputMessagesParam): OutputMessages {
   if (typeof param === "string" || Array.isArray(param)) {
     const arr = typeof param === "string" ? [param] : param;
-    return { version: A365_MESSAGE_SCHEMA_VERSION, messages: toOutputMessages(arr) };
+    return { messages: toOutputMessages(arr) };
   }
   return param;
 }
 
 /**
- * Serializes a versioned message wrapper to JSON.
+ * Serializes a message wrapper to JSON.
+ *
+ * The output is a plain JSON array per OTel gen-ai semantic conventions: `[{...}, ...]`.
  *
  * The try/catch ensures telemetry recording is non-throwing even when
  * message parts contain non-JSON-serializable values.
  */
 export function serializeMessages(wrapper: InputMessages | OutputMessages): string {
   try {
-    return JSON.stringify(wrapper);
+    return JSON.stringify(wrapper.messages);
   } catch {
-    return JSON.stringify({
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: [
-        {
-          role: MessageRole.SYSTEM,
-          parts: [
-            {
-              type: "text",
-              content: `[serialization failed: ${wrapper.messages.length} ${wrapper.messages.length === 1 ? "message" : "messages"}]`,
-            },
-          ],
-        },
-      ],
-    });
+    return JSON.stringify([
+      {
+        role: MessageRole.SYSTEM,
+        parts: [
+          {
+            type: "text",
+            content: `[serialization failed: ${wrapper.messages.length} ${wrapper.messages.length === 1 ? "message" : "messages"}]`,
+          },
+        ],
+      },
+    ]);
   }
 }
 

--- a/src/a365/scopes/OutputScope.ts
+++ b/src/a365/scopes/OutputScope.ts
@@ -9,11 +9,11 @@ import type {
   AgentDetails,
   UserDetails,
   OutputResponse,
+  OutputMessages,
   Request,
   SpanDetails,
   ResponseMessagesParam,
 } from "../contracts.js";
-import { A365_MESSAGE_SCHEMA_VERSION } from "../contracts.js";
 
 /**
  * Provides OpenTelemetry tracing scope for output message tracing.
@@ -96,8 +96,10 @@ export class OutputScope extends OpenTelemetryScope {
       return;
     }
     const normalized = normalizeOutputMessages(messages);
-    const wrapper = { version: A365_MESSAGE_SCHEMA_VERSION, messages: normalized.messages };
-    this.setTagMaybe(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(wrapper));
+    this.setTagMaybe(
+      OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
+      serializeMessages(normalized),
+    );
   }
 
   private _isRawDict(messages: ResponseMessagesParam): messages is Record<string, unknown> {
@@ -105,7 +107,7 @@ export class OutputScope extends OpenTelemetryScope {
       typeof messages === "object" &&
       messages !== null &&
       !Array.isArray(messages) &&
-      !("version" in messages && "messages" in messages)
+      !("messages" in messages && Array.isArray((messages as OutputMessages).messages))
     );
   }
 }

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -28,7 +28,7 @@ import {
   GEN_AI_OPERATION_INVOKE_AGENT,
 } from "../../index.js";
 import { serializeMessages, safeSerializeToJson } from "../../../a365/message-utils.js";
-import { MessageRole, A365_MESSAGE_SCHEMA_VERSION } from "../../../a365/contracts.js";
+import { MessageRole } from "../../../a365/contracts.js";
 import type {
   ChatMessage,
   OutputMessage,
@@ -144,10 +144,7 @@ export function setInputMessagesAttribute(run: Run, span: Span) {
   }
 
   if (chatMessages.length > 0) {
-    const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: chatMessages,
-    };
+    const wrapper: InputMessages = { messages: chatMessages };
     span.setAttribute(ATTR_GEN_AI_INPUT_MESSAGES, serializeMessages(wrapper));
   }
 }
@@ -432,10 +429,7 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
   }
 
   if (outputMessages.length > 0) {
-    const wrapper: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: outputMessages,
-    };
+    const wrapper: OutputMessages = { messages: outputMessages };
     span.setAttribute(ATTR_GEN_AI_OUTPUT_MESSAGES, serializeMessages(wrapper));
   }
 }

--- a/src/genai/instrumentations/openai/utils.ts
+++ b/src/genai/instrumentations/openai/utils.ts
@@ -16,7 +16,7 @@ import {
   GEN_AI_OPERATION_INVOKE_AGENT,
 } from "../../index.js";
 import { serializeMessages, safeSerializeToJson } from "../../../a365/message-utils.js";
-import { MessageRole, A365_MESSAGE_SCHEMA_VERSION } from "../../../a365/contracts.js";
+import { MessageRole, DEFAULT_FINISH_REASON } from "../../../a365/contracts.js";
 import type {
   ChatMessage,
   OutputMessage,
@@ -363,8 +363,13 @@ function getToolCallId(block: Record<string, unknown>): string | undefined {
 function wrapRawContentAsMessages(raw: unknown, role: MessageRole): InputMessages | OutputMessages {
   const content = typeof raw === "string" ? raw : safeJsonDumps(raw);
   return {
-    version: A365_MESSAGE_SCHEMA_VERSION,
-    messages: [{ role, parts: [{ type: "text", content }] }],
+    messages: [
+      {
+        role,
+        parts: [{ type: "text", content }],
+        finish_reason: role === MessageRole.ASSISTANT ? DEFAULT_FINISH_REASON : undefined,
+      },
+    ],
   };
 }
 
@@ -456,7 +461,7 @@ export function buildStructuredInputMessages(arr: OpenAIInputMessage[]): InputMe
     messages.push({ role, parts });
   }
 
-  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+  return { messages };
 }
 
 /**
@@ -491,7 +496,7 @@ export function buildStructuredOutputMessages(arr: OpenAIOutputItem[]): OutputMe
     });
   }
 
-  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+  return { messages };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export {
   Modality,
   InvocationRole,
   InferenceOperationType,
-  A365_MESSAGE_SCHEMA_VERSION,
+  DEFAULT_FINISH_REASON,
   isParentSpanRef,
   createContextWithParentSpanRef,
   runWithParentSpanRef,

--- a/test/internal/unit/a365/agent365Exporter.test.ts
+++ b/test/internal/unit/a365/agent365Exporter.test.ts
@@ -1229,18 +1229,15 @@ describe("Exporter utils", () => {
 
     it("should truncate blob parts in message attributes", () => {
       const blobContent = "b".repeat(MAX_SPAN_SIZE_BYTES);
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "user",
-            parts: [
-              { type: "blob", modality: "image", mime_type: "image/png", content: blobContent },
-              { type: "text", content: "Keep this text" },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "user",
+          parts: [
+            { type: "blob", modality: "image", mime_type: "image/png", content: blobContent },
+            { type: "text", content: "Keep this text" },
+          ],
+        },
+      ]);
       const span = {
         attributes: {
           "gen_ai.input.messages": messageWrapper,
@@ -1251,80 +1248,71 @@ describe("Exporter utils", () => {
       const size = Buffer.byteLength(JSON.stringify(result), "utf8");
       assert.ok(size <= MAX_SPAN_SIZE_BYTES);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.strictEqual(parsed.messages[0].parts[0].content, "[blob truncated]");
-      assert.strictEqual(parsed.messages[0].parts[1].content, "Keep this text");
+      assert.strictEqual(parsed[0].parts[0].content, "[blob truncated]");
+      assert.strictEqual(parsed[0].parts[1].content, "Keep this text");
       assert.strictEqual(result.attributes!["small_attr"], "keep me");
     });
 
     it("should shrink tool_call arguments with sentinel", () => {
       const largeArgs = { data: "x".repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "assistant",
-            parts: [
-              { type: "tool_call", name: "search", id: "call_1", arguments: largeArgs },
-              { type: "text", content: "short text" },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            { type: "tool_call", name: "search", id: "call_1", arguments: largeArgs },
+            { type: "text", content: "short text" },
+          ],
+        },
+      ]);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.strictEqual(parsed.messages[0].parts[0].arguments, "[truncated]");
-      assert.strictEqual(parsed.messages[0].parts[0].name, "search");
-      assert.strictEqual(parsed.messages[0].parts[1].content, "short text");
+      assert.strictEqual(parsed[0].parts[0].arguments, "[truncated]");
+      assert.strictEqual(parsed[0].parts[0].name, "search");
+      assert.strictEqual(parsed[0].parts[1].content, "short text");
     });
 
     it("should shrink tool_call_response response with sentinel", () => {
       const largeResponse = { data: "x".repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "tool",
-            parts: [
-              { type: "tool_call_response", id: "call_1", response: largeResponse },
-              { type: "text", content: "short text" },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "tool",
+          parts: [
+            { type: "tool_call_response", id: "call_1", response: largeResponse },
+            { type: "text", content: "short text" },
+          ],
+        },
+      ]);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.strictEqual(parsed.messages[0].parts[0].response, "[truncated]");
-      assert.strictEqual(parsed.messages[0].parts[0].id, "call_1");
-      assert.strictEqual(parsed.messages[0].parts[1].content, "short text");
+      assert.strictEqual(parsed[0].parts[0].response, "[truncated]");
+      assert.strictEqual(parsed[0].parts[0].id, "call_1");
+      assert.strictEqual(parsed[0].parts[1].content, "short text");
     });
 
     it("should shrink server_tool_call payload with sentinel", () => {
       const largePayload = { type: "web_search", query: "x".repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "assistant",
-            parts: [
-              {
-                type: "server_tool_call",
-                name: "web_search",
-                id: "stc_1",
-                server_tool_call: largePayload,
-              },
-              { type: "text", content: "keep me" },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "server_tool_call",
+              name: "web_search",
+              id: "stc_1",
+              server_tool_call: largePayload,
+            },
+            { type: "text", content: "keep me" },
+          ],
+        },
+      ]);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.strictEqual(parsed.messages[0].parts[0].server_tool_call, "[truncated]");
-      assert.strictEqual(parsed.messages[0].parts[0].name, "web_search");
-      assert.strictEqual(parsed.messages[0].parts[1].content, "keep me");
+      assert.strictEqual(parsed[0].parts[0].server_tool_call, "[truncated]");
+      assert.strictEqual(parsed[0].parts[0].name, "web_search");
+      assert.strictEqual(parsed[0].parts[1].content, "keep me");
     });
 
     it("should shrink server_tool_call_response payload with sentinel", () => {
@@ -1332,51 +1320,46 @@ describe("Exporter utils", () => {
         type: "web_search_result",
         results: "x".repeat(MAX_SPAN_SIZE_BYTES),
       };
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "tool",
-            parts: [
-              {
-                type: "server_tool_call_response",
-                id: "stc_1",
-                server_tool_call_response: largePayload,
-              },
-              { type: "text", content: "keep me" },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "tool",
+          parts: [
+            {
+              type: "server_tool_call_response",
+              id: "stc_1",
+              server_tool_call_response: largePayload,
+            },
+            { type: "text", content: "keep me" },
+          ],
+        },
+      ]);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.strictEqual(parsed.messages[0].parts[0].server_tool_call_response, "[truncated]");
-      assert.strictEqual(parsed.messages[0].parts[0].id, "stc_1");
-      assert.strictEqual(parsed.messages[0].parts[1].content, "keep me");
+      assert.strictEqual(parsed[0].parts[0].server_tool_call_response, "[truncated]");
+      assert.strictEqual(parsed[0].parts[0].id, "stc_1");
+      assert.strictEqual(parsed[0].parts[1].content, "keep me");
     });
 
     it("should trim text content in message attributes when oversized", () => {
       const largeText = "y".repeat(MAX_SPAN_SIZE_BYTES);
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: [{ type: "text", content: largeText }] }],
-      });
+      const messageWrapper = JSON.stringify([
+        { role: "user", parts: [{ type: "text", content: largeText }] },
+      ]);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.ok(parsed.messages[0].parts[0].content.includes("… [truncated]"));
-      assert.ok(parsed.messages[0].parts[0].content.length < largeText.length);
+      assert.ok(parsed[0].parts[0].content.includes("… [truncated]"));
+      assert.ok(parsed[0].parts[0].content.length < largeText.length);
       const spanSize = Buffer.byteLength(JSON.stringify(result), "utf8");
       assert.ok(spanSize <= MAX_SPAN_SIZE_BYTES);
     });
 
     it("should trim utf8 text content without splitting code points", () => {
       const largeEmojiText = "🙂".repeat(90 * 1024);
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: [{ type: "text", content: largeEmojiText }] }],
-      });
+      const messageWrapper = JSON.stringify([
+        { role: "user", parts: [{ type: "text", content: largeEmojiText }] },
+      ]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1392,7 +1375,7 @@ describe("Exporter utils", () => {
       };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      const trimmedContent = parsed.messages[0].parts[0].content as string;
+      const trimmedContent = parsed[0].parts[0].content as string;
       assert.ok(trimmedContent.includes("… [truncated]"));
       const prefix = trimmedContent.slice(0, -"… [truncated]".length);
       assert.ok(Array.from(prefix).every((cp: string) => cp === "🙂"));
@@ -1434,10 +1417,7 @@ describe("Exporter utils", () => {
         content: "x".repeat(blobSize),
       }));
       const textPart = { type: "text" as const, content: "y".repeat(1024) };
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: [...blobParts, textPart] }],
-      });
+      const messageWrapper = JSON.stringify([{ role: "user", parts: [...blobParts, textPart] }]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1452,7 +1432,7 @@ describe("Exporter utils", () => {
       const resultSize = Buffer.byteLength(JSON.stringify(result), "utf8");
       assert.ok(resultSize <= MAX_SPAN_SIZE_BYTES);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      const sentinelCount = parsed.messages[0].parts.filter(
+      const sentinelCount = parsed[0].parts.filter(
         (p: Record<string, unknown>) => p.type === "blob" && p.content === "[blob truncated]",
       ).length;
       assert.ok(sentinelCount > 0);
@@ -1466,10 +1446,7 @@ describe("Exporter utils", () => {
         { type: "text", content: "c".repeat(100 * 1024) },
         { type: "reasoning", content: "d".repeat(100 * 1024) },
       ];
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: regularParts }],
-      });
+      const messageWrapper = JSON.stringify([{ role: "user", parts: regularParts }]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1484,7 +1461,7 @@ describe("Exporter utils", () => {
       const resultSize = Buffer.byteLength(JSON.stringify(result), "utf8");
       assert.ok(resultSize <= MAX_SPAN_SIZE_BYTES);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      const truncatedCount = parsed.messages[0].parts.filter(
+      const truncatedCount = parsed[0].parts.filter(
         (part: Record<string, unknown>) =>
           typeof part.content === "string" && (part.content as string).includes("… [truncated]"),
       ).length;
@@ -1517,10 +1494,9 @@ describe("Exporter utils", () => {
 
     it("should only trim the excess bytes, preserving as much content as possible", () => {
       const textSize = MAX_SPAN_SIZE_BYTES + 5000;
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: [{ type: "text", content: "x".repeat(textSize) }] }],
-      });
+      const messageWrapper = JSON.stringify([
+        { role: "user", parts: [{ type: "text", content: "x".repeat(textSize) }] },
+      ]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1533,7 +1509,7 @@ describe("Exporter utils", () => {
       };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      const trimmedContent = parsed.messages[0].parts[0].content as string;
+      const trimmedContent = parsed[0].parts[0].content as string;
       assert.ok(trimmedContent.includes("… [truncated]"));
       const trimmedLength = Buffer.byteLength(trimmedContent, "utf8");
       assert.ok(trimmedLength > textSize * 0.9);
@@ -1543,18 +1519,15 @@ describe("Exporter utils", () => {
     it("should leave other fields untouched when trimming the largest is sufficient", () => {
       const largeContent = "L".repeat(300 * 1024);
       const mediumContent = "M".repeat(50 * 1024);
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "user",
-            parts: [
-              { type: "text", content: largeContent },
-              { type: "text", content: mediumContent },
-            ],
-          },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        {
+          role: "user",
+          parts: [
+            { type: "text", content: largeContent },
+            { type: "text", content: mediumContent },
+          ],
+        },
+      ]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1567,8 +1540,8 @@ describe("Exporter utils", () => {
       };
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      assert.ok((parsed.messages[0].parts[0].content as string).includes("… [truncated]"));
-      assert.strictEqual(parsed.messages[0].parts[1].content, mediumContent);
+      assert.ok((parsed[0].parts[0].content as string).includes("… [truncated]"));
+      assert.strictEqual(parsed[0].parts[1].content, mediumContent);
       assert.ok(Buffer.byteLength(JSON.stringify(result), "utf8") <= MAX_SPAN_SIZE_BYTES);
     });
 
@@ -1603,10 +1576,7 @@ describe("Exporter utils", () => {
         mime_type: "image/png",
         content: "x".repeat(blobSize),
       }));
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [{ role: "user", parts: blobParts }],
-      });
+      const messageWrapper = JSON.stringify([{ role: "user", parts: blobParts }]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1621,10 +1591,10 @@ describe("Exporter utils", () => {
       const resultSize = Buffer.byteLength(JSON.stringify(result), "utf8");
       assert.ok(resultSize <= MAX_SPAN_SIZE_BYTES);
       const parsed = JSON.parse(result.attributes!["gen_ai.input.messages"] as string);
-      const sentinelCount = parsed.messages[0].parts.filter(
+      const sentinelCount = parsed[0].parts.filter(
         (p: Record<string, unknown>) => p.content === "[blob truncated]",
       ).length;
-      const preservedCount = parsed.messages[0].parts.filter(
+      const preservedCount = parsed[0].parts.filter(
         (p: Record<string, unknown>) => p.content !== "[blob truncated]",
       ).length;
       assert.ok(sentinelCount > 0);
@@ -1633,14 +1603,11 @@ describe("Exporter utils", () => {
 
     it("should use structured overflow sentinel for message attributes in phase 2 fallback", () => {
       const hugeArray = new Array(100000).fill(42);
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          { role: "user", parts: [{ type: "text", content: "hello user" }] },
-          { role: "assistant", parts: [{ type: "text", content: "hello back" }] },
-          { role: "user", parts: [{ type: "text", content: "another msg" }] },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        { role: "user", parts: [{ type: "text", content: "hello user" }] },
+        { role: "assistant", parts: [{ type: "text", content: "hello back" }] },
+        { role: "user", parts: [{ type: "text", content: "another msg" }] },
+      ]);
       const span = {
         traceId: "00000000000000000000000000000001",
         spanId: "0000000000000002",
@@ -1657,11 +1624,11 @@ describe("Exporter utils", () => {
       const result = truncateSpan(span);
       const sentinelValue = result.attributes!["gen_ai.input.messages"] as string;
       const parsed = JSON.parse(sentinelValue);
-      assert.strictEqual(parsed.version, "0.1.0");
-      assert.strictEqual(parsed.messages.length, 1);
-      assert.strictEqual(parsed.messages[0].role, "system");
-      assert.strictEqual(parsed.messages[0].parts[0].type, "text");
-      assert.ok(parsed.messages[0].parts[0].content.includes("3 messages exceeded limit"));
+      assert.ok(Array.isArray(parsed));
+      assert.strictEqual(parsed.length, 1);
+      assert.strictEqual(parsed[0].role, "system");
+      assert.strictEqual(parsed[0].parts[0].type, "text");
+      assert.ok(parsed[0].parts[0].content.includes("3 messages exceeded limit"));
     });
 
     it("should truncate oversized raw dict in gen_ai.output.messages", () => {
@@ -1693,16 +1660,13 @@ describe("Exporter utils", () => {
       assert.strictEqual(result.attributes!["gen_ai.output.messages"], smallDict);
     });
 
-    it("should use message-aware shrinking for versioned wrapper in gen_ai.output.messages", () => {
-      const messageWrapper = JSON.stringify({
-        version: "1.0",
-        messages: [
-          {
-            role: "assistant",
-            parts: [{ type: "text", content: "z".repeat(200 * 1024) }],
-          },
-        ],
-      });
+    it("should use message-aware shrinking for array wrapper in gen_ai.output.messages", () => {
+      const messageWrapper = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "z".repeat(200 * 1024) }],
+        },
+      ]);
       const span = {
         attributes: {
           "gen_ai.output.messages": messageWrapper,
@@ -1713,9 +1677,9 @@ describe("Exporter utils", () => {
       const output = result.attributes!["gen_ai.output.messages"] as string;
       assert.notStrictEqual(output, "[overlimit]");
       const parsed = JSON.parse(output);
-      assert.strictEqual(parsed.version, "1.0");
-      assert.strictEqual(parsed.messages[0].parts[0].type, "text");
-      assert.ok(parsed.messages[0].parts[0].content.length < 200 * 1024);
+      assert.ok(Array.isArray(parsed));
+      assert.strictEqual(parsed[0].parts[0].type, "text");
+      assert.ok(parsed[0].parts[0].content.length < 200 * 1024);
       assert.ok(Buffer.byteLength(JSON.stringify(result), "utf8") <= MAX_SPAN_SIZE_BYTES);
     });
 
@@ -1724,7 +1688,7 @@ describe("Exporter utils", () => {
         role: "user",
         parts: [{ type: "text", content: "y".repeat(10000) }],
       }));
-      const messageWrapper = JSON.stringify({ version: "1.0", messages });
+      const messageWrapper = JSON.stringify(messages);
       const span = { attributes: { "gen_ai.input.messages": messageWrapper } };
       const result = truncateSpan(span);
       const size = Buffer.byteLength(JSON.stringify(result), "utf8");

--- a/test/internal/unit/a365/hosting/outputLoggingMiddleware.test.ts
+++ b/test/internal/unit/a365/hosting/outputLoggingMiddleware.test.ts
@@ -152,7 +152,7 @@ describe("OutputLoggingMiddleware", () => {
     const messages = outputSpan!.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY];
     expect(messages).toBeDefined();
     expect(typeof messages).toBe("string");
-    expect(JSON.parse(messages as string).messages[0].parts[0].content).toBe("Hi there!");
+    expect(JSON.parse(messages as string)[0].parts[0].content).toBe("Hi there!");
   });
 
   it("should skip non-message activities", async () => {

--- a/test/internal/unit/a365/messageUtils.test.ts
+++ b/test/internal/unit/a365/messageUtils.test.ts
@@ -3,11 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import {
-  MessageRole,
-  A365_MESSAGE_SCHEMA_VERSION,
-  Modality,
-} from "../../../../src/a365/contracts.js";
+import { MessageRole, Modality } from "../../../../src/a365/contracts.js";
 import type { InputMessages, OutputMessages } from "../../../../src/a365/contracts.js";
 import {
   isWrappedMessages,
@@ -21,7 +17,6 @@ import {
 describe("isWrappedMessages", () => {
   it("returns true for InputMessages wrapper", () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: "text", content: "hi" }] }],
     };
     expect(isWrappedMessages(wrapper)).toBe(true);
@@ -29,7 +24,6 @@ describe("isWrappedMessages", () => {
 
   it("returns true for OutputMessages wrapper", () => {
     const wrapper: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.ASSISTANT, parts: [{ type: "text", content: "hello" }] }],
     };
     expect(isWrappedMessages(wrapper)).toBe(true);
@@ -48,15 +42,11 @@ describe("isWrappedMessages", () => {
   });
 
   it("returns false for object missing messages property", () => {
-    expect(isWrappedMessages({ version: "0.1.0" } as unknown as any)).toBe(false);
-  });
-
-  it("returns false for object missing version property", () => {
-    expect(isWrappedMessages({ messages: [] } as unknown as any)).toBe(false);
-  });
-
-  it("returns false for arbitrary non-matching object", () => {
     expect(isWrappedMessages({ foo: "bar" } as unknown as any)).toBe(false);
+  });
+
+  it("returns false for object with non-array messages property", () => {
+    expect(isWrappedMessages({ messages: "not-an-array" } as unknown as any)).toBe(false);
   });
 });
 
@@ -81,11 +71,19 @@ describe("toInputMessages", () => {
 });
 
 describe("toOutputMessages", () => {
-  it("wraps strings as OutputMessage with role=assistant and TextPart", () => {
+  it("wraps strings as OutputMessage with role=assistant, TextPart, and default finish_reason", () => {
     const result = toOutputMessages(["response 1", "response 2"]);
     expect(result).toEqual([
-      { role: "assistant", parts: [{ type: "text", content: "response 1" }] },
-      { role: "assistant", parts: [{ type: "text", content: "response 2" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "response 1" }],
+        finish_reason: "stop",
+      },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "response 2" }],
+        finish_reason: "stop",
+      },
     ]);
   });
 
@@ -95,40 +93,62 @@ describe("toOutputMessages", () => {
 });
 
 describe("normalizeInputMessages", () => {
-  it("wraps string[] into versioned InputMessages", () => {
+  it("wraps string[] into InputMessages", () => {
     const result = normalizeInputMessages(["hello"]);
     expect(result).toEqual({
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: "user", parts: [{ type: "text", content: "hello" }] }],
     });
   });
 
   it("returns InputMessages wrapper as-is", () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.SYSTEM, parts: [{ type: "text", content: "system prompt" }] }],
     };
     expect(normalizeInputMessages(wrapper)).toBe(wrapper);
   });
 
-  it("wraps empty string[] into versioned wrapper with empty messages", () => {
+  it("wraps a single string into InputMessages", () => {
+    const result = normalizeInputMessages("hello");
+    expect(result).toEqual({
+      messages: [{ role: "user", parts: [{ type: "text", content: "hello" }] }],
+    });
+  });
+
+  it("wraps empty string[] into wrapper with empty messages", () => {
     const result = normalizeInputMessages([]);
-    expect(result).toEqual({ version: A365_MESSAGE_SCHEMA_VERSION, messages: [] });
+    expect(result).toEqual({ messages: [] });
   });
 });
 
 describe("normalizeOutputMessages", () => {
-  it("wraps string[] into versioned OutputMessages", () => {
+  it("wraps string[] into OutputMessages with default finish_reason", () => {
     const result = normalizeOutputMessages(["response"]);
     expect(result).toEqual({
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: [{ role: "assistant", parts: [{ type: "text", content: "response" }] }],
+      messages: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "response" }],
+          finish_reason: "stop",
+        },
+      ],
+    });
+  });
+
+  it("wraps a single string into OutputMessages with default finish_reason", () => {
+    const result = normalizeOutputMessages("response");
+    expect(result).toEqual({
+      messages: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "response" }],
+          finish_reason: "stop",
+        },
+      ],
     });
   });
 
   it("returns OutputMessages wrapper as-is", () => {
     const wrapper: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         {
           role: MessageRole.ASSISTANT,
@@ -142,40 +162,37 @@ describe("normalizeOutputMessages", () => {
 });
 
 describe("serializeMessages", () => {
-  it("returns JSON for versioned wrapper", () => {
+  it("returns JSON array for message wrapper", () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: "text", content: "hello" }] }],
     };
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages).toEqual(wrapper.messages);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual(wrapper.messages);
   });
 
-  it("serializes empty messages wrapper", () => {
-    const wrapper: InputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: [] };
+  it("serializes empty messages wrapper as empty array", () => {
+    const wrapper: InputMessages = { messages: [] };
     const parsed = JSON.parse(serializeMessages(wrapper));
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages).toEqual([]);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual([]);
   });
 
   it("serializes large messages without truncation", () => {
     const largeContent = "x".repeat(100_000);
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: "text", content: largeContent }] }],
     };
 
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.messages[0].parts[0].content).toBe(largeContent);
+    expect(parsed[0].parts[0].content).toBe(largeContent);
   });
 
   it("does not mutate the original messages", () => {
     const original = "z".repeat(50_000);
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: "text", content: original }] }],
     };
 
@@ -189,7 +206,6 @@ describe("serializeMessages", () => {
     circular.self = circular;
 
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         {
           role: MessageRole.TOOL,
@@ -200,14 +216,13 @@ describe("serializeMessages", () => {
 
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages[0].parts[0].content).toContain("serialization failed");
-    expect(parsed.messages[0].parts[0].content).toContain("1 message");
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].parts[0].content).toContain("serialization failed");
+    expect(parsed[0].parts[0].content).toContain("1 message");
   });
 
-  it("should serialize tool call request and response parts in wrapper", () => {
+  it("should serialize tool call request and response parts as plain array", () => {
     const messages: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         {
           role: MessageRole.ASSISTANT,
@@ -225,16 +240,15 @@ describe("serializeMessages", () => {
 
     const parsed = JSON.parse(serializeMessages(messages));
 
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages[0].parts[1].type).toBe("tool_call");
-    expect(parsed.messages[0].parts[1].arguments).toEqual({ query: "test" });
-    expect(parsed.messages[1].parts[0].type).toBe("tool_call_response");
-    expect(parsed.messages[1].parts[0].response).toEqual({ results: ["item1"] });
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].parts[1].type).toBe("tool_call");
+    expect(parsed[0].parts[1].arguments).toEqual({ query: "test" });
+    expect(parsed[1].parts[0].type).toBe("tool_call_response");
+    expect(parsed[1].parts[0].response).toEqual({ results: ["item1"] });
   });
 
   it("should serialize blob, file, and URI parts", () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         {
           role: MessageRole.USER,
@@ -259,15 +273,14 @@ describe("serializeMessages", () => {
 
     const parsed = JSON.parse(serializeMessages(wrapper));
 
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages[0].parts[0].modality).toBe("image");
-    expect(parsed.messages[0].parts[1].file_id).toBe("file-123");
-    expect(parsed.messages[0].parts[2].uri).toBe("https://example.com/audio.mp3");
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].parts[0].modality).toBe("image");
+    expect(parsed[0].parts[1].file_id).toBe("file-123");
+    expect(parsed[0].parts[2].uri).toBe("https://example.com/audio.mp3");
   });
 
   it("should serialize server tool call and generic parts", () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         {
           role: MessageRole.ASSISTANT,
@@ -299,9 +312,9 @@ describe("serializeMessages", () => {
 
     const parsed = JSON.parse(serializeMessages(wrapper));
 
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages[0].parts[0].server_tool_call.endpoint).toBe("/api");
-    expect(parsed.messages[1].parts[0].server_tool_call_response.status).toBe("ok");
-    expect(parsed.messages[2].parts[0].type).toBe("custom_annotation");
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].parts[0].server_tool_call.endpoint).toBe("/api");
+    expect(parsed[1].parts[0].server_tool_call_response.status).toBe("ok");
+    expect(parsed[2].parts[0].type).toBe("custom_annotation");
   });
 });

--- a/test/internal/unit/a365/scopes.test.ts
+++ b/test/internal/unit/a365/scopes.test.ts
@@ -25,7 +25,6 @@ import type {
   ToolCallDetails,
   InferenceDetails,
   UserDetails,
-  InputMessages,
   OutputResponse,
 } from "../../../../src/a365/index.js";
 import { InferenceOperationType, MessageRole } from "../../../../src/a365/index.js";

--- a/test/internal/unit/a365/scopes.test.ts
+++ b/test/internal/unit/a365/scopes.test.ts
@@ -28,11 +28,7 @@ import type {
   InputMessages,
   OutputResponse,
 } from "../../../../src/a365/index.js";
-import {
-  InferenceOperationType,
-  MessageRole,
-  A365_MESSAGE_SCHEMA_VERSION,
-} from "../../../../src/a365/index.js";
+import { InferenceOperationType, MessageRole } from "../../../../src/a365/index.js";
 import { safeSerializeToJson } from "../../../../src/a365/message-utils.js";
 
 let sharedExporter: InMemorySpanExporter;
@@ -1079,10 +1075,10 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.version).toBe("0.1.0");
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe("user");
-      expect(parsed.messages[0].parts[0]).toEqual({ type: "text", content: "Hello agent" });
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe("user");
+      expect(parsed[0].parts[0]).toEqual({ type: "text", content: "Hello agent" });
     });
 
     it("should record a string array as input message attributes", () => {
@@ -1097,14 +1093,14 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.messages).toHaveLength(2);
-      expect(parsed.messages[0].parts[0].content).toBe("msg1");
-      expect(parsed.messages[1].parts[0].content).toBe("msg2");
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].parts[0].content).toBe("msg1");
+      expect(parsed[1].parts[0].content).toBe("msg2");
     });
 
     it("should record a structured InputMessages wrapper as-is", () => {
-      const wrapper: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
+      const wrapper = {
         messages: [
           { role: MessageRole.SYSTEM, parts: [{ type: "text", content: "system prompt" }] },
         ],
@@ -1120,9 +1116,9 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.version).toBe("0.1.0");
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe("system");
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe("system");
     });
 
     it("should not set input messages when content is undefined", () => {
@@ -1144,9 +1140,11 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe("assistant");
-      expect(parsed.messages[0].parts[0].content).toBe("single output");
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe("assistant");
+      expect(parsed[0].parts[0].content).toBe("single output");
+      expect(parsed[0].finish_reason).toBe("stop");
     });
   });
 
@@ -1192,10 +1190,11 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe("assistant");
-      expect(parsed.messages[0].parts[0].content).toBe("Hello user");
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe("assistant");
+      expect(parsed[0].parts[0].content).toBe("Hello user");
+      expect(parsed[0].finish_reason).toBe("stop");
     });
 
     it("should allow overwriting output messages via recordOutputMessages", () => {
@@ -1208,7 +1207,7 @@ describe("Request content and message serialization (span attributes)", () => {
       const parsed = JSON.parse(
         attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
       );
-      expect(parsed.messages[0].parts[0].content).toBe("updated output");
+      expect(parsed[0].parts[0].content).toBe("updated output");
     });
 
     it("should handle raw dict as output messages", () => {

--- a/test/internal/unit/genai/openai/utils.test.ts
+++ b/test/internal/unit/genai/openai/utils.test.ts
@@ -244,7 +244,6 @@ describe("OpenAI Utils", () => {
     it("wraps input messages in structured format", () => {
       const messages = [{ role: "user", content: "Hello" }];
       const result = buildStructuredInputMessages(messages);
-      assert.ok(result.version);
       assert.ok(result.messages.length > 0);
     });
   });
@@ -255,7 +254,6 @@ describe("OpenAI Utils", () => {
         { role: "assistant", content: [{ type: "output_text", text: "Hello there!" }] },
       ];
       const result = buildStructuredOutputMessages(messages);
-      assert.ok(result.version);
       assert.ok(result.messages.length > 0);
     });
   });


### PR DESCRIPTION
## Summary
- Remove the versioned `{ version: "0.1.0", messages: [...] }` envelope from message serialization — messages now serialize as a plain JSON array `[...]` per OTel gen-ai semantic conventions
- Default `finish_reason` to `"stop"` on output messages created from plain strings via `toOutputMessages`/`normalizeOutputMessages`
- Tighten `isWrappedMessages` type guard with `Array.isArray` check to prevent false positives

Port of microsoft/Agent365-nodejs#256.

## Before / After — span attribute format

Captured from the `a365ManualScopes` sample agent flow (InvokeAgent → Inference → Tool → Inference → Output).

### Before (`gen_ai.input.messages`)
```json
{
  "version": "0.1.0",
  "messages": [
    { "role": "user", "parts": [{ "type": "text", "content": "You are a helpful weather assistant." }] },
    { "role": "user", "parts": [{ "type": "text", "content": "What's the weather in Seattle?" }] }
  ]
}
```

### After (`gen_ai.input.messages`)
```json
[
  { "role": "user", "parts": [{ "type": "text", "content": "You are a helpful weather assistant." }] },
  { "role": "user", "parts": [{ "type": "text", "content": "What's the weather in Seattle?" }] }
]
```

### Before (`gen_ai.output.messages` — plain string input)
```json
{
  "version": "0.1.0",
  "messages": [
    { "role": "assistant", "parts": [{ "type": "text", "content": "It's currently 62°F and partly cloudy in Seattle." }] }
  ]
}
```

### After (`gen_ai.output.messages` — plain string input)
```json
[
  {
    "role": "assistant",
    "parts": [{ "type": "text", "content": "It's currently 62°F and partly cloudy in Seattle." }],
    "finish_reason": "stop"
  }
]
```

### After (`gen_ai.output.messages` — structured with tool call)
```json
[
  {
    "role": "assistant",
    "parts": [
      { "type": "text", "content": "Let me check the weather." },
      { "type": "tool_call", "name": "getWeather", "id": "call_1", "arguments": { "city": "Seattle" } }
    ],
    "finish_reason": "tool_call"
  }
]
```

## Test plan
- [x] All 858 unit tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Prettier + ESLint clean
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)