### PR TITLE
Soften 'distro' word references in docs and comments

### DIFF
--- a/A365_DOCUMENTATION.md
+++ b/A365_DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# Agent 365 Observability — Microsoft OpenTelemetry Distro for Node.js
+# Agent 365 Observability — Microsoft OpenTelemetry for Node.js
 
 Short guide for A365-specific APIs in this package.
 

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -541,7 +541,7 @@ For the full troubleshooting guide, see the [official troubleshooting documentat
 - [ ] Set `service.name` and `service.version` via `resource` option or `OTEL_RESOURCE_ATTRIBUTES`
 
 **Auto-instrumentation:**
-- [ ] Remove explicit `instrumentor.enable()` calls (auto-instrumented automatically)
+- [ ] Remove explicit `instrumentor.enable()` calls (instrumentations are registered automatically)
 - [ ] Review which instrumentations are enabled by default in A365 mode (GenAI only)
 - [ ] Re-enable non-GenAI instrumentations if needed via `instrumentationOptions`
 

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -1,6 +1,6 @@
 # Migrating from `@microsoft/agents-a365-observability` to `@microsoft/opentelemetry`
 
-Migration guide for existing Agent365 observability customers moving to the production-ready distro.
+Migration guide for existing Agent365 observability customers moving to the production-ready `@microsoft/opentelemetry` package.
 
 For A365 documentation (scopes, baggage, scenarios), see [A365_DOCUMENTATION.md](./A365_DOCUMENTATION.md).
 
@@ -15,7 +15,7 @@ Reference docs: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/
 | `npm install @microsoft/agents-a365-observability` | `npm install @microsoft/opentelemetry` |
 | `import { ... } from "@microsoft/agents-a365-observability"` | `import { ... } from "@microsoft/opentelemetry"` |
 
-If you used hosting helpers, extension packages, or the runtime package, remove them and use the single distro package:
+If you used hosting helpers, extension packages, or the runtime package, remove them and use the single `@microsoft/opentelemetry` package:
 
 | Before | After |
 |---|---|
@@ -62,7 +62,7 @@ await shutdownMicrosoftOpenTelemetry();
 
 ## 3) Resource configuration (service identity)
 
-The Agent365 Observability SDK used `ObservabilityManager.configure(builder => builder.withService('name', 'version'))` to set the service name and version. In the distro, use the standard OpenTelemetry `resource` option:
+The Agent365 Observability SDK used `ObservabilityManager.configure(builder => builder.withService('name', 'version'))` to set the service name and version. In `@microsoft/opentelemetry`, use the standard OpenTelemetry `resource` option:
 
 ```typescript
 import { useMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
@@ -97,7 +97,7 @@ Without explicit configuration, the service name defaults to `unknown_service:<p
 
 ## 4) Auto-instrumentation behavior change
 
-The distro auto-discovers and instruments supported GenAI frameworks (OpenAI Agents SDK, LangChain) without explicit `instrumentor.enable()` calls. This is a key difference from the Agent365 Observability SDK.
+`@microsoft/opentelemetry` auto-discovers and instruments supported GenAI frameworks (OpenAI Agents SDK, LangChain) without explicit `instrumentor.enable()` calls. This is a key difference from the Agent365 Observability SDK.
 
 **What is auto-instrumented by default:**
 
@@ -110,9 +110,9 @@ The distro auto-discovers and instruments supported GenAI frameworks (OpenAI Age
 
 **Key differences from the Agent365 Observability SDK:**
 
-- The Agent365 Observability SDK required explicit `instrumentor.enable()` calls (e.g., `new OpenAIAgentsTraceInstrumentor(...).enable()`). The distro handles this automatically.
+- The Agent365 Observability SDK required explicit `instrumentor.enable()` calls (e.g., `new OpenAIAgentsTraceInstrumentor(...).enable()`). This is now handled automatically.
 - When A365 is enabled without Azure Monitor, non-GenAI instrumentations (HTTP, databases, etc.) are disabled by default to keep telemetry GenAI-focused.
-- **Warning:** If your migrated code still calls `instrumentor.enable()` alongside the distro's auto-instrumentation, you may get duplicate spans. Remove explicit `instrumentor.enable()` calls after migration.
+- **Warning:** If your migrated code still calls `instrumentor.enable()` alongside the bundled auto-instrumentation, you may get duplicate spans. Remove explicit `instrumentor.enable()` calls after migration.
 
 **To disable a specific auto-instrumentation:**
 
@@ -157,7 +157,7 @@ useMicrosoftOpenTelemetry({
 
 New built-in token cache for per-agent-per-tenant token acquisition and refresh.
 
-**Migrating from `withTokenResolver()`:** The Agent365 Observability SDK's `builder.withTokenResolver()` pattern maps directly to the `tokenResolver` option in the distro. The distro does **not** auto-register a built-in cache — you must always provide a `tokenResolver`. If you want built-in caching, use `AgenticTokenCacheInstance` as shown below.
+**Migrating from `withTokenResolver()`:** The Agent365 Observability SDK's `builder.withTokenResolver()` pattern maps directly to the `tokenResolver` option in `@microsoft/opentelemetry`. The package does **not** auto-register a built-in cache — you must always provide a `tokenResolver`. If you want built-in caching, use `AgenticTokenCacheInstance` as shown below.
 
 ### Using the shared singleton
 
@@ -168,7 +168,7 @@ import {
 } from "@microsoft/opentelemetry";
 
 // Use the built-in AgenticTokenCacheInstance as the token resolver.
-// No custom TokenCache class needed — the distro provides it out of the box.
+// No custom TokenCache class needed — provided out of the box.
 const otelTokenResolver = async (agentId: string, tenantId: string): Promise<string> => {
   const token = AgenticTokenCacheInstance.getObservabilityToken(agentId, tenantId) ?? '';
   return token;
@@ -190,7 +190,7 @@ If you previously used `withTokenResolver()` with custom logic, pass your resolv
 // Before (Agent365 Observability SDK)
 builder.withTokenResolver((agentId, tenantId) => myCustomTokenLogic(agentId, tenantId));
 
-// After (distro) — same resolver, new location
+// After (`@microsoft/opentelemetry`) — same resolver, new location
 useMicrosoftOpenTelemetry({
   a365: {
     enabled: true,
@@ -250,7 +250,7 @@ baggage.run(() => {
 
 The Agent365 Observability SDK's `withExporterOptions()` pattern is replaced by flat properties on the `a365` options object.
 
-| Agent365 Observability SDK (`Agent365ExporterOptions`) | Distro equivalent |
+| Agent365 Observability SDK (`Agent365ExporterOptions`) | `@microsoft/opentelemetry` equivalent |
 |---|---|
 | `maxQueueSize` | `a365.maxQueueSize` (default: `2048`) |
 | `scheduledDelayMilliseconds` | `a365.scheduledDelayMilliseconds` (default: `5000`) |
@@ -265,7 +265,7 @@ const exporterOptions = new Agent365ExporterOptions();
 exporterOptions.maxQueueSize = 10;
 builder.withExporterOptions(exporterOptions);
 
-// After (distro) — flat on a365 options
+// After (`@microsoft/opentelemetry`) — flat on a365 options
 useMicrosoftOpenTelemetry({
   a365: {
     enabled: true,
@@ -471,7 +471,7 @@ Your tenant must have one of the following licenses assigned in [Microsoft 365 a
 
 ### Duplicate spans after migration
 
-If your migrated code still calls `instrumentor.enable()` (e.g., `OpenAIAgentsTraceInstrumentor.enable()`) alongside the distro, you will get duplicate spans. Remove explicit instrumentor calls — the distro handles auto-instrumentation automatically.
+If your migrated code still calls `instrumentor.enable()` (e.g., `OpenAIAgentsTraceInstrumentor.enable()`) alongside `@microsoft/opentelemetry`, you will get duplicate spans. Remove explicit instrumentor calls — auto-instrumentation is handled automatically.
 
 ### Validating locally
 
@@ -541,7 +541,7 @@ For the full troubleshooting guide, see the [official troubleshooting documentat
 - [ ] Set `service.name` and `service.version` via `resource` option or `OTEL_RESOURCE_ATTRIBUTES`
 
 **Auto-instrumentation:**
-- [ ] Remove explicit `instrumentor.enable()` calls (the distro auto-instruments)
+- [ ] Remove explicit `instrumentor.enable()` calls (auto-instrumented automatically)
 - [ ] Review which instrumentations are enabled by default in A365 mode (GenAI only)
 - [ ] Re-enable non-GenAI instrumentations if needed via `instrumentationOptions`
 
@@ -568,7 +568,7 @@ For the full troubleshooting guide, see the [official troubleshooting documentat
 - [ ] Verify tenant license (Microsoft 365 E7 or Microsoft Agent 365 Frontier)
 
 **Logging:**
-- [ ] Set `OTEL_LOG_LEVEL` for distro diagnostics
+- [ ] Set `OTEL_LOG_LEVEL` for SDK diagnostics
 - [ ] Optionally set `AZURE_LOG_LEVEL` for Azure SDK alignment
 
 **Verification:**

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 | `logLevel`                    | `string`                                                                       | `"none"`                                                  | A365 internal log level: `none`, `info`, `warn`, `error`, or pipe-separated combination. Overrides `A365_OBSERVABILITY_LOG_LEVEL` env var                                                                                                                |
 | `useS2SEndpoint`              | `boolean`                                                                      | `false`                                                   | Use the S2S (service-to-service) endpoint path for export                                                                                                                                                                                                |
 
-When A365 export is enabled, the SDK defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
+When A365 export is enabled, Microsoft OpenTelemetry defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
 
 ```typescript
 useMicrosoftOpenTelemetry({

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ See the [OpenTelemetry OTLP Exporter specification](https://opentelemetry.io/doc
 | `logLevel`                    | `string`                                                                       | `"none"`                                                  | A365 internal log level: `none`, `info`, `warn`, `error`, or pipe-separated combination. Overrides `A365_OBSERVABILITY_LOG_LEVEL` env var                                                                                                                |
 | `useS2SEndpoint`              | `boolean`                                                                      | `false`                                                   | Use the S2S (service-to-service) endpoint path for export                                                                                                                                                                                                |
 
-When A365 export is enabled, the distro defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
+When A365 export is enabled, the SDK defaults to GenAI-focused telemetry. To opt back into non-GenAI auto-instrumentation, set explicit overrides:
 
 ```typescript
 useMicrosoftOpenTelemetry({

--- a/docs/fabric-getting-started.md
+++ b/docs/fabric-getting-started.md
@@ -7,11 +7,11 @@ This guide walks you through sending traces, metrics, and logs from a Node.js ap
 Your Node.js app doesn't connect to Fabric directly. Instead, it sends telemetry to an **OpenTelemetry Collector** running alongside it — either locally or in a cluster. The collector then forwards the data into your Fabric/ADX database.
 
 ```
-┌──────────────┐     OTLP/HTTP     ┌──────────────────┐     Kusto Ingest    ┌─────────────────────────┐
-│  Node.js App │ ───────────────►  │  OTel Collector  │ ──────────────────► │  Fabric / Azure Data    │
-│  (microsoft- │                   │                  │                     │                         │
-│opentelemetry)│    :4318          │  (ADX exporter)  │                     │  Explorer               │
-└──────────────┘                   └──────────────────┘                     └─────────────────────────┘
+┌──────────────────┐     OTLP/HTTP     ┌──────────────────┐     Kusto Ingest    ┌─────────────────────────┐
+│   Node.js App    │ ───────────────►  │  OTel Collector  │ ──────────────────► │  Fabric / Azure Data    │
+│   (@microsoft/   │                   │                  │                     │                         │
+│  opentelemetry)  │    :4318          │  (ADX exporter)  │                     │  Explorer               │
+└──────────────────┘                   └──────────────────┘                     └─────────────────────────┘
 ```
 
 **What each component does:**

--- a/docs/fabric-getting-started.md
+++ b/docs/fabric-getting-started.md
@@ -9,7 +9,8 @@ Your Node.js app doesn't connect to Fabric directly. Instead, it sends telemetry
 ```
 ┌──────────────┐     OTLP/HTTP     ┌──────────────────┐     Kusto Ingest    ┌─────────────────────────┐
 │  Node.js App │ ───────────────►  │  OTel Collector  │ ──────────────────► │  Fabric / Azure Data    │
-│  (distro)    │    :4318          │  (ADX exporter)  │                     │  Explorer               │
+│  (microsoft- │                   │                  │                     │                         │
+│opentelemetry)│    :4318          │  (ADX exporter)  │                     │  Explorer               │
 └──────────────┘                   └──────────────────┘                     └─────────────────────────┘
 ```
 
@@ -61,9 +62,9 @@ The collector needs permission to write data into your database. Run one of thes
 
 > Replace `<yourdbname>` with your actual database name, and `<ApplicationID>` with the client ID from your [Entra app registration](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app?tabs=portal).
 
-## Step 3: Create a Node.js app with the distro
+## Step 3: Create a Node.js app with `@microsoft/opentelemetry`
 
-Create a new Node.js app and install the distro:
+Create a new Node.js app and install `@microsoft/opentelemetry`:
 
 ```bash
 mkdir fabric-demo && cd fabric-demo
@@ -82,7 +83,7 @@ useMicrosoftOpenTelemetry();
 const app = express();
 
 app.get("/", (_req, res) => {
-  res.send("Hello from distro → Fabric!");
+  res.send("Hello from microsoft-opentelemetry → Fabric!");
 });
 
 app.listen(3000, () => {

--- a/samples/fabric/app.mjs
+++ b/samples/fabric/app.mjs
@@ -17,7 +17,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.get("/", (_req, res) => {
-  res.send("Hello from distro → Fabric!");
+  res.send("Hello from microsoft-opentelemetry → Fabric!");
 });
 
 app.get("/weather", (_req, res) => {

--- a/samples/src/a365Export.ts
+++ b/samples/src/a365Export.ts
@@ -68,7 +68,7 @@ async function myTokenResolver(agentId: string, tenantId: string): Promise<strin
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Step 2 — Initialize the distro with A365 export
+// Step 2 — Initialize Microsoft OpenTelemetry with A365 export
 // ────────────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {

--- a/samples/src/a365ManualScopes.ts
+++ b/samples/src/a365ManualScopes.ts
@@ -291,7 +291,7 @@ function demonstrateContextPropagation(): void {
 // ────────────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
-  // Initialize the distro with A365 export enabled (same as a365Export.ts)
+  // Initialize Microsoft OpenTelemetry with A365 export enabled (same as a365Export.ts)
   useMicrosoftOpenTelemetry({
     azureMonitor: {
       azureMonitorExporterOptions: {

--- a/src/a365/configuration/A365Configuration.ts
+++ b/src/a365/configuration/A365Configuration.ts
@@ -146,7 +146,7 @@ export class A365Configuration {
     // ENABLE_A365_OBSERVABILITY_EXPORTER controls just the HTTP exporter, not
     // the master `enabled` toggle. It is a secondary toggle that only takes
     // effect when A365 is configured in code (options provided), matching the
-    // Python distro behavior (see microsoft/opentelemetry-distro-python#87).
+    // Python package behavior (see microsoft/opentelemetry-distro-python#87).
     const envExporter = parseEnvBoolean(process.env[A365_ENV_VARS.EXPORTER_ENABLED]);
     if (
       envExporter !== undefined &&
@@ -163,7 +163,7 @@ export class A365Configuration {
 
     // observabilityScopeOverride wins over authScopes / env var so callers can
     // narrow the resolved scope set to a single explicit value (mirrors the
-    // Python distro's a365_observability_scope_override kwarg).
+    // Python package's a365_observability_scope_override kwarg).
     const scopeOverride = options?.observabilityScopeOverride?.trim();
     if (scopeOverride) {
       authScopes = [scopeOverride];

--- a/src/a365/configuration/A365ConfigurationOptions.ts
+++ b/src/a365/configuration/A365ConfigurationOptions.ts
@@ -65,7 +65,7 @@ export interface A365Options {
    *
    * Equivalent to the `A365_OBSERVABILITY_SCOPES_OVERRIDE` environment
    * variable; when supplied, it becomes the sole entry of the resolved
-   * {@link authScopes} array. Mirrors the Python distro's
+   * {@link authScopes} array. Mirrors the Python package's
    * `a365_observability_scope_override` kwarg
    * (microsoft/opentelemetry-distro-python#87).
    *

--- a/src/a365/scopes/OpenTelemetryScope.ts
+++ b/src/a365/scopes/OpenTelemetryScope.ts
@@ -34,7 +34,7 @@ export abstract class OpenTelemetryScope {
   /**
    * Returns a tracer from the current global TracerProvider.
    *
-   * This **must not** be stored in a static field because the distro's
+   * This **must not** be stored in a static field because
    * `useMicrosoftOpenTelemetry()` resets the global API state
    * (`trace.disable()` + global-object deletion) before starting the
    * NodeSDK. A static field would capture a `ProxyTracer` bound to the

--- a/src/azureMonitor/index.ts
+++ b/src/azureMonitor/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 /**
- * Azure Monitor–specific initialization that runs alongside the distro.
+ * Azure Monitor–specific initialization that runs alongside the main setup.
  * SDK Stats, Browser SDK Loader, and Live Metrics SDK prefix are
- * Azure Monitor concerns — not part of the generic OTel distro lifecycle.
+ * Azure Monitor concerns — not part of the generic OTel lifecycle.
  */
 
 import type { InternalConfig } from "../shared/config.js";

--- a/src/azureMonitor/logs/handler.ts
+++ b/src/azureMonitor/logs/handler.ts
@@ -24,9 +24,9 @@ export class LogHandler {
   private _instrumentations: Instrumentation[];
 
   /**
-   * Initializes a new instance of the TraceHandler class.
-   * @param _config - Microsoft OpenTelemetry configuration.
-   * @param _metricHandler - MetricHandler.
+   * Initializes a new instance of the LogHandler class.
+   * @param config - Microsoft OpenTelemetry configuration.
+   * @param metricHandler - MetricHandler.
    */
   constructor(config: InternalConfig, metricHandler: MetricHandler) {
     this._config = config;

--- a/src/azureMonitor/logs/handler.ts
+++ b/src/azureMonitor/logs/handler.ts
@@ -25,7 +25,7 @@ export class LogHandler {
 
   /**
    * Initializes a new instance of the TraceHandler class.
-   * @param _config - Distro configuration.
+   * @param _config - Microsoft OpenTelemetry configuration.
    * @param _metricHandler - MetricHandler.
    */
   constructor(config: InternalConfig, metricHandler: MetricHandler) {

--- a/src/azureMonitor/metrics/handler.ts
+++ b/src/azureMonitor/metrics/handler.ts
@@ -78,7 +78,7 @@ export class MetricHandler {
 
   /**
    * Initializes a new instance of the MetricHandler class.
-   * @param config - Distro configuration.
+   * @param config - Microsoft OpenTelemetry configuration.
    * @param options - Metric Handler options.
    */
   constructor(config: InternalConfig) {

--- a/src/azureMonitor/metrics/performanceCounters.ts
+++ b/src/azureMonitor/metrics/performanceCounters.ts
@@ -70,8 +70,8 @@ export class PerformanceCounterMetrics {
 
   /**
    * Creates performance counter instruments.
-   * @param options - Microsoft OpenTelemetry configuration.
-   * @param config - Application Insights configuration.
+   * @param config - Internal Microsoft OpenTelemetry configuration.
+   * @param options - Optional performance counter settings (e.g. collection interval).
    */
   constructor(config: InternalConfig, options?: { collectionInterval: number }) {
     this.internalConfig = config;

--- a/src/azureMonitor/metrics/performanceCounters.ts
+++ b/src/azureMonitor/metrics/performanceCounters.ts
@@ -70,7 +70,7 @@ export class PerformanceCounterMetrics {
 
   /**
    * Creates performance counter instruments.
-   * @param options - Distro configuration.
+   * @param options - Microsoft OpenTelemetry configuration.
    * @param config - Application Insights configuration.
    */
   constructor(config: InternalConfig, options?: { collectionInterval: number }) {

--- a/src/azureMonitor/metrics/quickpulse/filtering/validator.ts
+++ b/src/azureMonitor/metrics/quickpulse/filtering/validator.ts
@@ -49,7 +49,7 @@ export class Validator {
   public validateTelemetryType(telemetryType: string): void {
     if (telemetryType === "PerformanceCounter") {
       throw new TelemetryTypeError(
-        "The telemetry type PerformanceCounter was specified, but this distro does not send performance counters to quickpulse.",
+        "The telemetry type PerformanceCounter was specified, but this SDK does not send performance counters to quickpulse.",
       );
     } else if (telemetryType === "Event") {
       throw new TelemetryTypeError(
@@ -57,7 +57,7 @@ export class Validator {
       );
     } else if (telemetryType === "Metric") {
       throw new TelemetryTypeError(
-        "The telemetry type Metric was specified, but this distro does not send custom live metrics to quickpulse.",
+        "The telemetry type Metric was specified, but this SDK does not send custom live metrics to quickpulse.",
       );
     } else if (!validTelemetryTypes.has(telemetryType)) {
       throw new TelemetryTypeError(`'${telemetryType}' is not a valid telemetry type.`);

--- a/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
+++ b/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
@@ -143,9 +143,8 @@ export class LiveMetrics {
     Map<string, FilterConjunctionGroupInfo[]>
   > = new Map();
   /**
-   * Initializes a new instance of the StandardMetrics class.
+   * Initializes a new instance of the LiveMetrics class.
    * @param config - Microsoft OpenTelemetry configuration.
-   * @param options - Standard Metrics options.
    */
   constructor(config: InternalConfig) {
     this.config = config;

--- a/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
+++ b/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
@@ -144,7 +144,7 @@ export class LiveMetrics {
   > = new Map();
   /**
    * Initializes a new instance of the StandardMetrics class.
-   * @param config - Distro configuration.
+   * @param config - Microsoft OpenTelemetry configuration.
    * @param options - Standard Metrics options.
    */
   constructor(config: InternalConfig) {

--- a/src/azureMonitor/metrics/quickpulse/utils.ts
+++ b/src/azureMonitor/metrics/quickpulse/utils.ts
@@ -94,7 +94,7 @@ export function getSdkVersion(): string {
 
 /** Get the internal SDK version type */
 export function getSdkVersionType(): string {
-  // Always report the Microsoft OpenTelemetry distro version with the `mot`
+  // Always report the Microsoft OpenTelemetry version with the `mot`
   // prefix so live metrics align with the Azure Monitor exporter's
   // ai.internal.sdkVersion tag (see Azure/azure-sdk-for-js#38352).
   return `mot${process.env["MICROSOFT_OPENTELEMETRY_VERSION"] ?? MICROSOFT_OPENTELEMETRY_VERSION}`;

--- a/src/azureMonitor/metrics/standardMetrics.ts
+++ b/src/azureMonitor/metrics/standardMetrics.ts
@@ -42,7 +42,7 @@ export class StandardMetrics {
 
   /**
    * Initializes a new instance of the StandardMetrics class.
-   * @param config - Distro configuration.
+   * @param config - Microsoft OpenTelemetry configuration.
    * @param options - Standard Metrics options.
    */
   constructor(config: InternalConfig, options?: { collectionInterval: number }) {

--- a/src/distro/autoAttach.ts
+++ b/src/distro/autoAttach.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// TODO: Enable auto-attach warning once the distro supports auto-instrumentation scenarios
+// TODO: Enable auto-attach warning once auto-instrumentation scenarios are supported
 // (App Service, AKS, etc.). The logic below detects when Azure Monitor automatic
 // instrumentation may already be active and warns about double instrumentation.
 
@@ -17,7 +17,7 @@ export function sendAttachWarning(): void {
   if (process.env[AZURE_MONITOR_AUTO_ATTACH] === "true" && !isFunctionApp()) {
     // TODO: When AKS attach is public, update this message with disablement instructions for AKS
     const message =
-      "Distro detected that automatic instrumentation may have occurred. Only use autoinstrumentation if you " +
+      "Microsoft OpenTelemetry detected that automatic instrumentation may have occurred. Only use autoinstrumentation if you " +
       "are not using manual instrumentation of OpenTelemetry in your code, such as with " +
       "@azure/monitor-opentelemetry or @azure/monitor-opentelemetry-exporter. For App Service resources, disable " +
       "autoinstrumentation in the Application Insights experience on your App Service resource or by setting " +

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -133,9 +133,9 @@ export function _applyA365InstrumentationDefaults(
 }
 
 /**
- * Initialize Microsoft OpenTelemetry distribution.
+ * Initialize Microsoft OpenTelemetry.
  *
- * This is the primary entry point for the distro. It sets up OpenTelemetry
+ * This is the primary entry point. It sets up OpenTelemetry
  * providers and instrumentations, then attaches the configured exporters:
  * - Azure Monitor (when `options.azureMonitor` is provided or the
  *   `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is set; explicitly disable
@@ -167,7 +167,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     (!!options?.azureMonitor || hasAzureMonitorConnectionString(config));
   const azureMonitorEnabled = azureMonitorRequested && validateAzureMonitorConfig(config);
 
-  // ── SDKStats: record distro feature bits for ALL paths ──────────────────
+  // ── SDKStats: record feature bits for ALL paths ─────────────────────────
   // These bits are emitted via SDKStats regardless of which exporter is
   // active. When Azure Monitor is enabled the exporter package's own
   // SDKStats pipeline picks them up via `AZURE_MONITOR_STATSBEAT_FEATURES`;
@@ -400,7 +400,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   // - When Azure Monitor is enabled (`networkOnly: true`): only the
   //   network gauges are registered. The Feature / Feature.instrumentations
   //   long-interval metrics are owned by the AzMon exporter, with our
-  //   distro bits bridged in via `setSdkStatsFeatures` →
+  //   feature bits bridged in via `setSdkStatsFeatures` →
   //   `AZURE_MONITOR_STATSBEAT_FEATURES`. The network pipeline is safe to
   //   coexist because the (endpoint, host) attributes partition the
   //   time series (AzMon ingestion hosts vs A365 / OTLP hosts).

--- a/src/distro/instrumentations.ts
+++ b/src/distro/instrumentations.ts
@@ -3,8 +3,8 @@
 
 /**
  * Standalone helpers that create OTel instrumentations, samplers, and metric
- * views.  These are used by the distro regardless of whether Azure Monitor is
- * enabled, so they must not depend on Azure Monitor handler classes.
+ * views.  These are used regardless of whether Azure Monitor is enabled, so
+ * they must not depend on Azure Monitor handler classes.
  */
 
 import type { RequestOptions } from "node:http";
@@ -33,7 +33,7 @@ import { logLevelToSeverityNumber } from "../azureMonitor/utils/logUtils.js";
 // ── Instrumentations ────────────────────────────────────────────────
 
 /**
- * Build the list of auto-instrumentations based on the distro configuration.
+ * Build the list of auto-instrumentations based on the resolved configuration.
  * This covers trace instrumentations (HTTP, Azure SDK, DB clients) and log
  * instrumentations (Bunyan, Winston).
  *
@@ -117,7 +117,7 @@ export function createInstrumentations(
 // ── Sampler ─────────────────────────────────────────────────────────
 
 /**
- * Create an OTel sampler based on the distro configuration.
+ * Create an OTel sampler based on the resolved configuration.
  *
  * Precedence:
  * 1. Explicit sampler provided via environment config (e.g. OTEL_TRACES_SAMPLER)

--- a/src/distro/loader.ts
+++ b/src/distro/loader.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * ESM loader entry point for Microsoft OpenTelemetry distro.
+ * ESM loader entry point for Microsoft OpenTelemetry.
  *
  * For ESM applications, this loader should be preloaded with the --import flag
  * so OpenTelemetry import hooks are registered before application modules load.

--- a/src/sdkstats/index.ts
+++ b/src/sdkstats/index.ts
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 
 /**
- * SDK self-telemetry (SDKStats) for the Microsoft OpenTelemetry Distro.
+ * SDK self-telemetry (SDKStats) for `@microsoft/opentelemetry`.
  *
  * Backend-agnostic SDK health and usage telemetry that works regardless
  * of which export backends are enabled (Azure Monitor, OTLP, A365,
  * Console). Tracks:
  *
- * - **Features** — which distro features are active (A365, OTLP, console,
+ * - **Features** — which package features are active (A365, OTLP, console,
  *   live metrics, browser SDK loader, ...)
  * - **Instrumentations** — which library instrumentations are enabled
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/__init__.py` from the
- * Python distro.
+ * Python implementation.
  */
 
 export {

--- a/src/sdkstats/manager.ts
+++ b/src/sdkstats/manager.ts
@@ -7,15 +7,15 @@
  * pipeline.
  *
  * When the full Azure Monitor pipeline is enabled, the exporter package's
- * own SDKStats machinery handles SDKStats emission and the distro just
- * publishes its bits via the `AZURE_MONITOR_STATSBEAT_FEATURES` env var
+ * own SDKStats machinery handles SDKStats emission and we just
+ * publish our bits via the `AZURE_MONITOR_STATSBEAT_FEATURES` env var
  * for the exporter to read. For A365-only, OTLP-only, or Console-only
  * customers this manager spins up a standalone `MeterProvider` →
  * `AzureMonitorStatsbeatExporter` pipeline so feature/instrumentation
  * SDKStats are still collected.
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/_manager.py` from the
- * Python distro.
+ * Python implementation.
  */
 
 import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
@@ -47,7 +47,7 @@ const SDKSTATS_LONG_EXPORT_INTERVAL_ENV = "APPLICATIONINSIGHTS_STATS_LONG_EXPORT
 /**
  * Default short export interval (15 minutes) for network SDKStats
  * counters. Matches the Application Insights SDKStats short-interval
- * cadence used by the Python distro (`_get_stats_short_export_interval()`
+ * cadence used by the Python package (`_get_stats_short_export_interval()`
  * in `azure.monitor.opentelemetry.exporter.statsbeat._utils`).
  *
  * @internal
@@ -56,7 +56,7 @@ const DEFAULT_SHORT_EXPORT_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
  * Override env var: short (network) export interval in seconds.
- * Matches the Python distro env var name.
+ * Matches the Python package env var name.
  *
  * @internal
  */
@@ -67,7 +67,7 @@ const SDKSTATS_SHORT_EXPORT_INTERVAL_ENV = "APPLICATIONINSIGHTS_STATS_SHORT_EXPO
  * Insights connection string. When unset, SDKStats flow to the
  * Microsoft-owned SDKStats resource (`NON_EU_CONNECTION_STRING` in
  * the AzMon exporter package). Primarily useful for testing.
- * Matches the Python distro env var name.
+ * Matches the Python package env var name.
  *
  * @internal
  */
@@ -151,7 +151,7 @@ export class SdkStatsManager {
       const NON_EU_CONNECTION_STRING = sdkStatsTypesModule.NON_EU_CONNECTION_STRING;
 
       // Allow overriding the SDKStats ingestion target via env var,
-      // matching the Python distro's APPLICATIONINSIGHTS_STATS_CONNECTION_STRING
+      // matching the Python package's APPLICATIONINSIGHTS_STATS_CONNECTION_STRING
       // hook. Primarily useful for testing — production should leave
       // this unset so SDKStats flows to the Microsoft-owned SDKStats
       // resource (NON_EU_CONNECTION_STRING).

--- a/src/sdkstats/metrics.ts
+++ b/src/sdkstats/metrics.ts
@@ -9,7 +9,7 @@
  * caller-supplied `MeterProvider`.
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/_metrics.py` from the
- * Python distro.
+ * Python implementation.
  */
 
 import os from "node:os";
@@ -197,7 +197,7 @@ export class SdkStatsMetrics {
 
     // Feature / instrumentation bitmask gauges are skipped when running
     // alongside the Azure Monitor exporter's own SDKStats — that pipeline
-    // already emits them (with our distro bits bridged in via
+    // already emits them (with our feature bits bridged in via
     // `_bridge_sdkstats_to_azure_monitor`) and would collide with these.
     // These gauges are registered on the long-interval MeterProvider.
     if (!networkOnly && longMeterProvider) {

--- a/src/sdkstats/networkStats.ts
+++ b/src/sdkstats/networkStats.ts
@@ -12,7 +12,7 @@
  * interval.
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/_utils.py` from the Python
- * distro.
+ * implementation.
  */
 
 // Wire-format metric names and the set of HTTP status-code buckets used

--- a/src/sdkstats/otlpWrapper.ts
+++ b/src/sdkstats/otlpWrapper.ts
@@ -23,7 +23,7 @@
  * `Exception_Count` with a bounded set of `exceptionType` labels.
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py` from
- * the Python distro (microsoft/opentelemetry-distro-python#144).
+ * the Python implementation (microsoft/opentelemetry-distro-python#144).
  */
 
 import type { ExportResult } from "@opentelemetry/core";

--- a/src/sdkstats/state.ts
+++ b/src/sdkstats/state.ts
@@ -17,11 +17,11 @@
 import { SdkStatsFeature, SdkStatsInstrumentation } from "../types.js";
 
 /**
- * Microsoft-OpenTelemetry-specific feature flags, in addition to the
+ * Microsoft OpenTelemetry specific feature flags, in addition to the
  * {@link SdkStatsFeature} flags shared with the Azure Monitor exporter.
  *
  * These bit values intentionally start above the values used by
- * {@link SdkStatsFeature} so that our bits and exporter bits can be
+ * {@link SdkStatsFeature} so that the bits and exporter bits can be
  * OR-combined into a single 64-bit mask without collision.
  */
 export enum SdkStatsDistroFeature {

--- a/src/sdkstats/state.ts
+++ b/src/sdkstats/state.ts
@@ -7,21 +7,21 @@
  * Feature and instrumentation flags are stored as bitmasks so they can be
  * combined and reported efficiently. The bitmask values are intentionally
  * compatible with the Azure Monitor Exporter SDKStats encoding so that
- * Azure Monitor consumers see no behavioural change when the distro
- * bridges its bits into the exporter's existing pipeline.
+ * Azure Monitor consumers see no behavioural change when our bits are
+ * bridged into the exporter's existing pipeline.
  *
  * Mirrors `src/microsoft/opentelemetry/_sdkstats/_state.py` from the
- * Python distro (microsoft/opentelemetry-distro-python#89).
+ * Python implementation (microsoft/opentelemetry-distro-python#89).
  */
 
 import { SdkStatsFeature, SdkStatsInstrumentation } from "../types.js";
 
 /**
- * Distro-specific feature flags, in addition to the
+ * Microsoft-OpenTelemetry-specific feature flags, in addition to the
  * {@link SdkStatsFeature} flags shared with the Azure Monitor exporter.
  *
  * These bit values intentionally start above the values used by
- * {@link SdkStatsFeature} so that distro bits and exporter bits can be
+ * {@link SdkStatsFeature} so that our bits and exporter bits can be
  * OR-combined into a single 64-bit mask without collision.
  */
 export enum SdkStatsDistroFeature {
@@ -68,7 +68,7 @@ export function isSdkStatsEnabled(): boolean {
 
 // ---------------------------------------------------------------------------
 // Mutable global state — kept module-local to ensure a single source of truth
-// across the distro process. Node.js executes JS in a single thread (modulo
+// across the process. Node.js executes JS in a single thread (modulo
 // worker_threads), so no explicit locking is needed.
 // ---------------------------------------------------------------------------
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -67,7 +67,7 @@ export class InternalConfig {
 
   /**
    * Initializes a new instance of InternalConfig.
-   * Accepts MicrosoftOpenTelemetryOptions (distro-level) — global options come
+   * Accepts MicrosoftOpenTelemetryOptions (top-level) — global options come
    * from the top level, Azure Monitor-specific options from the azureMonitor key.
    */
   constructor(options?: MicrosoftOpenTelemetryOptions) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export interface MicrosoftOpenTelemetryOptions {
  *
  * These options control Azure Monitor-specific behavior. Global options
  * (resource, sampling, instrumentations, processors) are defined at the
- * distro level in {@link MicrosoftOpenTelemetryOptions}.
+ * top level in {@link MicrosoftOpenTelemetryOptions}.
  */
 export interface AzureMonitorOpenTelemetryOptions {
   /** Enable or disable Azure Monitor export (Default true) */


### PR DESCRIPTION
Mirrors microsoft/opentelemetry-distro-python#197.

Replaces `the distro` / `Microsoft OpenTelemetry Distro` phrasing in user-facing prose with `Microsoft OpenTelemetry`, `@microsoft/opentelemetry` `, `the SDK`, or `the package` as appropriate.

## Scope
- Markdown docs: README.md, A365_DOCUMENTATION.md (title), MIGRATION_A365.md, docs/fabric-getting-started.md (incl. ASCII diagram)
- Samples: samples/fabric/app.mjs runtime string, comments in a365Export.ts / a365ManualScopes.ts
- Source docstrings/comments only across src/distro/, src/sdkstats/, src/azureMonitor/, src/a365/, src/genai/, src/shared/, src/types.ts
- Two user-facing error messages in src/azureMonitor/metrics/quickpulse/filtering/validator.ts and a warn message in src/distro/autoAttach.ts

## Out of scope (preserved)
- The `src/distro/` directory and all identifiers (`SdkStatsDistroFeature`, `distroVersion`, `distro?: boolean`, etc.)
- All `microsoft/opentelemetry-distro-python` GitHub repo URL references

## Validation
- `npm run build` ✅
- `npm run lint` ✅ (0 errors)
- `npm test` ✅ (923 passed, 5 todo, 1 skipped)