### PR TITLE
Track on-by-default features/instrumentations as SDKStats opt-out flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Other Changes
 - Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`
+- SDKStats now tracks on-by-default features/instrumentations (disk retry, live metrics, Azure SDK, MongoDB, MySQL, PostgreSQL, Redis) as opt-out flags that are set only when the customer disables them.
 
 ## [1.2.0] - 2026-07-02
 

--- a/src/azureMonitor/index.ts
+++ b/src/azureMonitor/index.ts
@@ -66,7 +66,7 @@ export function getAzureMonitorSdkStatsFeatures(config: InternalConfig): SdkStat
   return {
     browserSdkLoader: config.browserSdkLoaderOptions.enabled,
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
-    diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
+    disableDiskRetry: !!config.azureMonitorExporterOptions?.disableOfflineStorage,
     aksResourceDetectorPopulation: aksResourceDetected,
   };
 }

--- a/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
+++ b/src/azureMonitor/metrics/quickpulse/liveMetrics.ts
@@ -294,9 +294,9 @@ export class LiveMetrics {
     if (this.meterProvider) {
       return;
     }
-    // Turn on live metrics active collection for SDK Stats
+    // Live metrics is now being accessed, so clear the "disabled" opt-out flag for SDK Stats.
     if (!this.sdkStatsOptionsUpdated) {
-      getInstance().setSdkStatsFeatures({}, { liveMetrics: true });
+      getInstance().setSdkStatsFeatures({}, { disableLiveMetrics: false });
       this.sdkStatsOptionsUpdated = true;
     }
     this.totalDependencyCount = 0;

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -190,11 +190,13 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
 
   // ── SDK Stats (feature & instrumentation tracking for all paths) ──
   const sdkStatsInstrumentations: SdkStatsInstrumentations = {
-    azureSdk: config.instrumentationOptions?.azureSdk?.enabled,
-    mongoDb: config.instrumentationOptions?.mongoDb?.enabled,
-    mySql: config.instrumentationOptions?.mySql?.enabled,
-    postgreSql: config.instrumentationOptions?.postgreSql?.enabled,
-    redis: config.instrumentationOptions?.redis?.enabled,
+    // On-by-default instrumentations: the flag is set only when the customer
+    // disables the instrumentation. Order must match the Kusto bit map.
+    disableAzureSdk: config.instrumentationOptions?.azureSdk?.enabled === false,
+    disableMongoDb: config.instrumentationOptions?.mongoDb?.enabled === false,
+    disableMySql: config.instrumentationOptions?.mySql?.enabled === false,
+    disablePostgreSql: config.instrumentationOptions?.postgreSql?.enabled === false,
+    disableRedis: config.instrumentationOptions?.redis?.enabled === false,
     bunyan: config.instrumentationOptions?.bunyan?.enabled,
     winston: config.instrumentationOptions?.winston?.enabled,
   };
@@ -204,12 +206,16 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
       : {
           browserSdkLoader: false,
           aadHandling: false,
-          diskRetry: false,
+          disableDiskRetry: false,
           aksResourceDetectorPopulation: false,
         }),
     a365: a365Config.enabled,
     otlp: otlpActive,
     customerSdkStats: process.env[APPLICATIONINSIGHTS_SDKSTATS_DISABLED]?.toLowerCase() === "true",
+    // Live metrics counts as "enabled" only when actually accessed (a live metrics
+    // session is established). At init it has not been accessed, so it starts as
+    // disabled; activateMetrics() clears this flag when a session connects.
+    disableLiveMetrics: true,
   };
   getSdkStatsInstance().setSdkStatsFeatures(sdkStatsInstrumentations, sdkStatsFeatures);
 

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -196,7 +196,11 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
     disableMongoDb: config.instrumentationOptions?.mongoDb?.enabled === false,
     disableMySql: config.instrumentationOptions?.mySql?.enabled === false,
     disablePostgreSql: config.instrumentationOptions?.postgreSql?.enabled === false,
-    disableRedis: config.instrumentationOptions?.redis?.enabled === false,
+    // redis and redis4 share the same underlying Redis instrumentation, which is
+    // registered when either is enabled. Only count Redis as disabled when both are off.
+    disableRedis:
+      config.instrumentationOptions?.redis?.enabled === false &&
+      config.instrumentationOptions?.redis4?.enabled === false,
     bunyan: config.instrumentationOptions?.bunyan?.enabled,
     winston: config.instrumentationOptions?.winston?.enabled,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,11 +139,11 @@ export interface LangChainInstrumentationConfig extends InstrumentationConfig {}
  * @internal
  */
 export interface SdkStatsFeatures {
-  diskRetry?: boolean;
+  disableDiskRetry?: boolean;
   aadHandling?: boolean;
   browserSdkLoader?: boolean;
   distro?: boolean;
-  liveMetrics?: boolean;
+  disableLiveMetrics?: boolean;
   shim?: boolean;
   customerSdkStats?: boolean;
   multiIkey?: boolean;
@@ -157,11 +157,11 @@ export interface SdkStatsFeatures {
  * @internal
  */
 export const SdkStatsFeaturesMap = new Map<string, number>([
-  ["diskRetry", 1],
+  ["disableDiskRetry", 1],
   ["aadHandling", 2],
   ["browserSdkLoader", 4],
   ["distro", 8],
-  ["liveMetrics", 16],
+  ["disableLiveMetrics", 16],
   ["shim", 32],
   ["customerSdkStats", 64],
   ["multiIkey", 128],
@@ -175,12 +175,13 @@ export const SdkStatsFeaturesMap = new Map<string, number>([
  * @internal
  */
 export interface SdkStatsInstrumentations {
-  /** Azure Monitor Supported Instrumentations */
-  azureSdk?: boolean;
-  mongoDb?: boolean;
-  mySql?: boolean;
-  postgreSql?: boolean;
-  redis?: boolean;
+  /** Azure Monitor Supported Instrumentations. These are on-by-default, so the
+   * flag is set only when the customer disables the instrumentation. */
+  disableAzureSdk?: boolean;
+  disableMongoDb?: boolean;
+  disableMySql?: boolean;
+  disablePostgreSql?: boolean;
+  disableRedis?: boolean;
   bunyan?: boolean;
   winston?: boolean;
   /** OpenTelemetry Community Instrumentations */
@@ -274,11 +275,11 @@ export const APPLICATIONINSIGHTS_SDKSTATS_DISABLED = "APPLICATIONINSIGHTS_SDKSTA
 
 export enum SdkStatsFeature {
   NONE = 0,
-  DISK_RETRY = 1,
+  DISABLE_DISK_RETRY = 1,
   AAD_HANDLING = 2,
   BROWSER_SDK_LOADER = 4,
   DISTRO = 8,
-  LIVE_METRICS = 16,
+  DISABLE_LIVE_METRICS = 16,
   SHIM = 32,
   CUSTOMER_SDKSTATS = 64,
   MULTI_IKEY = 128,
@@ -290,11 +291,11 @@ export enum SdkStatsFeature {
 export enum SdkStatsInstrumentation {
   /** Azure Monitor Supported Instrumentations */
   NONE = 0,
-  AZURE_CORE_TRACING = 1,
-  MONGODB = 2,
-  MYSQL = 4,
-  REDIS = 8,
-  POSTGRES = 16,
+  DISABLE_AZURE_SDK = 1,
+  DISABLE_MONGODB = 2,
+  DISABLE_MYSQL = 4,
+  DISABLE_POSTGRESQL = 8,
+  DISABLE_REDIS = 16,
   BUNYAN = 32,
   WINSTON = 64,
   /** OpenTelemetry Supported Instrumentations */

--- a/src/utils/sdkStats.ts
+++ b/src/utils/sdkStats.ts
@@ -113,10 +113,6 @@ class SdkStatsConfiguration {
       this.currentSdkStatsFeatures.distro = true;
     }
 
-    if (sdkStatsFeatures.liveMetrics) {
-      this.currentSdkStatsFeatures.liveMetrics = true;
-    }
-
     const featureArray: Array<SdkStatsOption> = Object.entries(this.currentSdkStatsFeatures).map(
       (entry) => {
         return { option: entry[0], value: entry[1] };
@@ -148,7 +144,13 @@ class SdkStatsConfiguration {
       }
       process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
         instrumentation: instrumentationBitMap,
-        feature: featureBitMap,
+        feature:
+          // disableLiveMetrics is authoritative from the current process: live
+          // metrics counts as enabled once accessed, so the bit is cleared even
+          // if a previously-persisted env-var value still had it set.
+          this.currentSdkStatsFeatures.disableLiveMetrics === false
+            ? featureBitMap & ~SdkStatsFeature.DISABLE_LIVE_METRICS
+            : featureBitMap,
       });
     } catch (_error) {
       // Fail silently — SDK Stats is best-effort

--- a/test/internal/unit/azureMonitor/getAzureMonitorSdkStatsFeatures.test.ts
+++ b/test/internal/unit/azureMonitor/getAzureMonitorSdkStatsFeatures.test.ts
@@ -41,19 +41,19 @@ describe("getAzureMonitorSdkStatsFeatures", () => {
     expect(features.aadHandling).toBe(false);
   });
 
-  it("should return diskRetry true when disableOfflineStorage is falsy", () => {
+  it("should return disableDiskRetry false when disableOfflineStorage is falsy", () => {
     const config = new InternalConfig();
 
     const features = getAzureMonitorSdkStatsFeatures(config);
-    expect(features.diskRetry).toBe(true);
+    expect(features.disableDiskRetry).toBe(false);
   });
 
-  it("should return diskRetry false when disableOfflineStorage is true", () => {
+  it("should return disableDiskRetry true when disableOfflineStorage is true", () => {
     const config = new InternalConfig();
     config.azureMonitorExporterOptions.disableOfflineStorage = true;
 
     const features = getAzureMonitorSdkStatsFeatures(config);
-    expect(features.diskRetry).toBe(false);
+    expect(features.disableDiskRetry).toBe(true);
   });
 
   it("should detect AKS resource when k8s.cluster.name attribute is present", () => {

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -345,24 +345,95 @@ describe("Main functions", () => {
     const features = Number(output["feature"]);
     const instrumentations = Number(output["instrumentation"]);
     assert.notOk(features & SdkStatsFeature.AAD_HANDLING, "AAD_HANDLING is set");
-    assert.notOk(features & SdkStatsFeature.DISK_RETRY, "DISK_RETRY is set");
     assert.notOk(features & SdkStatsFeature.BROWSER_SDK_LOADER, "BROWSER_SDK_LOADER is set");
     assert.ok(features & SdkStatsFeature.DISTRO, "DISTRO is not set");
-    assert.strictEqual(features, 8);
-    assert.ok(
-      instrumentations & SdkStatsInstrumentation.AZURE_CORE_TRACING,
-      "AZURE_CORE_TRACING not set",
-    );
+    // Offline storage is disabled, so the opt-out DISABLE_DISK_RETRY feature is set.
+    assert.ok(features & SdkStatsFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY is not set");
+    // Live metrics has not been accessed, so it counts as disabled until a session is established.
+    assert.ok(features & SdkStatsFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
     assert.notOk(features & SdkStatsFeature.SHIM, "SHIM is set");
     assert.notOk(
       features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
       "AKS_RESOURCE_DETECTOR_POPULATION should not be set",
     );
-    assert.ok(instrumentations & SdkStatsInstrumentation.MONGODB, "MONGODB not set");
-    assert.ok(instrumentations & SdkStatsInstrumentation.MYSQL, "MYSQL not set");
-    assert.ok(instrumentations & SdkStatsInstrumentation.POSTGRES, "POSTGRES not set");
-    assert.ok(instrumentations & SdkStatsInstrumentation.REDIS, "REDIS not set");
-    assert.strictEqual(instrumentations, 31);
+    // On-by-default instrumentations are enabled, so none of the DISABLE_* instrumentation bits set.
+    assert.strictEqual(instrumentations, 0);
+  });
+
+  it("should set DISABLE_* opt-out flags when on-by-default features/instrumentations are disabled", () => {
+    const config: MicrosoftOpenTelemetryOptions = {
+      instrumentationOptions: {
+        azureSdk: { enabled: false },
+        mongoDb: { enabled: false },
+        mySql: { enabled: false },
+        postgreSql: { enabled: false },
+        redis: { enabled: false },
+      },
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+        enableLiveMetrics: false,
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    const instrumentations = Number(output["instrumentation"]);
+    // Live metrics disabled -> feature bit set. Offline storage enabled (default) -> not set.
+    assert.ok(features & SdkStatsFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
+    assert.notOk(features & SdkStatsFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY is set");
+    // Disabled instrumentations -> their DISABLE_* instrumentation bits are set.
+    assert.ok(
+      instrumentations & SdkStatsInstrumentation.DISABLE_AZURE_SDK,
+      "DISABLE_AZURE_SDK is not set",
+    );
+    assert.ok(
+      instrumentations & SdkStatsInstrumentation.DISABLE_MONGODB,
+      "DISABLE_MONGODB not set",
+    );
+    assert.ok(instrumentations & SdkStatsInstrumentation.DISABLE_MYSQL, "DISABLE_MYSQL not set");
+    assert.ok(
+      instrumentations & SdkStatsInstrumentation.DISABLE_POSTGRESQL,
+      "DISABLE_POSTGRESQL is not set",
+    );
+    assert.ok(instrumentations & SdkStatsInstrumentation.DISABLE_REDIS, "DISABLE_REDIS not set");
+    assert.strictEqual(
+      instrumentations,
+      SdkStatsInstrumentation.DISABLE_AZURE_SDK |
+        SdkStatsInstrumentation.DISABLE_MONGODB |
+        SdkStatsInstrumentation.DISABLE_MYSQL |
+        SdkStatsInstrumentation.DISABLE_POSTGRESQL |
+        SdkStatsInstrumentation.DISABLE_REDIS,
+    );
+  });
+
+  it("should clear DISABLE_LIVE_METRICS once live metrics is accessed", () => {
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+        enableLiveMetrics: true,
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    let features = Number(
+      JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]))["feature"],
+    );
+    // Not accessed yet -> counts as disabled.
+    assert.ok(features & SdkStatsFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
+
+    // Simulate a live metrics session being established (LiveMetrics.activateMetrics).
+    getInstance().setSdkStatsFeatures({}, { disableLiveMetrics: false });
+    features = Number(
+      JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]))["feature"],
+    );
+    assert.notOk(
+      features & SdkStatsFeature.DISABLE_LIVE_METRICS,
+      "DISABLE_LIVE_METRICS should be cleared once live metrics is accessed",
+    );
+    assert.ok(features & SdkStatsFeature.DISTRO, "DISTRO should remain set");
   });
 
   it("should set shim feature in SDK Stats if env var is populated", () => {
@@ -422,8 +493,8 @@ describe("Main functions", () => {
     const env = <{ [id: string]: string }>{};
     let current = 0;
     current |= SdkStatsFeature.AAD_HANDLING;
-    current |= SdkStatsFeature.DISK_RETRY;
-    current |= SdkStatsFeature.LIVE_METRICS;
+    current |= SdkStatsFeature.DISABLE_DISK_RETRY;
+    current |= SdkStatsFeature.DISABLE_LIVE_METRICS;
     env.AZURE_MONITOR_STATSBEAT_FEATURES = current.toString();
     process.env = env;
     const config: MicrosoftOpenTelemetryOptions = {
@@ -437,10 +508,13 @@ describe("Main functions", () => {
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const numberOutput = Number(output["feature"]);
     assert.ok(numberOutput & SdkStatsFeature.AAD_HANDLING, "AAD_HANDLING not set");
-    assert.ok(numberOutput & SdkStatsFeature.DISK_RETRY, "DISK_RETRY not set");
+    assert.ok(numberOutput & SdkStatsFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY not set");
     assert.ok(numberOutput & SdkStatsFeature.DISTRO, "DISTRO not set");
     assert.notOk(numberOutput & SdkStatsFeature.BROWSER_SDK_LOADER, "BROWSER_SDK_LOADER is set");
-    assert.ok(numberOutput & SdkStatsFeature.LIVE_METRICS, "LIVE_METRICS is not set");
+    assert.ok(
+      numberOutput & SdkStatsFeature.DISABLE_LIVE_METRICS,
+      "DISABLE_LIVE_METRICS is not set",
+    );
   });
 
   it("should capture the app service SDK prefix correctly", () => {
@@ -587,13 +661,15 @@ describe("Main functions", () => {
   it("should update SDK Stats env var based on reading instrumentations array", () => {
     const config: MicrosoftOpenTelemetryOptions = {
       instrumentationOptions: {
-        azureSdk: { enabled: false },
+        // Keep on-by-default instrumentations enabled so no DISABLE_* bits are set
+        // and the base instrumentation bitmap is 0 before the dynamic update.
+        azureSdk: { enabled: true },
         http: { enabled: false },
-        mongoDb: { enabled: false },
-        mySql: { enabled: false },
-        postgreSql: { enabled: false },
-        redis: { enabled: false },
-        redis4: { enabled: false },
+        mongoDb: { enabled: true },
+        mySql: { enabled: true },
+        postgreSql: { enabled: true },
+        redis: { enabled: true },
+        redis4: { enabled: true },
         bunyan: { enabled: false },
         winston: { enabled: false },
       },

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -367,7 +367,9 @@ describe("Main functions", () => {
         mongoDb: { enabled: false },
         mySql: { enabled: false },
         postgreSql: { enabled: false },
+        // redis and redis4 share the same instrumentation; both must be off to count as disabled.
         redis: { enabled: false },
+        redis4: { enabled: false },
       },
       azureMonitor: {
         azureMonitorExporterOptions: {
@@ -405,6 +407,29 @@ describe("Main functions", () => {
         SdkStatsInstrumentation.DISABLE_MYSQL |
         SdkStatsInstrumentation.DISABLE_POSTGRESQL |
         SdkStatsInstrumentation.DISABLE_REDIS,
+    );
+  });
+
+  it("should not set DISABLE_REDIS when redis is disabled but redis4 is still enabled", () => {
+    const config: MicrosoftOpenTelemetryOptions = {
+      instrumentationOptions: {
+        // redis and redis4 share the same underlying instrumentation, which stays
+        // enabled while redis4 is on, so Redis must not be counted as disabled.
+        redis: { enabled: false },
+        redis4: { enabled: true },
+      },
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const instrumentations = Number(output["instrumentation"]);
+    assert.notOk(
+      instrumentations & SdkStatsInstrumentation.DISABLE_REDIS,
+      "DISABLE_REDIS should not be set while redis4 is still enabled",
     );
   });
 

--- a/test/internal/unit/sdkStats.test.ts
+++ b/test/internal/unit/sdkStats.test.ts
@@ -66,7 +66,7 @@ describe("SdkStatsConfiguration — a365 and otlp feature flags", () => {
   it("should preserve existing feature bits when adding a365/otlp", () => {
     // Seed the env var with an existing feature bitmap
     process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = String(
-      SdkStatsFeature.AAD_HANDLING | SdkStatsFeature.DISK_RETRY,
+      SdkStatsFeature.AAD_HANDLING | SdkStatsFeature.DISABLE_DISK_RETRY,
     );
 
     const sb = getInstance();
@@ -75,7 +75,7 @@ describe("SdkStatsConfiguration — a365 and otlp feature flags", () => {
     const output = JSON.parse(String(process.env[AZURE_MONITOR_STATSBEAT_FEATURES]));
     const features = Number(output.feature);
     expect(features & SdkStatsFeature.AAD_HANDLING).toBeTruthy();
-    expect(features & SdkStatsFeature.DISK_RETRY).toBeTruthy();
+    expect(features & SdkStatsFeature.DISABLE_DISK_RETRY).toBeTruthy();
     expect(features & SdkStatsFeature.A365).toBeTruthy();
     expect(features & SdkStatsFeature.OTLP).toBeTruthy();
   });
@@ -84,7 +84,7 @@ describe("SdkStatsConfiguration — a365 and otlp feature flags", () => {
     // Seed the env var with JSON format (as written by a previous setSdkStatsFeatures call)
     process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
       instrumentation: 0,
-      feature: SdkStatsFeature.AAD_HANDLING | SdkStatsFeature.DISK_RETRY,
+      feature: SdkStatsFeature.AAD_HANDLING | SdkStatsFeature.DISABLE_DISK_RETRY,
     });
 
     const sb = getInstance();
@@ -93,7 +93,7 @@ describe("SdkStatsConfiguration — a365 and otlp feature flags", () => {
     const output = JSON.parse(String(process.env[AZURE_MONITOR_STATSBEAT_FEATURES]));
     const features = Number(output.feature);
     expect(features & SdkStatsFeature.AAD_HANDLING).toBeTruthy();
-    expect(features & SdkStatsFeature.DISK_RETRY).toBeTruthy();
+    expect(features & SdkStatsFeature.DISABLE_DISK_RETRY).toBeTruthy();
     expect(features & SdkStatsFeature.A365).toBeTruthy();
   });
 

--- a/test/internal/unit/sdkstats/metrics.test.ts
+++ b/test/internal/unit/sdkstats/metrics.test.ts
@@ -118,8 +118,8 @@ describe("sdkstats/metrics", () => {
   });
 
   it("emits a Feature.instrumentations observation tagged with type=1", async () => {
-    setSdkStatsInstrumentation(SdkStatsInstrumentation.MONGODB);
-    setSdkStatsInstrumentation(SdkStatsInstrumentation.REDIS);
+    setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_MONGODB);
+    setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_REDIS);
 
     const { PeriodicExportingMetricReader } = await import("@opentelemetry/sdk-metrics");
     const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
@@ -141,7 +141,7 @@ describe("sdkstats/metrics", () => {
     const point = instrMetrics[0].dataPoints[0];
     expect(point.attributes.type).toBe(FEATURE_TYPE_INSTRUMENTATION);
     expect(point.attributes.feature).toBe(
-      String(SdkStatsInstrumentation.MONGODB | SdkStatsInstrumentation.REDIS),
+      String(SdkStatsInstrumentation.DISABLE_MONGODB | SdkStatsInstrumentation.DISABLE_REDIS),
     );
 
     await meterProvider.shutdown();
@@ -173,7 +173,7 @@ describe("sdkstats/metrics", () => {
     it("skips Feature/Feature.instrumentations gauges but still registers network gauges", async () => {
       // Set bits that would normally trigger feature/instrumentation observations.
       setSdkStatsFeature(SdkStatsFeature.DISTRO);
-      setSdkStatsInstrumentation(SdkStatsInstrumentation.MONGODB);
+      setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_MONGODB);
       // Drop a network counter so a request_success_count observation will fire.
       _resetNetworkStatsForTest();
       recordSuccess(A365_ENDPOINT_CATEGORY, "contoso.example.com");

--- a/test/internal/unit/sdkstats/state.test.ts
+++ b/test/internal/unit/sdkstats/state.test.ts
@@ -56,8 +56,10 @@ describe("sdkstats/state", () => {
     it("ORs in shared SdkStatsFeature values", () => {
       setSdkStatsFeature(SdkStatsFeature.DISTRO);
       expect(getSdkStatsFeatureFlags()).toBe(SdkStatsFeature.DISTRO);
-      setSdkStatsFeature(SdkStatsFeature.LIVE_METRICS);
-      expect(getSdkStatsFeatureFlags()).toBe(SdkStatsFeature.DISTRO | SdkStatsFeature.LIVE_METRICS);
+      setSdkStatsFeature(SdkStatsFeature.DISABLE_LIVE_METRICS);
+      expect(getSdkStatsFeatureFlags()).toBe(
+        SdkStatsFeature.DISTRO | SdkStatsFeature.DISABLE_LIVE_METRICS,
+      );
     });
 
     it("ORs in distro-specific values without colliding with SdkStatsFeature", () => {
@@ -81,10 +83,10 @@ describe("sdkstats/state", () => {
   describe("instrumentation bitmask", () => {
     it("starts at 0 and ORs in values", () => {
       expect(getSdkStatsInstrumentationFlags()).toBe(0);
-      setSdkStatsInstrumentation(SdkStatsInstrumentation.MONGODB);
-      setSdkStatsInstrumentation(SdkStatsInstrumentation.REDIS);
+      setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_MONGODB);
+      setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_REDIS);
       expect(getSdkStatsInstrumentationFlags()).toBe(
-        SdkStatsInstrumentation.MONGODB | SdkStatsInstrumentation.REDIS,
+        SdkStatsInstrumentation.DISABLE_MONGODB | SdkStatsInstrumentation.DISABLE_REDIS,
       );
     });
   });
@@ -107,7 +109,7 @@ describe("sdkstats/state", () => {
   describe("_resetSdkStatsStateForTest", () => {
     it("clears all bitmasks and the shutdown flag", () => {
       setSdkStatsFeature(SdkStatsDistroFeature.A365_EXPORT);
-      setSdkStatsInstrumentation(SdkStatsInstrumentation.MONGODB);
+      setSdkStatsInstrumentation(SdkStatsInstrumentation.DISABLE_MONGODB);
       setSdkStatsShutdown(true);
       _resetSdkStatsStateForTest();
       expect(getSdkStatsFeatureFlags()).toBe(0);


### PR DESCRIPTION
## Summary
Reworks SDKStats tracking for on-by-default features/instrumentations so they are recorded as **opt-out** flags — the bit is set only when the customer has **disabled** the capability.

Existing bit values are reused (renamed + inverted), not new ones:
- Features: `DISK_RETRY` -> `DISABLE_DISK_RETRY`, `LIVE_METRICS` -> `DISABLE_LIVE_METRICS`
- Instrumentations: `AZURE_CORE_TRACING` -> `DISABLE_AZURE_SDK`, `MONGODB` -> `DISABLE_MONGODB`, `MYSQL` -> `DISABLE_MYSQL`, with bit-3/bit-4 labels corrected to match SDK emission (`DISABLE_POSTGRESQL` = bit 3, `DISABLE_REDIS` = bit 4)

**Live metrics** counts as enabled only when actually **accessed** (a live metrics session is established), not merely turned on in settings. `DISABLE_LIVE_METRICS` starts set and is cleared by `activateMetrics()`.

## Testing
- 98 unit tests pass (updated + added, incl. "clears once live metrics is accessed").
- End-to-end: real SDK -> `AZURE_MONITOR_STATSBEAT_FEATURES` -> exporter split -> Kusto bit-map decode, all decode to correct `DISABLE_*` names.

Coordinated with matching changes in `@azure/monitor-opentelemetry` and the SDKStats Kusto pipeline.
