### PR TITLE
Add needs-author-feedback GitHub Actions workflows

### DIFF
--- a/.github/workflows/needs-author-feedback-followup.yml
+++ b/.github/workflows/needs-author-feedback-followup.yml
@@ -1,0 +1,177 @@
+name: needs-author-feedback followup
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  follow-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remind or close issues waiting for author feedback
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = new Date();
+
+            function daysBetween(earlier, later) {
+              return Math.floor((later - earlier) / (1000 * 60 * 60 * 24));
+            }
+
+            function getLatestAppliedMarker(comments) {
+              const matching = comments.filter(comment =>
+                comment.user?.type === "Bot" &&
+                comment.body?.includes("<!-- needs-author-feedback:applied -->")
+              );
+
+              if (matching.length === 0) {
+                return null;
+              }
+
+              matching.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              return matching[0];
+            }
+
+            function hasReminderSince(comments, appliedAt) {
+              return comments.some(comment =>
+                comment.user?.type === "Bot" &&
+                comment.body?.includes("<!-- needs-author-feedback:reminder -->") &&
+                new Date(comment.created_at) > appliedAt
+              );
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: "needs-author-feedback",
+              per_page: 100
+            });
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+
+              const issue_number = issue.number;
+              const author = issue.user.login;
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100
+              });
+
+              const latestAppliedComment = getLatestAppliedMarker(comments);
+              if (!latestAppliedComment) {
+                // Backfill an applied marker for issues labeled before this
+                // workflow existed (or where the marker comment was deleted).
+                // Without this, such issues would stay labeled forever because
+                // the reminder/close logic below keys off the marker timestamp.
+                // The backfilled comment uses today's date as the start of the
+                // 14-day clock and intentionally does not @-mention the author.
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: [
+                    `Backfilling \`needs-author-feedback\` follow-up tracker on ${now.toISOString().slice(0, 10)}.`,
+                    "The reminder/auto-close clock starts from this comment.",
+                    "",
+                    "<!-- needs-author-feedback:applied -->"
+                  ].join("\n")
+                });
+                continue;
+              }
+
+              const appliedAt = new Date(latestAppliedComment.created_at);
+
+              const authorReplied = comments.some(comment =>
+                comment.user?.login === author &&
+                new Date(comment.created_at) > appliedAt
+              );
+
+              if (authorReplied) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number,
+                    name: "needs-author-feedback"
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: "Thanks for the response. Removing `needs-author-feedback`."
+                });
+
+                continue;
+              }
+
+              const ageInDays = daysBetween(appliedAt, now);
+
+              if (ageInDays >= 14) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: [
+                    `@${author} we have not received the requested information within 14 days, so we are closing this issue for now.`,
+                    "",
+                    "If you still need help, please comment with the requested details and we can reopen it.",
+                    "",
+                    "<!-- needs-author-feedback:closed -->"
+                  ].join("\n")
+                });
+
+                // Remove the label before closing so that if a maintainer later
+                // reopens the issue, this workflow does not immediately re-close
+                // it based on the stale `applied` marker.  When the label is
+                // re-applied to gather more info, a fresh `applied` marker
+                // restarts the 14-day clock.
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number,
+                    name: "needs-author-feedback"
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number,
+                  state: "closed"
+                });
+
+                continue;
+              }
+
+              if (ageInDays >= 7 && !hasReminderSince(comments, appliedAt)) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: [
+                    `@${author} friendly reminder: we are still waiting for your feedback.`,
+                    "",
+                    "If we do not hear back within 7 more days, this issue may be closed automatically.",
+                    "",
+                    "<!-- needs-author-feedback:reminder -->"
+                  ].join("\n")
+                });
+              }
+            }

--- a/.github/workflows/needs-author-feedback.yml
+++ b/.github/workflows/needs-author-feedback.yml
@@ -1,0 +1,81 @@
+name: needs-author-feedback
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  notify-on-label:
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'needs-author-feedback'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify issue author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (issue.pull_request) return;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+            const author = issue.user.login;
+            const today = new Date().toISOString().slice(0, 10);
+
+            const body = [
+              `@${author} we need more information before we can continue working on this issue.`,
+              "",
+              "Please reply within 14 days. If we do not hear back, this issue may be closed automatically.",
+              "",
+              "<!-- needs-author-feedback:applied -->",
+              `Marked as needs-author-feedback on ${today}.`
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body
+            });
+
+  remove-label-on-author-reply:
+    if: github.event_name == 'issue_comment' && github.event.action == 'created'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label when issue author replies
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+
+            if (issue.pull_request) return;
+            if (!issue.labels.some(label => label.name === "needs-author-feedback")) return;
+            if (comment.user.login !== issue.user.login) return;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: "needs-author-feedback"
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: "Thanks for the response. Removing `needs-author-feedback`."
+            });


### PR DESCRIPTION
Ports microsoft/opentelemetry-distro-python#178 to the JavaScript distro.

Adds two GitHub Actions workflows:

- `.github/workflows/needs-author-feedback.yml` — When the `needs-author-feedback` label is applied to an issue, posts a notification comment to the author with an `applied` marker. When the issue author replies, the label is removed automatically.
- `.github/workflows/needs-author-feedback-followup.yml` — Daily cron (03:00 UTC, also `workflow_dispatch`). Backfills missing markers, removes the label if the author has replied, posts a friendly reminder after 7 days, and closes the issue (removing the label first, so reopens get a fresh clock) after 14 days of no response.