### PR TITLE
fix(langchain): load LangChainTracer synchronously to avoid span loss

### DIFF
--- a/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
+++ b/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
@@ -11,7 +11,7 @@ import {
   InstrumentationModuleDefinition,
   isWrapped,
 } from "@opentelemetry/instrumentation";
-import type { LangChainTracer } from "./tracer.js";
+import { LangChainTracer } from "./tracer.js";
 
 type CallbackManagerModuleType = typeof CallbackManagerModule;
 type LangChainTracerCtor = new (tracer: Tracer) => LangChainTracer;
@@ -21,10 +21,14 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
   private _hasBeenEnabled = false;
   private _isPatched = false;
   protected otelTracer: Tracer;
-  /** Lazy-loaded to avoid eagerly importing @langchain/core/tracers/base
-   *  (which transitively loads @langchain/core/callbacks/manager) before
-   *  the instrumentation hooks for that module have been registered. */
-  private _tracerCtor: LangChainTracerCtor | undefined;
+  // Statically bound at module load. A previous lazy `import("./tracer.js")`
+  // resolved on a later microtask, so any `_configureSync` call that landed
+  // in that window (typically the first compiled-graph `invoke` after distro
+  // startup) silently fell through with no tracer attached, dropping the
+  // outer `invoke_agent LangGraph` wrapper span and fragmenting the trace.
+  // A static import is safe: by the time `patch()` runs, the callbacks
+  // manager module is already loaded (it is the `module` argument).
+  private _tracerCtor: LangChainTracerCtor = LangChainTracer;
 
   private constructor() {
     if (LangChainTraceInstrumentorImpl._instance !== null) {
@@ -91,22 +95,6 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
       return module;
     }
 
-    // Now that the hooks are registered and @langchain/core/callbacks/manager
-    // is loaded, it is safe to load tracer.js (and its transitive
-    // @langchain/core/tracers/base dependency). The promise resolves in the
-    // next microtask — well before any user code invokes a LangChain
-    // chain/agent/tool (which is what triggers _configureSync).
-    void import("./tracer.js").then(
-      (m) => {
-        this._tracerCtor = m.LangChainTracer;
-      },
-      (err) => {
-        diag.error(
-          `[LangChainTraceInstrumentor] Failed to load LangChainTracer: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      },
-    );
-
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const instrumentor = this;
     this._wrap(CallbackManager, "_configureSync", (original) => {
@@ -114,12 +102,8 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
         this: CallbackManagerModuleType,
         ...args: Parameters<(typeof CallbackManager)["_configureSync"]>
       ) {
-        if (instrumentor._tracerCtor) {
-          args[0] = addTracerToHandlers(instrumentor.otelTracer, args[0], instrumentor._tracerCtor);
-          diag.debug("[LangChainTraceInstrumentor] _configureSync wrapped to add LangChainTracer");
-        } else {
-          diag.debug("[LangChainTraceInstrumentor] LangChainTracer not yet loaded, skipping");
-        }
+        args[0] = addTracerToHandlers(instrumentor.otelTracer, args[0], instrumentor._tracerCtor);
+        diag.debug("[LangChainTraceInstrumentor] _configureSync wrapped to add LangChainTracer");
         return original.apply(this, args);
       };
     });

--- a/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
+++ b/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
@@ -45,6 +45,41 @@ describe("LangChainTraceInstrumentor", () => {
       // Should not throw
       LangChainTraceInstrumentor.instrument(mockModule);
     });
+
+    // Regression test for the startup race fixed by binding `_tracerCtor`
+    // statically at field-declaration time. Previously the tracer ctor was
+    // resolved via a dynamic `import("./tracer.js")` whose `.then(...)`
+    // callback ran on a later microtask. Any `_configureSync` call landing
+    // in that window (typically the very first compiled-graph `invoke` after
+    // distro startup) silently fell through with no tracer attached,
+    // dropping the outer wrapper span and fragmenting the trace.
+    // This test asserts the wrapped `_configureSync` attaches a
+    // `LangChainTracer` on its very first synchronous invocation — i.e.,
+    // without awaiting any microtask after `instrument(...)`.
+    it("attaches a LangChainTracer synchronously on the first _configureSync call", () => {
+      const configureSyncOriginal = vi.fn();
+      const mockModule = {
+        CallbackManager: {
+          _configureSync: configureSyncOriginal,
+        },
+      };
+
+      LangChainTraceInstrumentor.instrument(mockModule as any);
+
+      // Invoke the wrapped _configureSync immediately — no awaits, no
+      // microtask flush. This is the scenario that previously dropped the
+      // outer wrapper span.
+      mockModule.CallbackManager._configureSync(undefined as any);
+
+      assert.strictEqual(configureSyncOriginal.mock.calls.length, 1);
+      const handlersArg = configureSyncOriginal.mock.calls[0][0];
+      assert.ok(Array.isArray(handlersArg), "handlers should be coerced into an array");
+      assert.strictEqual(handlersArg.length, 1);
+      assert.ok(
+        handlersArg[0] instanceof LangChainTracer,
+        "LangChainTracer should be attached on the first call, not deferred to a later microtask",
+      );
+    });
   });
 
   describe("enable / disable", () => {


### PR DESCRIPTION
## Summary

The LangChain instrumentor was loading `LangChainTracer` lazily via `void import("./tracer.js").then(...)`. Because the dynamic import resolves on a later microtask, any `CallbackManager._configureSync` call that fired in the window between `patch()` running and the import resolving silently fell through with no tracer attached:

```ts
if (instrumentor._tracerCtor) {
    args[0] = addTracerToHandlers(...);
} else {
    diag.debug("[LangChainTraceInstrumentor] LangChainTracer not yet loaded, skipping");
}
```

In practice the first compiled-`StateGraph` `invoke(...)` after distro startup reliably lands in that window. Its outer chain run never gets a tracer, so the outermost `invoke_agent LangGraph` wrapper span is never emitted, the inner agent/chat spans become trace roots, and the App Insights end-to-end view splits a single workflow run into multiple unrelated traces.

## Fix

- Switch `LangChainTracer` from a type-only lazy `import()` to a static value import.
- Initialize `_tracerCtor = LangChainTracer` at field-declaration time so it is defined before `patch()` ever runs.
- Drop the `if (_tracerCtor) ... else { ...skipping }` branch in the wrapped `_configureSync` — the tracer is now guaranteed to be present.

The static import is safe here because by the time `patch()` runs, `@langchain/core/callbacks/manager` is already loaded (it is the very `module` argument), so transitively importing `BaseTracer` no longer bypasses any instrumentation hooks.

## Verification

Reproduced against the public LangChain + Microsoft OTEL distro NodeJs repro at https://github.com/tokaplan/testrepo/tree/master/LangChain%20with%20Microsoft%20OTEL%20distro/NodeJs.

**Before:** the first protocol exercised (typically `completions` / `AzureChatOpenAI`) was missing its `invoke_agent LangGraph` outer span; reordering the protocols showed the missing wrapper followed whichever workflow ran first — confirming the cause was an init race, not anything client-specific.

**After (built from this branch):** all three protocols emit the outer `invoke_agent LangGraph` wrapper span on the same `traceId` as the inner `MainWeatherAgent` / `chat` spans, and no `LangChainTracer not yet loaded, skipping` debug messages are emitted.

```
[span] proto=completions          invoke_agent LangGraph     traceId=47edc544...
[span] proto=foundry-completions  invoke_agent LangGraph     traceId=5dbc8b58...
[span] proto=foundry-responses    invoke_agent LangGraph     traceId=f3fdc365...
```

`npm run lint` and `tsc -p tsconfig.src.json --noEmit` both clean.
