### PR TITLE
feat(genai): add main agent attribution propagation

### DIFF
--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -34,6 +34,10 @@ import {
 import { isOtlpEnabled, createOtlpComponents } from "../otlp/index.js";
 import { A365Configuration, Agent365Exporter, A365SpanProcessor } from "../a365/index.js";
 import { configureA365Logger } from "../a365/logging.js";
+import {
+  GenAIMainAgentLogRecordProcessor,
+  GenAIMainAgentSpanProcessor,
+} from "../genai/mainAgent/index.js";
 import { SdkStatsDistroFeature, SdkStatsManager, setSdkStatsFeature } from "../sdkstats/index.js";
 import type {
   MicrosoftOpenTelemetryOptions,
@@ -264,6 +268,18 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const spanProcessors: SpanProcessor[] = [...(options?.spanProcessors || [])];
   const logRecordProcessors: LogRecordProcessor[] = [...(options?.logRecordProcessors || [])];
   const customViews: ViewOptions[] = [...(options?.views || [])];
+
+  // ── GenAI main-agent propagation ─────────────────────────────────
+  // Prepend the main-agent processors so their on_start / on_emit run
+  // BEFORE any Batch* export processor appended later in the pipeline.
+  // This enriches each span/log once and the enriched attributes are
+  // then visible to Azure Monitor (and any other downstream exporter).
+  // Mirrors microsoft/opentelemetry-distro-python which gates these
+  // processors on `enable_azure_monitor`.
+  if (azureMonitorEnabled) {
+    spanProcessors.unshift(new GenAIMainAgentSpanProcessor());
+    logRecordProcessors.unshift(new GenAIMainAgentLogRecordProcessor());
+  }
 
   const metricReaders: MetricReader[] = [
     ...(metricHandler ? [metricHandler.getMetricReader()] : []),

--- a/src/genai/index.ts
+++ b/src/genai/index.ts
@@ -11,4 +11,3 @@ export {
   GenAIMainAgentLogRecordProcessor,
   GenAIMainAgentSpanProcessor,
 } from "./mainAgent/index.js";
-

--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -88,10 +88,13 @@ export class LangChainTracer extends BaseTracer {
       return;
     }
 
-    // Attach to parent span if one exists in the run hierarchy
-    const parentCtx = this.getNearestParentSpanContext(run);
-    const activeContext = parentCtx
-      ? trace.setSpanContext(context.active(), parentCtx)
+    // Attach to parent span if one exists in the run hierarchy. We put the
+    // actual parent Span (not just its SpanContext) into the context so that
+    // span processors observing on_start of this span (e.g.
+    // GenAIMainAgentSpanProcessor) can read attributes off the parent.
+    const parentSpan = this.getNearestParentSpan(run);
+    const activeContext = parentSpan
+      ? trace.setSpan(context.active(), parentSpan)
       : context.active();
 
     // Build span name: "<operation> <name|model>"
@@ -124,6 +127,21 @@ export class LangChainTracer extends BaseTracer {
       },
       activeContext,
     );
+
+    // Set identity attributes (operation, agent, session/conversation) BEFORE
+    // any child run starts, so that span processors observing on_start of
+    // child spans (e.g. GenAIMainAgentSpanProcessor) can read them from this
+    // parent span. Output/usage/model attributes are still set at end time
+    // because their values are not known yet.
+    try {
+      Utils.setOperationTypeAttribute(operation, span);
+      Utils.setAgentAttributes(run, span);
+      Utils.setSessionIdAttribute(run, span);
+    } catch (error) {
+      diag.debug(
+        `[LangChainTracer] Failed to set start-time attributes for run ${run.name}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
 
     this.runs.set(run.id, { run, span, startTime, lastAccessTime: startTime });
   }
@@ -178,7 +196,11 @@ export class LangChainTracer extends BaseTracer {
         span.setStatus({ code: SpanStatusCode.OK });
       }
 
-      // Always-on attributes: operation type, agent info, model, provider, session, tokens
+      // Always-on attributes: operation type, agent info, model, provider, session, tokens.
+      // Operation/agent/session are also set at span start so that
+      // GenAIMainAgentSpanProcessor.onStart sees them on child spans; setting
+      // them again here is idempotent and guarantees end-time corrections
+      // (e.g. metadata that only becomes available mid-run) still land.
       Utils.setOperationTypeAttribute(operation, span);
       Utils.setAgentAttributes(run, span);
       if (operation === "invoke_agent") {
@@ -213,15 +235,15 @@ export class LangChainTracer extends BaseTracer {
 
   /**
    * Walks up the parent run chain to find the nearest ancestor that has an
-   * active span, returning its `SpanContext` so the new span can be linked
-   * as a child.
+   * active span, returning that Span so the new span can be linked as a
+   * child and processors can read parent attributes.
    */
-  private getNearestParentSpanContext(run: Run) {
+  private getNearestParentSpan(run: Run) {
     let pid = run.parent_run_id;
 
     while (pid) {
       const entry = this.runs.get(pid);
-      if (entry) return entry.span.spanContext();
+      if (entry) return entry.span;
       pid = this.parentByRunId.get(pid);
     }
     return undefined;

--- a/src/genai/mainAgent/constants.ts
+++ b/src/genai/mainAgent/constants.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Constants for the GenAI "main agent" propagation feature.
+ *
+ * Target attribute keys written by {@link GenAIMainAgentSpanProcessor} and
+ * {@link GenAIMainAgentLogRecordProcessor} so that downstream telemetry
+ * (spans + logs) is attributed to the user-facing ("main") agent rather
+ * than internal sub-agents in a multi-agent system.
+ *
+ * Mirrors `microsoft/opentelemetry-distro-python`.
+ */
+
+export const GEN_AI_MAIN_AGENT_NAME_KEY = "microsoft.gen_ai.main_agent.name" as const;
+export const GEN_AI_MAIN_AGENT_ID_KEY = "microsoft.gen_ai.main_agent.id" as const;
+export const GEN_AI_MAIN_AGENT_VERSION_KEY = "microsoft.gen_ai.main_agent.version" as const;
+export const GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY =
+  "microsoft.gen_ai.main_agent.conversation_id" as const;
+export const GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX = "microsoft.gen_ai.main_agent." as const;

--- a/src/genai/mainAgent/index.ts
+++ b/src/genai/mainAgent/index.ts
@@ -8,7 +8,4 @@ export {
   GEN_AI_MAIN_AGENT_NAME_KEY,
   GEN_AI_MAIN_AGENT_VERSION_KEY,
 } from "./constants.js";
-export {
-  GenAIMainAgentLogRecordProcessor,
-  GenAIMainAgentSpanProcessor,
-} from "./processor.js";
+export { GenAIMainAgentLogRecordProcessor, GenAIMainAgentSpanProcessor } from "./processor.js";

--- a/src/genai/mainAgent/index.ts
+++ b/src/genai/mainAgent/index.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export * from "./semconv.js";
 export {
   GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX,
   GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
   GEN_AI_MAIN_AGENT_ID_KEY,
   GEN_AI_MAIN_AGENT_NAME_KEY,
   GEN_AI_MAIN_AGENT_VERSION_KEY,
+} from "./constants.js";
+export {
   GenAIMainAgentLogRecordProcessor,
   GenAIMainAgentSpanProcessor,
-} from "./mainAgent/index.js";
-
+} from "./processor.js";

--- a/src/genai/mainAgent/processor.ts
+++ b/src/genai/mainAgent/processor.ts
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Span and log-record processors that propagate
+ * `microsoft.gen_ai.main_agent.*` attributes from the top-level (user-facing)
+ * GenAI agent so that all downstream telemetry is attributed to the main
+ * agent rather than internal sub-agents in a multi-agent system.
+ *
+ * Mirrors `microsoft/opentelemetry-distro-python`
+ * (`src/microsoft/opentelemetry/_genai/main_agent/_processor.py`).
+ */
+
+import type { Context, Span } from "@opentelemetry/api";
+import { isSpanContextValid, trace } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  SpanProcessor as BaseSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import type { LogRecordProcessor, SdkLogRecord } from "@opentelemetry/sdk-logs";
+import {
+  ATTR_GEN_AI_AGENT_ID,
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  GEN_AI_OPERATION_INVOKE_AGENT,
+} from "../semconv.js";
+import {
+  GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX,
+  GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
+  GEN_AI_MAIN_AGENT_ID_KEY,
+  GEN_AI_MAIN_AGENT_NAME_KEY,
+  GEN_AI_MAIN_AGENT_VERSION_KEY,
+} from "./constants.js";
+
+// `gen_ai.agent.version` is not exported by ./semconv.ts; declare locally
+// to keep parity with the Python processor's fallback table.
+const ATTR_GEN_AI_AGENT_VERSION = "gen_ai.agent.version" as const;
+
+/**
+ * Each row: [target attribute on current span,
+ *            primary source attribute on parent span,
+ *            fallback source attribute on parent span].
+ */
+const PROPAGATION_TABLE: ReadonlyArray<readonly [string, string, string]> = [
+  [GEN_AI_MAIN_AGENT_NAME_KEY, GEN_AI_MAIN_AGENT_NAME_KEY, ATTR_GEN_AI_AGENT_NAME],
+  [GEN_AI_MAIN_AGENT_ID_KEY, GEN_AI_MAIN_AGENT_ID_KEY, ATTR_GEN_AI_AGENT_ID],
+  [GEN_AI_MAIN_AGENT_VERSION_KEY, GEN_AI_MAIN_AGENT_VERSION_KEY, ATTR_GEN_AI_AGENT_VERSION],
+  [
+    GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
+    GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
+    ATTR_GEN_AI_CONVERSATION_ID,
+  ],
+];
+
+/** Used at `onEnd` for the self-copy fallback on the top-level `invoke_agent`. */
+const SELF_COPY_TABLE: ReadonlyArray<readonly [string, string]> = PROPAGATION_TABLE.map(
+  ([target, _primary, fallback]) => [target, fallback] as const,
+);
+
+interface ReadableSpanLike {
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Propagates `microsoft.gen_ai.main_agent.*` attributes onto spans.
+ *
+ * - `onStart`: copies main-agent attributes from the parent span (or falls
+ *   back to the parent's `gen_ai.agent.*` / `gen_ai.conversation.id`
+ *   attributes) onto the new span.
+ * - `onEnd`: when the span is itself an `invoke_agent` operation and has not
+ *   already been enriched, copies its own `gen_ai.agent.*` /
+ *   `gen_ai.conversation.id` attributes onto `microsoft.gen_ai.main_agent.*`
+ *   so the top-level agent identifies itself as the main agent.
+ */
+export class GenAIMainAgentSpanProcessor implements BaseSpanProcessor {
+  onStart(span: Span, parentContext: Context): void {
+    const parent = trace.getSpan(parentContext);
+    if (!parent || !isSpanContextValid(parent.spanContext())) {
+      return;
+    }
+
+    const parentAttributes = (parent as unknown as ReadableSpanLike).attributes ?? {};
+    for (const [target, primary, fallback] of PROPAGATION_TABLE) {
+      const value = parentAttributes[primary] ?? parentAttributes[fallback];
+      if (value !== undefined && value !== null) {
+        span.setAttribute(target, value as never);
+      }
+    }
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const attributes = span.attributes;
+    if (!attributes || attributes[ATTR_GEN_AI_OPERATION_NAME] !== GEN_AI_OPERATION_INVOKE_AGENT) {
+      return;
+    }
+
+    for (const key of Object.keys(attributes)) {
+      if (key.startsWith(GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX)) {
+        return;
+      }
+    }
+
+    // The span has already ended by the time onEnd fires, so `setAttribute`
+    // is a no-op. Mutate the underlying attributes map directly, which is
+    // what downstream exporters read.
+    const mutable = attributes as Record<string, unknown>;
+    for (const [target, source] of SELF_COPY_TABLE) {
+      const value = attributes[source];
+      if (value !== undefined && value !== null) {
+        mutable[target] = value;
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    // no-op
+  }
+
+  async forceFlush(): Promise<void> {
+    // no-op
+  }
+}
+
+interface LogRecordAttributesLike {
+  attributes?: Record<string, unknown> | null;
+  setAttribute?: (key: string, value: unknown) => unknown;
+}
+
+/**
+ * Copies any `microsoft.gen_ai.main_agent.*` attributes from the current
+ * span onto every emitted log record.
+ */
+export class GenAIMainAgentLogRecordProcessor implements LogRecordProcessor {
+  onEmit(logRecord: SdkLogRecord, contextArg?: Context): void {
+    const span = contextArg ? trace.getSpan(contextArg) : trace.getActiveSpan();
+    if (!span || !isSpanContextValid(span.spanContext())) {
+      return;
+    }
+
+    const spanAttributes = (span as unknown as ReadableSpanLike).attributes ?? {};
+    const target = logRecord as unknown as LogRecordAttributesLike;
+
+    let setAttribute: ((key: string, value: unknown) => unknown) | undefined;
+    if (typeof target.setAttribute === "function") {
+      setAttribute = target.setAttribute.bind(target);
+    } else {
+      if (!target.attributes) {
+        target.attributes = {};
+      }
+      const attrsBag = target.attributes;
+      setAttribute = (key: string, value: unknown) => {
+        attrsBag[key] = value;
+        return undefined;
+      };
+    }
+
+    for (const [key, value] of Object.entries(spanAttributes)) {
+      if (
+        key.startsWith(GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX) &&
+        value !== undefined &&
+        value !== null
+      ) {
+        setAttribute(key, value);
+      }
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    // no-op
+  }
+
+  async shutdown(): Promise<void> {
+    // no-op
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,14 @@ export type {
 
 // ── Re-exports from types ───────────────────────────────────────────────────
 export type { OpenAIAgentsInstrumentationConfig, LangChainInstrumentationConfig } from "./types.js";
+
+// ── Re-exports from GenAI main-agent propagation ────────────────────────────
+export {
+  GEN_AI_MAIN_AGENT_ATTRIBUTE_PREFIX,
+  GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
+  GEN_AI_MAIN_AGENT_ID_KEY,
+  GEN_AI_MAIN_AGENT_NAME_KEY,
+  GEN_AI_MAIN_AGENT_VERSION_KEY,
+  GenAIMainAgentLogRecordProcessor,
+  GenAIMainAgentSpanProcessor,
+} from "./genai/mainAgent/index.js";

--- a/test/internal/unit/genai/langchain/mainAgentPropagation.test.ts
+++ b/test/internal/unit/genai/langchain/mainAgentPropagation.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * End-to-end test that the LangChain tracer sets agent identity attributes on
+ * the `invoke_agent` span BEFORE any child runs start, so that
+ * GenAIMainAgentSpanProcessor.onStart can read them from the parent and
+ * propagate them onto child `chat`/`execute_tool` spans.
+ *
+ * Mirrors microsoft/opentelemetry-distro-python PR #171
+ * (tests/langchain/test_main_agent_propagation.py).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import type { Run } from "@langchain/core/tracers/base";
+
+import { LangChainTracer } from "../../../../../src/genai/instrumentations/langchain/tracer.js";
+import {
+  GEN_AI_MAIN_AGENT_NAME_KEY,
+  GenAIMainAgentSpanProcessor,
+} from "../../../../../src/genai/mainAgent/index.js";
+import { ATTR_GEN_AI_AGENT_NAME } from "../../../../../src/genai/semconv.js";
+
+function makeAgentRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: `agent-${Math.random().toString(36).slice(2, 8)}`,
+    name: "MyAgent",
+    run_type: "chain",
+    start_time: Date.now(),
+    end_time: Date.now() + 100,
+    serialized: {
+      id: ["langchain", "langgraph", "pregel", "CompiledStateGraph"],
+    },
+    inputs: {},
+    outputs: {},
+    execution_order: 1,
+    child_execution_order: 1,
+    child_runs: [],
+    tags: [],
+    events: [],
+    ...overrides,
+  } as unknown as Run;
+}
+
+function makeChatRun(parentId: string, overrides: Partial<Run> = {}): Run {
+  return {
+    id: `chat-${Math.random().toString(36).slice(2, 8)}`,
+    name: "gpt-4o",
+    run_type: "llm",
+    parent_run_id: parentId,
+    start_time: Date.now(),
+    end_time: Date.now() + 100,
+    serialized: {},
+    inputs: {},
+    outputs: {},
+    execution_order: 2,
+    child_execution_order: 2,
+    child_runs: [],
+    tags: [],
+    events: [],
+    ...overrides,
+  } as unknown as Run;
+}
+
+describe("LangChainTracer × GenAIMainAgentSpanProcessor propagation", () => {
+  let provider: BasicTracerProvider;
+  let memoryExporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    memoryExporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new GenAIMainAgentSpanProcessor(), new SimpleSpanProcessor(memoryExporter)],
+    });
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+  });
+
+  it("sets gen_ai.agent.name on invoke_agent span at start so child chat span inherits microsoft.gen_ai.main_agent.name", async () => {
+    const tracer = provider.getTracer("langchain-test");
+    const lct = new LangChainTracer(tracer);
+
+    // 1) Start the agent run (this opens the invoke_agent span and must set
+    //    gen_ai.agent.name BEFORE any child runs start).
+    const agentRun = makeAgentRun({ name: "MyAgent" });
+    await lct.onRunCreate(agentRun);
+
+    // 2) While the agent run is still open, start a child chat run. The
+    //    GenAIMainAgentSpanProcessor.onStart for this span runs *now*, and
+    //    must see gen_ai.agent.name on the parent span attributes.
+    const chatRun = makeChatRun(agentRun.id, { name: "gpt-4o" });
+    await lct.onRunCreate(chatRun);
+
+    // 3) End both runs.
+    // _endTrace is protected; cast to invoke for test purposes.
+    await (lct as unknown as { _endTrace: (r: Run) => Promise<void> })._endTrace(chatRun);
+    await (lct as unknown as { _endTrace: (r: Run) => Promise<void> })._endTrace(agentRun);
+
+    const finished = memoryExporter.getFinishedSpans();
+    const chatSpan = finished.find((s) => s.name.startsWith("chat"));
+    const agentSpan = finished.find((s) => s.name.startsWith("invoke_agent"));
+    expect(agentSpan, "invoke_agent span should be exported").toBeDefined();
+    expect(chatSpan, "chat span should be exported").toBeDefined();
+
+    // The parent invoke_agent span must end up with the agent name set.
+    expect(agentSpan!.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe("MyAgent");
+
+    // Critical: the child chat span must have inherited the main-agent name
+    // via the GenAIMainAgentSpanProcessor at on_start time. If the LangChain
+    // tracer set gen_ai.agent.name only at _endTrace, this would be undefined.
+    expect(chatSpan!.attributes[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("MyAgent");
+  });
+});

--- a/test/internal/unit/genai/mainAgent/processor.test.ts
+++ b/test/internal/unit/genai/mainAgent/processor.test.ts
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { context, SpanKind, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { logs as logsApi } from "@opentelemetry/api-logs";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from "@opentelemetry/sdk-logs";
+
+import {
+  GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY,
+  GEN_AI_MAIN_AGENT_ID_KEY,
+  GEN_AI_MAIN_AGENT_NAME_KEY,
+  GEN_AI_MAIN_AGENT_VERSION_KEY,
+  GenAIMainAgentLogRecordProcessor,
+  GenAIMainAgentSpanProcessor,
+} from "../../../../../src/genai/mainAgent/index.js";
+import {
+  ATTR_GEN_AI_AGENT_ID,
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  GEN_AI_OPERATION_INVOKE_AGENT,
+} from "../../../../../src/genai/semconv.js";
+
+const ATTR_GEN_AI_AGENT_VERSION = "gen_ai.agent.version";
+
+describe("GenAIMainAgentSpanProcessor", () => {
+  let provider: BasicTracerProvider;
+  let memoryExporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    memoryExporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new GenAIMainAgentSpanProcessor(), new SimpleSpanProcessor(memoryExporter)],
+    });
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+  });
+
+  describe("onStart propagation from parent", () => {
+    it("does nothing when there is no parent span", () => {
+      const tracer = provider.getTracer("test");
+      const span = tracer.startSpan("chat", { kind: SpanKind.CLIENT });
+      span.end();
+
+      const finished = memoryExporter.getFinishedSpans();
+      expect(finished).toHaveLength(1);
+      const attrs = finished[0].attributes;
+      expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBeUndefined();
+      expect(attrs[GEN_AI_MAIN_AGENT_ID_KEY]).toBeUndefined();
+    });
+
+    it("falls back to gen_ai.agent.* and gen_ai.conversation.id on the parent", () => {
+      const tracer = provider.getTracer("test");
+      const parent = tracer.startSpan("invoke_agent main", {
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+          [ATTR_GEN_AI_AGENT_NAME]: "main",
+          [ATTR_GEN_AI_AGENT_ID]: "id-1",
+          [ATTR_GEN_AI_AGENT_VERSION]: "v1",
+          [ATTR_GEN_AI_CONVERSATION_ID]: "conv-1",
+        },
+      });
+      const parentCtx = trace.setSpan(context.active(), parent);
+      const child = tracer.startSpan("chat sub", { kind: SpanKind.CLIENT }, parentCtx);
+      child.end();
+      parent.end();
+
+      const finished = memoryExporter.getFinishedSpans();
+      const childSpan = finished.find((s) => s.name === "chat sub")!;
+      expect(childSpan.attributes[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("main");
+      expect(childSpan.attributes[GEN_AI_MAIN_AGENT_ID_KEY]).toBe("id-1");
+      expect(childSpan.attributes[GEN_AI_MAIN_AGENT_VERSION_KEY]).toBe("v1");
+      expect(childSpan.attributes[GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY]).toBe("conv-1");
+    });
+
+    it("primary microsoft.gen_ai.main_agent.* attrs on parent win over fallback gen_ai.agent.*", () => {
+      const tracer = provider.getTracer("test");
+      const parent = tracer.startSpan("invoke_agent middle", {
+        attributes: {
+          [GEN_AI_MAIN_AGENT_NAME_KEY]: "primary",
+          [ATTR_GEN_AI_AGENT_NAME]: "middle-fallback",
+        },
+      });
+      const parentCtx = trace.setSpan(context.active(), parent);
+      const child = tracer.startSpan("execute_tool sub", {}, parentCtx);
+      child.end();
+      parent.end();
+
+      const finished = memoryExporter.getFinishedSpans();
+      const childSpan = finished.find((s) => s.name === "execute_tool sub")!;
+      expect(childSpan.attributes[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("primary");
+    });
+
+    it("propagates across multiple span levels (main -> sub-agent -> chat)", () => {
+      const tracer = provider.getTracer("test");
+      const main = tracer.startSpan("invoke_agent main", {
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+          [ATTR_GEN_AI_AGENT_NAME]: "main",
+          [ATTR_GEN_AI_AGENT_ID]: "id-main",
+        },
+      });
+      const ctxMain = trace.setSpan(context.active(), main);
+      const sub = tracer.startSpan(
+        "invoke_agent sub",
+        {
+          attributes: {
+            [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+            [ATTR_GEN_AI_AGENT_NAME]: "sub",
+          },
+        },
+        ctxMain,
+      );
+      const ctxSub = trace.setSpan(context.active(), sub);
+      const chat = tracer.startSpan("chat gpt", {}, ctxSub);
+      chat.end();
+      sub.end();
+      main.end();
+
+      const finished = memoryExporter.getFinishedSpans();
+      const subSpan = finished.find((s) => s.name === "invoke_agent sub")!;
+      const chatSpan = finished.find((s) => s.name === "chat gpt")!;
+      expect(subSpan.attributes[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("main");
+      expect(subSpan.attributes[GEN_AI_MAIN_AGENT_ID_KEY]).toBe("id-main");
+      expect(chatSpan.attributes[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("main");
+      expect(chatSpan.attributes[GEN_AI_MAIN_AGENT_ID_KEY]).toBe("id-main");
+    });
+  });
+
+  describe("onEnd self-copy for top-level invoke_agent", () => {
+    it("copies own gen_ai.agent.* onto microsoft.gen_ai.main_agent.* when no parent enriched it", () => {
+      const tracer = provider.getTracer("test");
+      const span = tracer.startSpan("invoke_agent root", {
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+          [ATTR_GEN_AI_AGENT_NAME]: "root-name",
+          [ATTR_GEN_AI_AGENT_ID]: "root-id",
+          [ATTR_GEN_AI_AGENT_VERSION]: "root-v",
+          [ATTR_GEN_AI_CONVERSATION_ID]: "root-conv",
+        },
+      });
+      span.end();
+
+      const finished = memoryExporter.getFinishedSpans();
+      const attrs = finished[0].attributes;
+      expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("root-name");
+      expect(attrs[GEN_AI_MAIN_AGENT_ID_KEY]).toBe("root-id");
+      expect(attrs[GEN_AI_MAIN_AGENT_VERSION_KEY]).toBe("root-v");
+      expect(attrs[GEN_AI_MAIN_AGENT_CONVERSATION_ID_KEY]).toBe("root-conv");
+    });
+
+    it("does not self-copy when operation is not invoke_agent", () => {
+      const tracer = provider.getTracer("test");
+      const span = tracer.startSpan("chat top", {
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: "chat",
+          [ATTR_GEN_AI_AGENT_NAME]: "shouldnt-copy",
+        },
+      });
+      span.end();
+
+      const attrs = memoryExporter.getFinishedSpans()[0].attributes;
+      expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBeUndefined();
+    });
+
+    it("skips self-copy when a main_agent.* attribute is already present", () => {
+      const tracer = provider.getTracer("test");
+      const span = tracer.startSpan("invoke_agent already-set", {
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+          [GEN_AI_MAIN_AGENT_NAME_KEY]: "already",
+          [ATTR_GEN_AI_AGENT_NAME]: "self",
+        },
+      });
+      span.end();
+
+      const attrs = memoryExporter.getFinishedSpans()[0].attributes;
+      expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("already");
+    });
+  });
+});
+
+describe("GenAIMainAgentLogRecordProcessor", () => {
+  let provider: BasicTracerProvider;
+  let logProvider: LoggerProvider;
+  let memoryLogExporter: InMemoryLogRecordExporter;
+
+  let ctxManager: AsyncLocalStorageContextManager;
+
+  beforeEach(() => {
+    ctxManager = new AsyncLocalStorageContextManager();
+    ctxManager.enable();
+    context.setGlobalContextManager(ctxManager);
+
+    memoryLogExporter = new InMemoryLogRecordExporter();
+    logProvider = new LoggerProvider({
+      processors: [
+        new GenAIMainAgentLogRecordProcessor(),
+        new SimpleLogRecordProcessor(memoryLogExporter),
+      ],
+    });
+    logsApi.setGlobalLoggerProvider(logProvider);
+    provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await logProvider.shutdown();
+    await provider.shutdown();
+    logsApi.disable();
+    trace.disable();
+    context.disable();
+  });
+
+  it("copies main_agent.* attributes from the active span onto emitted log records", () => {
+    const tracer = provider.getTracer("test");
+    const span = tracer.startSpan("invoke_agent root", {
+      attributes: {
+        [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_INVOKE_AGENT,
+        [GEN_AI_MAIN_AGENT_NAME_KEY]: "main-from-span",
+        [GEN_AI_MAIN_AGENT_ID_KEY]: "id-from-span",
+      },
+    });
+
+    context.with(trace.setSpan(context.active(), span), () => {
+      const logger = logsApi.getLogger("test");
+      logger.emit({ body: "hello" });
+    });
+    span.end();
+
+    const records = memoryLogExporter.getFinishedLogRecords();
+    expect(records).toHaveLength(1);
+    const attrs = records[0].attributes ?? {};
+    expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBe("main-from-span");
+    expect(attrs[GEN_AI_MAIN_AGENT_ID_KEY]).toBe("id-from-span");
+  });
+
+  it("does nothing when no active span", () => {
+    const logger = logsApi.getLogger("test");
+    logger.emit({ body: "no span" });
+
+    const records = memoryLogExporter.getFinishedLogRecords();
+    expect(records).toHaveLength(1);
+    const attrs = records[0].attributes ?? {};
+    expect(attrs[GEN_AI_MAIN_AGENT_NAME_KEY]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **main agent attribution propagation** to the Microsoft OpenTelemetry JS distro, mirroring the Python distro's [#120](https://github.com/microsoft/opentelemetry-distro-python/pull/120) (feature) and [#171](https://github.com/microsoft/opentelemetry-distro-python/pull/171) (LangChain timing fix).

In multi-agent / agent-with-tools scenarios, downstream `chat` and `execute_tool` spans need to be attributed to the **top-level user-facing agent**, not the inner sub-agent or LLM call that emitted them. This PR adds processors that copy `microsoft.gen_ai.main_agent.*` from parent → child spans (and from active span → log records) at on-start / on-emit time, so the attribution survives through arbitrarily deep span trees.

## What's added

### `GenAIMainAgentSpanProcessor`
- **`onStart`:** copies `microsoft.gen_ai.main_agent.{name,id,version,conversation_id}` from the parent span; falls back to the parent's `gen_ai.agent.{name,id,version}` / `gen_ai.conversation.id` if the primary attrs aren't set yet.
- **`onEnd`:** when the span is itself a top-level `invoke_agent` and has no `main_agent.*` attrs, self-copies from its own `gen_ai.agent.*` / `gen_ai.conversation.id` so the top-level agent identifies itself as the main agent (mutates the attribute map directly since `setAttribute` is a no-op on an ended JS span).

### `GenAIMainAgentLogRecordProcessor`
- **`onEmit`:** copies all `microsoft.gen_ai.main_agent.*` attributes from the active/emit-context span onto the emitted log record.

Both processors are prepended (`unshift`) to the distro's span/log processor lists when `azureMonitor.enabled` is true — matching the Python distro's gating on `enable_azure_monitor`.

### LangChain integration fixes
1. **PR #171 timing fix (JS port):** moved `setOperationTypeAttribute` / `setAgentAttributes` / `setSessionIdAttribute` calls to *immediately after* `tracer.startSpan(...)` in `startTracing`. Previously these only fired in `_endTrace`, so child `chat` / `execute_tool` runs created under an `invoke_agent` would `onStart` before the parent had its agent attrs, and propagation silently failed.
2. **JS-only parent-Span fix:** child spans now carry the actual parent **`Span`** (`trace.setSpan(ctx, parent)`) rather than just its `SpanContext` (`trace.setSpanContext(...)`). The latter wraps the parent in a `NonRecordingSpan` whose `attributes` are not readable — so even with the timing fix above, propagation would never have worked. Required for the feature to function at all.

## Tests

- **9 new unit tests** for the processors (onStart propagation, primary-vs-fallback precedence, multi-level chains, onEnd self-copy, no-op on non-`invoke_agent` operations, skip-when-already-set, log record propagation with/without active span).
- **1 new end-to-end test** that drives the real `LangChainTracer` through the OTel SDK and asserts that a child `chat` span inherits `microsoft.gen_ai.main_agent.name` from an `invoke_agent` parent (would have failed without both fixes above).
- **Full unit suite:** 837 passed, 5 todo, 0 failed.
- **Type-check:** `tsc --noEmit -p tsconfig.src.json` clean.

## End-to-end validation

Tested against a real LangGraph ReAct agent (`createReactAgent({ name: "TravelBot", tools: [get_weather], llm: ChatOpenAI(gpt-4.1) })`) running against Azure Foundry OpenAI. Four spans emitted in one trace:

```
invoke_agent TravelBot          (root, kind=SERVER)
├── chat gpt-4.1                inherits microsoft.gen_ai.main_agent.name = "TravelBot"
├── execute_tool get_weather    inherits microsoft.gen_ai.main_agent.name = "TravelBot"
└── chat gpt-4.1                inherits microsoft.gen_ai.main_agent.name = "TravelBot"
```

All 3 child spans correctly carry the main-agent name via `onStart` propagation; the root span carries it via the `onEnd` self-copy.

## Files

- **New:** `src/genai/mainAgent/{constants,processor,index}.ts`
- **New tests:** `test/internal/unit/genai/mainAgent/processor.test.ts`, `test/internal/unit/genai/langchain/mainAgentPropagation.test.ts`
- **Modified:**
  - `src/distro/distro.ts` — register processors when Azure Monitor is enabled
  - `src/genai/instrumentations/langchain/tracer.ts` — timing + parent-Span fixes
  - `src/genai/index.ts`, `src/index.ts` — re-exports
