### PR TITLE
fix(a365): add timeout guard to agentic token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,12 @@
 ## [Unreleased]
 
 ### Bugs Fixed
-
 - A365: forward `a365.maxQueueSize`, `a365.scheduledDelayMilliseconds`, `a365.maxExportBatchSize`, and `a365.exporterTimeoutMilliseconds` to the `BatchSpanProcessor` that wraps the `Agent365Exporter`.
 - A365: add a configurable timeout to agentic token exchange so an unresponsive STS no longer hangs telemetry exports indefinitely [#183](https://github.com/microsoft/opentelemetry-distro-javascript/pull/183)
 
 ## [1.1.0] - 2026-05-29
 
 ### Features Added
-
 - Add network SDKStats (request success) for A365 + OTLP exporters [#145](https://github.com/microsoft/opentelemetry-distro-javascript/pull/145)
 - Update message format to align with OTel spec [#155](https://github.com/microsoft/opentelemetry-distro-javascript/pull/155)
 - Add `ApplyGuardrailScope` for security guardrail tracing [#157](https://github.com/microsoft/opentelemetry-distro-javascript/pull/157)
@@ -18,7 +16,6 @@
 - Add `ContextualTokenResolver` with agentic user ID support [#159](https://github.com/microsoft/opentelemetry-distro-javascript/pull/159)
 
 ### Bugs Fixed
-
 - LangChain: split request/response model and emit `gen_ai.response.id` [#127](https://github.com/microsoft/opentelemetry-distro-javascript/pull/127)
 - Add product context fallback for subchannels [#133](https://github.com/microsoft/opentelemetry-distro-javascript/pull/133)
 - Revert `getCallerBaggagePairs` userId fallback [#140](https://github.com/microsoft/opentelemetry-distro-javascript/pull/140)
@@ -27,7 +24,6 @@
 - LangChain: populate `gen_ai.response.model` for Responses API (`useResponsesApi`) [#151](https://github.com/microsoft/opentelemetry-distro-javascript/pull/151)
 
 ### Other Changes
-
 - Update telemetry SDK name to `microsoft-opentelemetry` [#134](https://github.com/microsoft/opentelemetry-distro-javascript/pull/134)
 - Correct repository URLs from Azure to microsoft org and add API docs badge [#136](https://github.com/microsoft/opentelemetry-distro-javascript/pull/136)
 - Only redeploy docs when package version changes [#141](https://github.com/microsoft/opentelemetry-distro-javascript/pull/141)
@@ -40,12 +36,10 @@
 ## [1.0.2] - 2026-05-11
 
 ### Bugs Fixed
-
 - Fix `getCallerBaggagePairs` to resolve `userId` across all channels [#116](https://github.com/microsoft/opentelemetry-distro-javascript/pull/116)
 - Import OpenAI agent types from `@openai/agents` to avoid version drift [#122](https://github.com/microsoft/opentelemetry-distro-javascript/pull/122)
 
 ### Other Changes
-
 - Accept beta versions of azure monitor exporter but not preview versions [#110](https://github.com/microsoft/opentelemetry-distro-javascript/pull/110)
 - Add explicit `enableConsoleExporters` to migration guide validation section [#121](https://github.com/microsoft/opentelemetry-distro-javascript/pull/121)
 - Promote A365 sub-owners in CODEOWNERS [#123](https://github.com/microsoft/opentelemetry-distro-javascript/pull/123)
@@ -53,7 +47,6 @@
 ## [1.0.1] - 2026-05-01
 
 ### Other Changes
-
 - Lazy-load LangChain tracer to avoid eager import of `@langchain/core` before instrumentation hooks register. Removed noise when openai and langchain packages are not installed [#98](https://github.com/microsoft/opentelemetry-distro-javascript/pull/98)
 - Add Fabric/ADX getting started guide and sample app [#100](https://github.com/microsoft/opentelemetry-distro-javascript/pull/100)
 
@@ -62,25 +55,21 @@
 First stable (GA) release. Promotes all functionality from the 0.1.0-beta series.
 
 ### Breaking Changes
-
 - A365: `a365.enabled: true` now registers only the `A365SpanProcessor`. Set `a365.enableObservabilityExporter: true` (or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`) to also add the A365 HTTP exporter. ([#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - A365: `ENABLE_A365_OBSERVABILITY_EXPORTER` env var now toggles only the HTTP exporter, not the master `a365.enabled` flag. ([#83](https://github.com/microsoft/opentelemetry-distro-javascript/pull/83), [#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - Remove `hostDetector` from default resource detectors. Host attributes (`host.name`, `host.id`, etc.) are no longer added by default. Opt back in via `OTEL_NODE_RESOURCE_DETECTORS=env,host,os`. ([#97](https://github.com/microsoft/opentelemetry-distro-javascript/pull/97))
 
 ### Features Added
-
 - Add `a365.enableObservabilityExporter`, `a365.observabilityScopeOverride`, and `a365.logLevel` code options as equivalents of `ENABLE_A365_OBSERVABILITY_EXPORTER`, `A365_OBSERVABILITY_SCOPES_OVERRIDE`, and `A365_OBSERVABILITY_LOG_LEVEL`. Programmatic values take precedence over env vars. ([#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - Expose all A365 exporter/batching settings (`maxQueueSize`, `scheduledDelayMilliseconds`, `exporterTimeoutMilliseconds`, `httpRequestTimeoutMilliseconds`, `maxExportBatchSize`, `maxPayloadSizeInBytes`, `useS2SEndpoint`) in the main config through `A365Options`. ([#94](https://github.com/microsoft/opentelemetry-distro-javascript/pull/94))
 - Make Statsbeat feature/instrumentation tracking universal across Azure Monitor, A365, and OTLP paths. Add a standalone SDKStats pipeline that emits Feature/Instrumentation SDKStats to the Application Insights Statsbeat ingestion endpoint. New distro feature bits: `A365_EXPORT` (512), `OTLP_EXPORT` (1024), `CONSOLE_EXPORT` (2048). ([#85](https://github.com/microsoft/opentelemetry-distro-javascript/pull/85))
 - Report `mot` SDK version prefix to Azure Monitor and Quickpulse so `ai.internal.sdkVersion` surfaces the distro version. ([#86](https://github.com/microsoft/opentelemetry-distro-javascript/pull/86))
 
 ### Bugs Fixed
-
 - `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable now correctly acts only as a secondary toggle within an already-configured A365 setup, preventing it from silently disabling HTTP instrumentation or creating a broken exporter. ([#83](https://github.com/microsoft/opentelemetry-distro-javascript/pull/83))
 - Enable GenAI instrumentations (OpenAI Agents, LangChain) by default for all users. Previously they were only initialized when `instrumentationOptions` explicitly included them. ([#87](https://github.com/microsoft/opentelemetry-distro-javascript/pull/87))
 
 ### Other Changes
-
 - Documentation updates for A365 observability. ([#82](https://github.com/microsoft/opentelemetry-distro-javascript/pull/82))
 - Add custom SpanProcessor filtering scenario to A365 migration guide. ([#89](https://github.com/microsoft/opentelemetry-distro-javascript/pull/89))
 - Update A365 documentation title, Learn docs links, and expand migration guide with resource config, auto-instrumentation behavior, and troubleshooting guidance. ([#96](https://github.com/microsoft/opentelemetry-distro-javascript/pull/96))
@@ -91,69 +80,57 @@ First stable (GA) release. Promotes all functionality from the 0.1.0-beta series
 First beta release. Promotes all functionality from the 0.1.0-alpha series.
 
 ### Breaking Changes
-
 - When A365 is enabled through configured A365 options, non-GenAI instrumentations are now disabled by default unless explicitly enabled in `instrumentationOptions`. `ENABLE_A365_OBSERVABILITY_EXPORTER` no longer activates A365 on its own; it only toggles the exporter within an already-configured A365 setup. ([#79](https://github.com/microsoft/opentelemetry-distro-javascript/pull/79))
 - Align GenAI instrumentations with A365 observability schema: use structured message format, update span kinds and attributes (`gen_ai.agent.name`, `gen_ai.conversation.id`, `error.type`), and remove `isContentRecordingEnabled` option (content is now always recorded). ([#75](https://github.com/microsoft/opentelemetry-distro-javascript/pull/75))
 
 ### Features Added
-
 - Add ESM loader entrypoint (`@microsoft/opentelemetry/loader`) and document ESM support. ([#74](https://github.com/microsoft/opentelemetry-distro-javascript/pull/74))
 
 ### Bugs Fixed
-
 - `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable no longer activates A365 on its own. A365 options must be provided in code; the env var only toggles the exporter within an already-configured A365 setup. ([#43](https://github.com/microsoft/opentelemetry-distro-javascript/issues/43))
 - Fix `Agent365Exporter` not emitting `[EVENT]:` export outcome logs to a logger configured via `configureA365Logger` after the exporter was constructed. The exporter previously cached the logger snapshot at construction time, so the distro-bootstrapped exporter never picked up partner-supplied loggers. ([#81](https://github.com/microsoft/opentelemetry-distro-javascript/pull/81))
 - Register `A365SpanProcessor` for console fallback path so `telemetry.sdk.*` attributes and baggage-to-span enrichment are present when the A365 exporter is disabled. ([#78](https://github.com/microsoft/opentelemetry-distro-javascript/pull/78))
 - Restore `AgenticTokenCache` that was accidentally removed in #66. ([#77](https://github.com/microsoft/opentelemetry-distro-javascript/pull/77))
 
 ### Other Changes
-
 - Bump postcss from 8.5.8 to 8.5.10. ([#72](https://github.com/microsoft/opentelemetry-distro-javascript/pull/72))
 
 ## [0.1.0-alpha.6] - 2026-04-24
 
 ### Breaking Changes
-
 - Remove `A365BaggageOptions` and `A365HostingOptions` configuration types and the `a365.baggage` and `a365.hosting` configuration options. These options were never hooked up to runtime behavior and do not exist in the baseline package. `A365SpanProcessor` is now unconditionally enabled whenever A365 export is enabled. See the [A365 migration guide](./MIGRATION_A365.md) for details. ([#66](https://github.com/microsoft/opentelemetry-distro-javascript/pull/66))
 
 ### Features Added
-
 - Add `configureA365Hosting(adapter, options?)` helper for one-line A365 hosting middleware setup. ([#55](https://github.com/microsoft/opentelemetry-distro-javascript/pull/55))
 - Add `AgenticTokenCache` for built-in token caching support. ([#68](https://github.com/microsoft/opentelemetry-distro-javascript/pull/68))
 - Migrate `PerRequestSpanProcessor` from Agent365-nodejs. ([#70](https://github.com/microsoft/opentelemetry-distro-javascript/pull/70))
 
 ### Bugs Fixed
-
 - Fix hosting middleware for plain CloudAdapter activities. ([#64](https://github.com/microsoft/opentelemetry-distro-javascript/pull/64))
 - Restore A365 exporter event logs for export outcomes. ([#67](https://github.com/microsoft/opentelemetry-distro-javascript/pull/67))
 
 ### Other Changes
-
 - Unify GenAI init order and add distro integration coverage. ([#63](https://github.com/microsoft/opentelemetry-distro-javascript/pull/63))
 - Temporarily remove co-code owners. ([#65](https://github.com/microsoft/opentelemetry-distro-javascript/pull/65))
 - Update A365 migration guide. ([#69](https://github.com/microsoft/opentelemetry-distro-javascript/pull/69))
 
-## [0.1.0-alpha.5] - 2026-04-24
+## [0.1.0-alpha.5] - 2026-04-24 
 
 ### Breaking Changes
-
 - Remove Azure Functions auto-instrumentation support from this package. The `instrumentationOptions.azureFunctions` option is no longer available. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Remove JSON configuration support (`applicationinsights.json`, `APPLICATIONINSIGHTS_CONFIGURATION_FILE`, and `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT`). Configuration now comes only from programmatic options and environment variables. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
 - Remove `PerRequestSpanProcessor` and `PerRequestSpanProcessorOptions` from the public API. ([#47](https://github.com/microsoft/opentelemetry-distro-javascript/pull/47))
 
 ### Features Added
-
 - Expose additional A365 public configuration options through `A365Options`: `serviceNamespace`, `exporterOptions`, `observabilityLogLevel`, and `logger`.
 - Add A365 logger configuration support with injectable `ILogger`, `configureA365Logger`, `getA365Logger`, and env override via `A365_OBSERVABILITY_LOG_LEVEL`.
 - Apply A365 exporter tuning options to batch processor/exporter wiring and support global `service.namespace` resource merge when configured via A365 options.
 
 ### Bugs Fixed
-
 - Prevent ESM/CJS interop regressions by removing the problematic Azure Functions instrumentation path and adding explicit built-ESM import regression coverage. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Remove startup noise caused by implicit JSON config file probing in the Microsoft distro. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
 
 ### Other Changes
-
 - Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Bump hono from 4.12.12 to 4.12.14. ([#19](https://github.com/microsoft/opentelemetry-distro-javascript/pull/19))
 - Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test.
@@ -162,38 +139,33 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 ## [0.1.0-alpha.4] - 2026-04-22
 
 ### Breaking Changes
-
 - Remove `PerRequestSpanProcessor` and its `PerRequestSpanProcessorOptions` from the public API. The `perRequestExport` option on `A365Options` and the `ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT` environment variable have also been removed. ([#40](https://github.com/microsoft/opentelemetry-distro-javascript/pull/40))
   - **Migration:** If you were relying on per-request export behaviour, use the now-public `Agent365Exporter` together with any OTel-compatible `SpanProcessor`. See the [migration guide](./MIGRATION_A365.md#custom-span-export) for an example.
 
 ### Features Added
-
 - Export `Agent365Exporter`, `Agent365ExporterOptions`, and `TokenResolver` as public API to enable custom span processor configurations. ([#40](https://github.com/microsoft/opentelemetry-distro-javascript/pull/40))
 - Add console exporter ([#35](https://github.com/microsoft/opentelemetry-distro-javascript/pull/35))
 - Conditional azure monitor and readme updates ([#33](https://github.com/microsoft/opentelemetry-distro-javascript/pull/33))
 - Add a365 hosting middleware ([#29](https://github.com/microsoft/opentelemetry-distro-javascript/pull/29))
 
 ### Bugs Fixed
-
 - Fix A365 scopes producing no-op spans with zeroed trace/span IDs after distro initialization. ([#41](https://github.com/microsoft/opentelemetry-distro-javascript/pull/41))
 - Remove legacy useAzureMonitor API and add Azure Monitor E2E tests([#38](https://github.com/microsoft/opentelemetry-distro-javascript/pull/38))
 
 ## [0.1.0-alpha.3] - 2026-04-21
 
 ### Features Added
-
 - Vendor A365 observability code in-repo: scopes, exporter, processors, baggage, context propagation, and configuration ([#27](https://github.com/microsoft/opentelemetry-distro-javascript/pull/27))
 - Add Azure Monitor disable flag ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 
 ### Bugs Fixed
-
 - Fix dual ESM/CJS output ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 - Fix samples build: use local package reference, add `skipLibCheck`, replace deprecated `ChatOpenAI` with `AzureChatOpenAI` ([#28](https://github.com/microsoft/opentelemetry-distro-javascript/pull/28))
+
 
 ## [0.1.0-alpha.2] - 2026-04-20
 
 ### Features Added
-
 - Integrate A365 observability with the distro ([#25](https://github.com/microsoft/opentelemetry-distro-javascript/pull/25))
 - Move Azure Monitor files into src/azureMonitor/ subdirectory ([#23](https://github.com/microsoft/opentelemetry-distro-javascript/pull/23))
 - Add OpenAI Agents SDK instrumentation. ([#14](https://github.com/microsoft/opentelemetry-distro-javascript/pull/14))
@@ -201,7 +173,6 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 ## [0.1.0-alpha.1] - 2026-04-10
 
 ### Features Added
-
 - `useMicrosoftOpenTelemetry` entry point with Azure Monitor integration.
 - `shutdownMicrosoftOpenTelemetry` for clean teardown.
 - Modular setup architecture with extension points for OTLP and A365.
@@ -210,7 +181,6 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 - Add langchain instrumentation. ([#10](https://github.com/microsoft/opentelemetry-distro-javascript/pull/10))
 
 ### Other Changes
-
 - Initial project scaffolding with TypeScript, ESLint, and Vitest.
 - PR validation CI workflow.
 - Added `azure-monitor-opentelemetry` package source for Azure Monitor OpenTelemetry distro integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 - A365: forward `a365.maxQueueSize`, `a365.scheduledDelayMilliseconds`, `a365.maxExportBatchSize`, and `a365.exporterTimeoutMilliseconds` to the `BatchSpanProcessor` that wraps the `Agent365Exporter`.
-- A365: add a configurable timeout to agentic token exchange so an unresponsive STS no longer hangs telemetry exports indefinitely [#183](https://github.com/microsoft/opentelemetry-distro-javascript/pull/183)
+- A365: add a configurable timeout to agentic token exchange so an unresponsive STS no longer hangs telemetry exports indefinitely
 
 ## [1.1.0] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## [Unreleased]
 
 ### Bugs Fixed
+
 - A365: forward `a365.maxQueueSize`, `a365.scheduledDelayMilliseconds`, `a365.maxExportBatchSize`, and `a365.exporterTimeoutMilliseconds` to the `BatchSpanProcessor` that wraps the `Agent365Exporter`.
+- A365: add a configurable timeout to agentic token exchange so an unresponsive STS no longer hangs telemetry exports indefinitely [#183](https://github.com/microsoft/opentelemetry-distro-javascript/pull/183)
 
 ## [1.1.0] - 2026-05-29
 
 ### Features Added
+
 - Add network SDKStats (request success) for A365 + OTLP exporters [#145](https://github.com/microsoft/opentelemetry-distro-javascript/pull/145)
 - Update message format to align with OTel spec [#155](https://github.com/microsoft/opentelemetry-distro-javascript/pull/155)
 - Add `ApplyGuardrailScope` for security guardrail tracing [#157](https://github.com/microsoft/opentelemetry-distro-javascript/pull/157)
@@ -15,6 +18,7 @@
 - Add `ContextualTokenResolver` with agentic user ID support [#159](https://github.com/microsoft/opentelemetry-distro-javascript/pull/159)
 
 ### Bugs Fixed
+
 - LangChain: split request/response model and emit `gen_ai.response.id` [#127](https://github.com/microsoft/opentelemetry-distro-javascript/pull/127)
 - Add product context fallback for subchannels [#133](https://github.com/microsoft/opentelemetry-distro-javascript/pull/133)
 - Revert `getCallerBaggagePairs` userId fallback [#140](https://github.com/microsoft/opentelemetry-distro-javascript/pull/140)
@@ -23,6 +27,7 @@
 - LangChain: populate `gen_ai.response.model` for Responses API (`useResponsesApi`) [#151](https://github.com/microsoft/opentelemetry-distro-javascript/pull/151)
 
 ### Other Changes
+
 - Update telemetry SDK name to `microsoft-opentelemetry` [#134](https://github.com/microsoft/opentelemetry-distro-javascript/pull/134)
 - Correct repository URLs from Azure to microsoft org and add API docs badge [#136](https://github.com/microsoft/opentelemetry-distro-javascript/pull/136)
 - Only redeploy docs when package version changes [#141](https://github.com/microsoft/opentelemetry-distro-javascript/pull/141)
@@ -35,10 +40,12 @@
 ## [1.0.2] - 2026-05-11
 
 ### Bugs Fixed
+
 - Fix `getCallerBaggagePairs` to resolve `userId` across all channels [#116](https://github.com/microsoft/opentelemetry-distro-javascript/pull/116)
 - Import OpenAI agent types from `@openai/agents` to avoid version drift [#122](https://github.com/microsoft/opentelemetry-distro-javascript/pull/122)
 
 ### Other Changes
+
 - Accept beta versions of azure monitor exporter but not preview versions [#110](https://github.com/microsoft/opentelemetry-distro-javascript/pull/110)
 - Add explicit `enableConsoleExporters` to migration guide validation section [#121](https://github.com/microsoft/opentelemetry-distro-javascript/pull/121)
 - Promote A365 sub-owners in CODEOWNERS [#123](https://github.com/microsoft/opentelemetry-distro-javascript/pull/123)
@@ -46,6 +53,7 @@
 ## [1.0.1] - 2026-05-01
 
 ### Other Changes
+
 - Lazy-load LangChain tracer to avoid eager import of `@langchain/core` before instrumentation hooks register. Removed noise when openai and langchain packages are not installed [#98](https://github.com/microsoft/opentelemetry-distro-javascript/pull/98)
 - Add Fabric/ADX getting started guide and sample app [#100](https://github.com/microsoft/opentelemetry-distro-javascript/pull/100)
 
@@ -54,21 +62,25 @@
 First stable (GA) release. Promotes all functionality from the 0.1.0-beta series.
 
 ### Breaking Changes
+
 - A365: `a365.enabled: true` now registers only the `A365SpanProcessor`. Set `a365.enableObservabilityExporter: true` (or `ENABLE_A365_OBSERVABILITY_EXPORTER=true`) to also add the A365 HTTP exporter. ([#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - A365: `ENABLE_A365_OBSERVABILITY_EXPORTER` env var now toggles only the HTTP exporter, not the master `a365.enabled` flag. ([#83](https://github.com/microsoft/opentelemetry-distro-javascript/pull/83), [#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - Remove `hostDetector` from default resource detectors. Host attributes (`host.name`, `host.id`, etc.) are no longer added by default. Opt back in via `OTEL_NODE_RESOURCE_DETECTORS=env,host,os`. ([#97](https://github.com/microsoft/opentelemetry-distro-javascript/pull/97))
 
 ### Features Added
+
 - Add `a365.enableObservabilityExporter`, `a365.observabilityScopeOverride`, and `a365.logLevel` code options as equivalents of `ENABLE_A365_OBSERVABILITY_EXPORTER`, `A365_OBSERVABILITY_SCOPES_OVERRIDE`, and `A365_OBSERVABILITY_LOG_LEVEL`. Programmatic values take precedence over env vars. ([#93](https://github.com/microsoft/opentelemetry-distro-javascript/pull/93))
 - Expose all A365 exporter/batching settings (`maxQueueSize`, `scheduledDelayMilliseconds`, `exporterTimeoutMilliseconds`, `httpRequestTimeoutMilliseconds`, `maxExportBatchSize`, `maxPayloadSizeInBytes`, `useS2SEndpoint`) in the main config through `A365Options`. ([#94](https://github.com/microsoft/opentelemetry-distro-javascript/pull/94))
 - Make Statsbeat feature/instrumentation tracking universal across Azure Monitor, A365, and OTLP paths. Add a standalone SDKStats pipeline that emits Feature/Instrumentation SDKStats to the Application Insights Statsbeat ingestion endpoint. New distro feature bits: `A365_EXPORT` (512), `OTLP_EXPORT` (1024), `CONSOLE_EXPORT` (2048). ([#85](https://github.com/microsoft/opentelemetry-distro-javascript/pull/85))
 - Report `mot` SDK version prefix to Azure Monitor and Quickpulse so `ai.internal.sdkVersion` surfaces the distro version. ([#86](https://github.com/microsoft/opentelemetry-distro-javascript/pull/86))
 
 ### Bugs Fixed
+
 - `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable now correctly acts only as a secondary toggle within an already-configured A365 setup, preventing it from silently disabling HTTP instrumentation or creating a broken exporter. ([#83](https://github.com/microsoft/opentelemetry-distro-javascript/pull/83))
 - Enable GenAI instrumentations (OpenAI Agents, LangChain) by default for all users. Previously they were only initialized when `instrumentationOptions` explicitly included them. ([#87](https://github.com/microsoft/opentelemetry-distro-javascript/pull/87))
 
 ### Other Changes
+
 - Documentation updates for A365 observability. ([#82](https://github.com/microsoft/opentelemetry-distro-javascript/pull/82))
 - Add custom SpanProcessor filtering scenario to A365 migration guide. ([#89](https://github.com/microsoft/opentelemetry-distro-javascript/pull/89))
 - Update A365 documentation title, Learn docs links, and expand migration guide with resource config, auto-instrumentation behavior, and troubleshooting guidance. ([#96](https://github.com/microsoft/opentelemetry-distro-javascript/pull/96))
@@ -79,57 +91,69 @@ First stable (GA) release. Promotes all functionality from the 0.1.0-beta series
 First beta release. Promotes all functionality from the 0.1.0-alpha series.
 
 ### Breaking Changes
+
 - When A365 is enabled through configured A365 options, non-GenAI instrumentations are now disabled by default unless explicitly enabled in `instrumentationOptions`. `ENABLE_A365_OBSERVABILITY_EXPORTER` no longer activates A365 on its own; it only toggles the exporter within an already-configured A365 setup. ([#79](https://github.com/microsoft/opentelemetry-distro-javascript/pull/79))
 - Align GenAI instrumentations with A365 observability schema: use structured message format, update span kinds and attributes (`gen_ai.agent.name`, `gen_ai.conversation.id`, `error.type`), and remove `isContentRecordingEnabled` option (content is now always recorded). ([#75](https://github.com/microsoft/opentelemetry-distro-javascript/pull/75))
 
 ### Features Added
+
 - Add ESM loader entrypoint (`@microsoft/opentelemetry/loader`) and document ESM support. ([#74](https://github.com/microsoft/opentelemetry-distro-javascript/pull/74))
 
 ### Bugs Fixed
+
 - `ENABLE_A365_OBSERVABILITY_EXPORTER` environment variable no longer activates A365 on its own. A365 options must be provided in code; the env var only toggles the exporter within an already-configured A365 setup. ([#43](https://github.com/microsoft/opentelemetry-distro-javascript/issues/43))
 - Fix `Agent365Exporter` not emitting `[EVENT]:` export outcome logs to a logger configured via `configureA365Logger` after the exporter was constructed. The exporter previously cached the logger snapshot at construction time, so the distro-bootstrapped exporter never picked up partner-supplied loggers. ([#81](https://github.com/microsoft/opentelemetry-distro-javascript/pull/81))
 - Register `A365SpanProcessor` for console fallback path so `telemetry.sdk.*` attributes and baggage-to-span enrichment are present when the A365 exporter is disabled. ([#78](https://github.com/microsoft/opentelemetry-distro-javascript/pull/78))
 - Restore `AgenticTokenCache` that was accidentally removed in #66. ([#77](https://github.com/microsoft/opentelemetry-distro-javascript/pull/77))
 
 ### Other Changes
+
 - Bump postcss from 8.5.8 to 8.5.10. ([#72](https://github.com/microsoft/opentelemetry-distro-javascript/pull/72))
 
 ## [0.1.0-alpha.6] - 2026-04-24
 
 ### Breaking Changes
+
 - Remove `A365BaggageOptions` and `A365HostingOptions` configuration types and the `a365.baggage` and `a365.hosting` configuration options. These options were never hooked up to runtime behavior and do not exist in the baseline package. `A365SpanProcessor` is now unconditionally enabled whenever A365 export is enabled. See the [A365 migration guide](./MIGRATION_A365.md) for details. ([#66](https://github.com/microsoft/opentelemetry-distro-javascript/pull/66))
 
 ### Features Added
+
 - Add `configureA365Hosting(adapter, options?)` helper for one-line A365 hosting middleware setup. ([#55](https://github.com/microsoft/opentelemetry-distro-javascript/pull/55))
 - Add `AgenticTokenCache` for built-in token caching support. ([#68](https://github.com/microsoft/opentelemetry-distro-javascript/pull/68))
 - Migrate `PerRequestSpanProcessor` from Agent365-nodejs. ([#70](https://github.com/microsoft/opentelemetry-distro-javascript/pull/70))
 
 ### Bugs Fixed
+
 - Fix hosting middleware for plain CloudAdapter activities. ([#64](https://github.com/microsoft/opentelemetry-distro-javascript/pull/64))
 - Restore A365 exporter event logs for export outcomes. ([#67](https://github.com/microsoft/opentelemetry-distro-javascript/pull/67))
 
 ### Other Changes
+
 - Unify GenAI init order and add distro integration coverage. ([#63](https://github.com/microsoft/opentelemetry-distro-javascript/pull/63))
 - Temporarily remove co-code owners. ([#65](https://github.com/microsoft/opentelemetry-distro-javascript/pull/65))
 - Update A365 migration guide. ([#69](https://github.com/microsoft/opentelemetry-distro-javascript/pull/69))
 
-## [0.1.0-alpha.5] - 2026-04-24 
+## [0.1.0-alpha.5] - 2026-04-24
 
 ### Breaking Changes
+
 - Remove Azure Functions auto-instrumentation support from this package. The `instrumentationOptions.azureFunctions` option is no longer available. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Remove JSON configuration support (`applicationinsights.json`, `APPLICATIONINSIGHTS_CONFIGURATION_FILE`, and `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT`). Configuration now comes only from programmatic options and environment variables. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
 - Remove `PerRequestSpanProcessor` and `PerRequestSpanProcessorOptions` from the public API. ([#47](https://github.com/microsoft/opentelemetry-distro-javascript/pull/47))
 
 ### Features Added
+
 - Expose additional A365 public configuration options through `A365Options`: `serviceNamespace`, `exporterOptions`, `observabilityLogLevel`, and `logger`.
 - Add A365 logger configuration support with injectable `ILogger`, `configureA365Logger`, `getA365Logger`, and env override via `A365_OBSERVABILITY_LOG_LEVEL`.
 - Apply A365 exporter tuning options to batch processor/exporter wiring and support global `service.namespace` resource merge when configured via A365 options.
 
 ### Bugs Fixed
+
 - Prevent ESM/CJS interop regressions by removing the problematic Azure Functions instrumentation path and adding explicit built-ESM import regression coverage. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Remove startup noise caused by implicit JSON config file probing in the Microsoft distro. ([#49](https://github.com/microsoft/opentelemetry-distro-javascript/pull/49))
 
 ### Other Changes
+
 - Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test. ([#45](https://github.com/microsoft/opentelemetry-distro-javascript/pull/45))
 - Bump hono from 4.12.12 to 4.12.14. ([#19](https://github.com/microsoft/opentelemetry-distro-javascript/pull/19))
 - Expand PR validation checks to run unit tests, functional tests, and a built ESM import smoke test.
@@ -138,33 +162,38 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 ## [0.1.0-alpha.4] - 2026-04-22
 
 ### Breaking Changes
+
 - Remove `PerRequestSpanProcessor` and its `PerRequestSpanProcessorOptions` from the public API. The `perRequestExport` option on `A365Options` and the `ENABLE_A365_OBSERVABILITY_PER_REQUEST_EXPORT` environment variable have also been removed. ([#40](https://github.com/microsoft/opentelemetry-distro-javascript/pull/40))
   - **Migration:** If you were relying on per-request export behaviour, use the now-public `Agent365Exporter` together with any OTel-compatible `SpanProcessor`. See the [migration guide](./MIGRATION_A365.md#custom-span-export) for an example.
 
 ### Features Added
+
 - Export `Agent365Exporter`, `Agent365ExporterOptions`, and `TokenResolver` as public API to enable custom span processor configurations. ([#40](https://github.com/microsoft/opentelemetry-distro-javascript/pull/40))
 - Add console exporter ([#35](https://github.com/microsoft/opentelemetry-distro-javascript/pull/35))
 - Conditional azure monitor and readme updates ([#33](https://github.com/microsoft/opentelemetry-distro-javascript/pull/33))
 - Add a365 hosting middleware ([#29](https://github.com/microsoft/opentelemetry-distro-javascript/pull/29))
 
 ### Bugs Fixed
+
 - Fix A365 scopes producing no-op spans with zeroed trace/span IDs after distro initialization. ([#41](https://github.com/microsoft/opentelemetry-distro-javascript/pull/41))
 - Remove legacy useAzureMonitor API and add Azure Monitor E2E tests([#38](https://github.com/microsoft/opentelemetry-distro-javascript/pull/38))
 
 ## [0.1.0-alpha.3] - 2026-04-21
 
 ### Features Added
+
 - Vendor A365 observability code in-repo: scopes, exporter, processors, baggage, context propagation, and configuration ([#27](https://github.com/microsoft/opentelemetry-distro-javascript/pull/27))
 - Add Azure Monitor disable flag ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 
 ### Bugs Fixed
+
 - Fix dual ESM/CJS output ([#30](https://github.com/microsoft/opentelemetry-distro-javascript/pull/30))
 - Fix samples build: use local package reference, add `skipLibCheck`, replace deprecated `ChatOpenAI` with `AzureChatOpenAI` ([#28](https://github.com/microsoft/opentelemetry-distro-javascript/pull/28))
-
 
 ## [0.1.0-alpha.2] - 2026-04-20
 
 ### Features Added
+
 - Integrate A365 observability with the distro ([#25](https://github.com/microsoft/opentelemetry-distro-javascript/pull/25))
 - Move Azure Monitor files into src/azureMonitor/ subdirectory ([#23](https://github.com/microsoft/opentelemetry-distro-javascript/pull/23))
 - Add OpenAI Agents SDK instrumentation. ([#14](https://github.com/microsoft/opentelemetry-distro-javascript/pull/14))
@@ -172,6 +201,7 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 ## [0.1.0-alpha.1] - 2026-04-10
 
 ### Features Added
+
 - `useMicrosoftOpenTelemetry` entry point with Azure Monitor integration.
 - `shutdownMicrosoftOpenTelemetry` for clean teardown.
 - Modular setup architecture with extension points for OTLP and A365.
@@ -180,6 +210,7 @@ First beta release. Promotes all functionality from the 0.1.0-alpha series.
 - Add langchain instrumentation. ([#10](https://github.com/microsoft/opentelemetry-distro-javascript/pull/10))
 
 ### Other Changes
+
 - Initial project scaffolding with TypeScript, ESLint, and Vitest.
 - PR validation CI workflow.
 - Added `azure-monitor-opentelemetry` package source for Azure Monitor OpenTelemetry distro integration.

--- a/README.md
+++ b/README.md
@@ -345,18 +345,19 @@ useMicrosoftOpenTelemetry({
 
 A365 options can also be set via environment variables (highest precedence):
 
-| Environment Variable                      | Description                                                                                                                            |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `ENABLE_A365_OBSERVABILITY_EXPORTER`      | `"true"` / `"false"` — override `enabled`                                                                                              |
-| `A365_OBSERVABILITY_SCOPES_OVERRIDE`      | Space-separated list of OAuth scopes                                                                                                   |
-| `A365_OBSERVABILITY_DOMAIN_OVERRIDE`      | Override service domain                                                                                                                |
-| `CLUSTER_CATEGORY`                        | Override cluster category                                                                                                              |
-| `A365_OBSERVABILITY_LOG_LEVEL`            | A365 internal logger filter level (`none`, `info`, `warn`, `error`, or pipe-delimited combination) — overrides `observabilityLogLevel` |
-| `A365_PER_REQUEST_MAX_TRACES`             | Max buffered traces (default: `1000`)                                                                                                  |
-| `A365_PER_REQUEST_MAX_SPANS_PER_TRACE`    | Max spans per trace (default: `5000`)                                                                                                  |
-| `A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS` | Max concurrent exports (default: `20`)                                                                                                 |
-| `A365_PER_REQUEST_FLUSH_GRACE_MS`         | Grace period after root span ends (default: `250`)                                                                                     |
-| `A365_PER_REQUEST_MAX_TRACE_AGE_MS`       | Max trace age before forced flush (default: `1800000`)                                                                                 |
+| Environment Variable                           | Description                                                                                                                            |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `ENABLE_A365_OBSERVABILITY_EXPORTER`           | `"true"` / `"false"` — override `enabled`                                                                                              |
+| `A365_OBSERVABILITY_SCOPES_OVERRIDE`           | Space-separated list of OAuth scopes                                                                                                   |
+| `A365_OBSERVABILITY_DOMAIN_OVERRIDE`           | Override service domain                                                                                                                |
+| `CLUSTER_CATEGORY`                             | Override cluster category                                                                                                              |
+| `A365_OBSERVABILITY_LOG_LEVEL`                 | A365 internal logger filter level (`none`, `info`, `warn`, `error`, or pipe-delimited combination) — overrides `observabilityLogLevel` |
+| `A365_PER_REQUEST_MAX_TRACES`                  | Max buffered traces (default: `1000`)                                                                                                  |
+| `A365_PER_REQUEST_MAX_SPANS_PER_TRACE`         | Max spans per trace (default: `5000`)                                                                                                  |
+| `A365_PER_REQUEST_MAX_CONCURRENT_EXPORTS`      | Max concurrent exports (default: `20`)                                                                                                 |
+| `A365_PER_REQUEST_FLUSH_GRACE_MS`              | Grace period after root span ends (default: `250`)                                                                                     |
+| `A365_PER_REQUEST_MAX_TRACE_AGE_MS`            | Max trace age before forced flush (default: `1800000`)                                                                                 |
+| `A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS` | Per-attempt timeout (ms) for agentic token exchange; `0` or negative disables (default: `30000`)                                       |
 
 ### Example
 

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -8,6 +8,9 @@
 import { getA365Logger } from "../logging.js";
 import type { TurnContextLike } from "./types.js";
 
+/** Max setTimeout delay (2^31 - 1 ms); larger values overflow and fire immediately. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 /**
  * Minimal authorization shape required by AgenticTokenCache.
  *
@@ -280,13 +283,13 @@ export class AgenticTokenCache {
     if (!(this._exchangeTimeoutMs > 0)) {
       return exchange;
     }
+    // setTimeout delays overflow a 32-bit signed int and fire immediately; clamp.
+    const delayMs = Math.min(this._exchangeTimeoutMs, MAX_TIMER_DELAY_MS);
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(
-          new Error(`[AgenticTokenCache] exchangeToken timeout after ${this._exchangeTimeoutMs}ms`),
-        );
-      }, this._exchangeTimeoutMs);
+        reject(new Error(`[AgenticTokenCache] exchangeToken timeout after ${delayMs}ms`));
+      }, delayMs);
     });
     try {
       return await Promise.race([exchange, timeout]);

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -55,8 +55,10 @@ export class AgenticTokenCache {
   private readonly _defaultMaxTokenAgeMs = 3_600_000;
   private readonly _maxCacheSize = 10_000;
   private readonly _maxExpSeconds = 86_400; // 24 hours
+  private readonly _defaultExchangeTimeoutMs = 30_000;
   private readonly _keyLocks = new Map<string, Promise<unknown>>();
   private readonly _authScopes: string[];
+  private readonly _exchangeTimeoutMs: number;
 
   constructor(options?: AgenticTokenCacheOptions) {
     const envScopes = process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE?.trim();
@@ -67,6 +69,12 @@ export class AgenticTokenCache {
         "api://9b975845-388f-4429-889e-eab1ef63949c/.default",
       ];
     }
+
+    // A non-positive timeout disables the guard (waits indefinitely).
+    const envTimeout = Number(process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS?.trim());
+    this._exchangeTimeoutMs = Number.isFinite(envTimeout)
+      ? envTimeout
+      : (options?.exchangeTimeoutMs ?? this._defaultExchangeTimeoutMs);
   }
 
   public static makeKey(agentId: string, tenantId: string): string {
@@ -152,9 +160,12 @@ export class AgenticTokenCache {
           `[AgenticTokenCache] Exchanging token attempt ${attempt + 1}/${maxRetries + 1}`,
         );
         try {
-          const tokenResponse = await authorization.exchangeToken(turnContext, authHandlerName, {
-            scopes: entry.scopes,
-          });
+          const tokenResponse = await this.exchangeTokenWithTimeout(
+            authorization,
+            turnContext,
+            authHandlerName,
+            entry.scopes,
+          );
           if (!tokenResponse?.token) {
             getA365Logger().error("[AgenticTokenCache] Undefined token returned");
             entry.token = undefined;
@@ -251,6 +262,41 @@ export class AgenticTokenCache {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  /**
+   * Wraps exchangeToken in a timeout so an unresponsive STS/auth service
+   * surfaces a (retriable) timeout error instead of hanging the refresh
+   * promise indefinitely and stalling all dependent exports. The rejection
+   * message contains "timeout" so {@link isRetriableError} retries it.
+   */
+  private async exchangeTokenWithTimeout(
+    authorization: AuthorizationLike,
+    turnContext: TurnContextLike,
+    authHandlerName: string,
+    scopes: string[],
+  ): Promise<{ token?: string } | undefined> {
+    const exchange = authorization.exchangeToken(turnContext, authHandlerName, { scopes });
+    if (!(this._exchangeTimeoutMs > 0)) {
+      return exchange;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `[AgenticTokenCache] exchangeToken timeout after ${this._exchangeTimeoutMs}ms`,
+          ),
+        );
+      }, this._exchangeTimeoutMs);
+    });
+    try {
+      return await Promise.race([exchange, timeout]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
   private withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     // Chain onto any existing promise for this key so that concurrent
     // callers are serialised rather than racing after the same await.
@@ -277,6 +323,13 @@ export class AgenticTokenCache {
 export interface AgenticTokenCacheOptions {
   /** OAuth scopes for token exchange. Defaults to the A365 observability scope. */
   authScopes?: string[];
+  /**
+   * Per-attempt timeout (ms) for the `exchangeToken` call. A timed-out attempt
+   * is treated as a retriable error. Set to 0 or a negative value to disable
+   * (wait indefinitely). Overridden by the
+   * `A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS` env var. @default 30000
+   */
+  exchangeTimeoutMs?: number;
 }
 
 /**

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -71,7 +71,9 @@ export class AgenticTokenCache {
     }
 
     // A non-positive timeout disables the guard (waits indefinitely).
-    const envTimeout = Number(process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS?.trim());
+    // A blank/unset env var falls through to the option/default.
+    const rawTimeout = process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS?.trim();
+    const envTimeout = rawTimeout ? Number(rawTimeout) : NaN;
     this._exchangeTimeoutMs = Number.isFinite(envTimeout)
       ? envTimeout
       : (options?.exchangeTimeoutMs ?? this._defaultExchangeTimeoutMs);

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -9,7 +9,7 @@ import { getA365Logger } from "../logging.js";
 import type { TurnContextLike } from "./types.js";
 
 /** Max setTimeout delay (2^31 - 1 ms); larger values overflow and fire immediately. */
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 
 /**
  * Minimal authorization shape required by AgenticTokenCache.

--- a/src/a365/hosting/agenticTokenCache.ts
+++ b/src/a365/hosting/agenticTokenCache.ts
@@ -282,9 +282,7 @@ export class AgenticTokenCache {
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
         reject(
-          new Error(
-            `[AgenticTokenCache] exchangeToken timeout after ${this._exchangeTimeoutMs}ms`,
-          ),
+          new Error(`[AgenticTokenCache] exchangeToken timeout after ${this._exchangeTimeoutMs}ms`),
         );
       }, this._exchangeTimeoutMs);
     });

--- a/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
+++ b/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
@@ -414,6 +414,24 @@ describe("AgenticTokenCache", () => {
     }
   });
 
+  it("clamps an oversized timeout so it does not fire immediately", async () => {
+    // A delay above 2^31-1 overflows setTimeout and would fire ~immediately
+    // without clamping; with clamping the (slow) exchange still wins the race.
+    const timeoutCache = new AgenticTokenCache({ exchangeTimeoutMs: 2_147_483_648 * 4 });
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 30));
+        return { token: jwt };
+      }),
+    };
+
+    await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(1);
+    expect(timeoutCache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
   it("reads the timeout from the env var when set", async () => {
     const prev = process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS;
     process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS = "10";

--- a/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
+++ b/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
@@ -390,4 +390,49 @@ describe("AgenticTokenCache", () => {
     expect(auth.exchangeToken).toHaveBeenCalledTimes(1);
     expect(timeoutCache.getObservabilityToken("a", "t")).toBe(jwt);
   });
+
+  it("does not disable the guard when the env var is set but blank", async () => {
+    const prev = process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS;
+    process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS = "  ";
+    try {
+      // Blank env var must fall through to the option (not parse to 0/disabled).
+      const timeoutCache = new AgenticTokenCache({ exchangeTimeoutMs: 10 });
+      const auth: AuthorizationLike = {
+        exchangeToken: vi.fn(() => new Promise(() => {})),
+      };
+
+      await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+      expect(auth.exchangeToken).toHaveBeenCalledTimes(3);
+      expect(timeoutCache.getObservabilityToken("a", "t")).toBeNull();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS;
+      } else {
+        process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS = prev;
+      }
+    }
+  });
+
+  it("reads the timeout from the env var when set", async () => {
+    const prev = process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS;
+    process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS = "10";
+    try {
+      const timeoutCache = new AgenticTokenCache();
+      const auth: AuthorizationLike = {
+        exchangeToken: vi.fn(() => new Promise(() => {})),
+      };
+
+      await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+      expect(auth.exchangeToken).toHaveBeenCalledTimes(3);
+      expect(timeoutCache.getObservabilityToken("a", "t")).toBeNull();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS;
+      } else {
+        process.env.A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS = prev;
+      }
+    }
+  });
 });

--- a/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
+++ b/test/internal/unit/a365/hosting/agenticTokenCache.test.ts
@@ -341,4 +341,53 @@ describe("AgenticTokenCache", () => {
   it("makeKey produces agent:tenant format", () => {
     expect(AgenticTokenCache.makeKey("agent1", "tenant1")).toBe("agent1:tenant1");
   });
+
+  // ── Timeout guard (hung STS / auth) ──────────────────────────────────────
+
+  it("times out a hung exchangeToken and retries then succeeds", async () => {
+    const timeoutCache = new AgenticTokenCache({ exchangeTimeoutMs: 20 });
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    let call = 0;
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(() => {
+        call++;
+        // First attempt never settles (simulates unresponsive STS).
+        return call === 1 ? new Promise(() => {}) : Promise.resolve({ token: jwt });
+      }),
+    };
+
+    await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(2);
+    expect(timeoutCache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
+
+  it("does not hang indefinitely when exchangeToken never settles", async () => {
+    const timeoutCache = new AgenticTokenCache({ exchangeTimeoutMs: 10 });
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(() => new Promise(() => {})),
+    };
+
+    await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    // 1 initial attempt + 2 retries, all timing out.
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(3);
+    expect(timeoutCache.getObservabilityToken("a", "t")).toBeNull();
+  });
+
+  it("waits without timing out when timeout is disabled (0)", async () => {
+    const timeoutCache = new AgenticTokenCache({ exchangeTimeoutMs: 0 });
+    const jwt = makeJwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    const auth: AuthorizationLike = {
+      exchangeToken: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 40));
+        return { token: jwt };
+      }),
+    };
+
+    await timeoutCache.refreshObservabilityToken("a", "t", makeTurnContext(), auth);
+
+    expect(auth.exchangeToken).toHaveBeenCalledTimes(1);
+    expect(timeoutCache.getObservabilityToken("a", "t")).toBe(jwt);
+  });
 });


### PR DESCRIPTION
## Summary
Adds a timeout guard around the agentic token exchange in `AgenticTokenCache` (resolves AB#37981741).

## Problem
In `src/a365/hosting/agenticTokenCache.ts`, `authorization.exchangeToken(...)` was awaited with **no timeout, AbortSignal, or cancellation**. If the STS/auth service becomes unresponsive, the refresh promise never settles, so:
- the `await` hangs indefinitely,
- the retry loop (which only catches *rejections*) never engages, and
- the per-key `withKeyLock` stalls every subsequent refresh for that tenant/agent pair → **silent telemetry export loss**.

This was also inconsistent with the sibling exporter (`Agent365Exporter.ts`), which already guards HTTP with `AbortSignal.timeout(...)`.

## Change
- Added a configurable per-attempt timeout `exchangeTimeoutMs` (default **30000ms**, env override `A365_OBSERVABILITY_TOKEN_EXCHANGE_TIMEOUT_MS`; `0`/negative disables).
- New `exchangeTokenWithTimeout` helper races the call against a timer (the `AuthorizationLike` interface can't accept an `AbortSignal`), clearing the timer in `finally`.
- The timeout rejection message contains `"timeout"`, so the existing `isRetriableError` retries it, then fails cleanly (token cleared) instead of hanging.

## Tests
3 new unit tests: hang→timeout→retry→success, hang→exhaust retries→null (no infinite hang), and timeout-disabled passthrough.

## Verification
- `vitest` unit: **23/23 pass** (hang test resolves in ~660ms instead of hanging)
- `tsc -p tsconfig.src.json --noEmit`: clean
- `eslint` on changed files: clean