### PR TITLE
chore: remove unused AZURE_MONITOR_DISTRO_VERSION env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## [Unreleased]
+
+### Other Changes
+- Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`
+
 ## [1.2.0] - 2026-07-02
 
 ### Bugs Fixed

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -21,7 +21,6 @@ import { MetricHandler } from "../azureMonitor/metrics/index.js";
 import { TraceHandler } from "../azureMonitor/traces/handler.js";
 import { LogHandler } from "../azureMonitor/logs/index.js";
 import { ConnectionStringParser } from "../azureMonitor/utils/connectionStringParser.js";
-import { AZURE_MONITOR_OPENTELEMETRY_VERSION } from "../types.js";
 import { patchOpenTelemetryInstrumentationEnable } from "../utils/opentelemetryInstrumentationPatcher.js";
 import { parseResourceDetectorsFromEnvVar } from "../utils/common.js";
 import { getInstance as getSdkStatsInstance } from "../utils/sdkStats.js";
@@ -55,7 +54,6 @@ import {
 import { createInstrumentations, createSampler, createViews } from "./instrumentations.js";
 import { Logger } from "../shared/logging/index.js";
 
-process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSION;
 process.env["MICROSOFT_OPENTELEMETRY_VERSION"] = MICROSOFT_OPENTELEMETRY_VERSION;
 
 let sdk: NodeSDK;

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,6 @@ export interface BrowserSdkLoaderOptions {
   connectionString?: string;
 }
 
-export const AZURE_MONITOR_OPENTELEMETRY_VERSION = "1.18.2";
 export const AZURE_MONITOR_STATSBEAT_FEATURES = "AZURE_MONITOR_STATSBEAT_FEATURES";
 export const AZURE_MONITOR_PREFIX = "AZURE_MONITOR_PREFIX";
 export const AZURE_MONITOR_AUTO_ATTACH = "AZURE_MONITOR_AUTO_ATTACH";

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -85,15 +85,10 @@ describe("Main functions", () => {
   });
 
   it("sets MICROSOFT_OPENTELEMETRY_VERSION env var on import so the Azure Monitor exporter reports the 'mot' sdkVersion prefix", async () => {
-    const { MICROSOFT_OPENTELEMETRY_VERSION, AZURE_MONITOR_OPENTELEMETRY_VERSION } =
-      await import("../../../src/types.js");
+    const { MICROSOFT_OPENTELEMETRY_VERSION } = await import("../../../src/types.js");
     assert.strictEqual(
       process.env["MICROSOFT_OPENTELEMETRY_VERSION"],
       MICROSOFT_OPENTELEMETRY_VERSION,
-    );
-    assert.strictEqual(
-      process.env["AZURE_MONITOR_DISTRO_VERSION"],
-      AZURE_MONITOR_OPENTELEMETRY_VERSION,
     );
   });
 


### PR DESCRIPTION
## Summary
Removes the unused `AZURE_MONITOR_DISTRO_VERSION` environment variable (and its `AZURE_MONITOR_OPENTELEMETRY_VERSION` constant).

## Why
The Azure Monitor exporter's `Context._getVersion()` builds the `ai.internal.sdkVersion` tag and checks `MICROSOFT_OPENTELEMETRY_VERSION` **before** `AZURE_MONITOR_DISTRO_VERSION`. This distro sets both in `distro.ts`, so it always reports the `mot<version>` prefix and the `dst`/`AZURE_MONITOR_DISTRO_VERSION` branch is never reached. The assignment and its constant are therefore dead code with no effect on emitted telemetry.

## Changes
- `src/distro/distro.ts`: drop the `AZURE_MONITOR_DISTRO_VERSION` assignment and its import
- `src/types.ts`: remove the unused `AZURE_MONITOR_OPENTELEMETRY_VERSION` constant
- `test/internal/unit/main.test.ts`: drop the obsolete assertion
- `CHANGELOG.md`: Unreleased note

## Validation
Build, lint (0 errors), Prettier, and `main.test.ts` (56 tests) all pass. No behavior change.