### PR TITLE
feat(langchain): add enableSensitiveData option to gate GenAI message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Features Added
-- Add top-level `enableSensitiveData` option to capture GenAI message content (prompts, completions, tool arguments/results, system instructions) for LangChain; content is hidden by default and can also be enabled via the OTel GenAI content-capture environment variables
+- Add top-level `enableSensitiveData` option to capture GenAI message content (prompts, completions, tool arguments/results, system instructions) for LangChain; content is hidden by default
 
 ### Other Changes
 - Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Features Added
+- Add top-level `enableSensitiveData` option to capture GenAI message content (prompts, completions, tool arguments/results, system instructions) for LangChain; content is hidden by default and can also be enabled via the OTel GenAI content-capture environment variables
+
 ### Other Changes
 - Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ That's it — traces, metrics, and logs are collected automatically with built-i
 | `azureMonitor`           | `AzureMonitorOpenTelemetryOptions` | —             | Azure Monitor backend config. When provided, Azure Monitor export is enabled |
 | `a365`                   | `A365Options`                      | —             | A365 observability config                                                    |
 | `enableConsoleExporters` | `boolean`                          | auto          | Enable console exporters for traces, metrics, and logs                       |
+| `enableSensitiveData`    | `boolean`                          | `false`       | Capture GenAI message content (prompts, completions, tool args/results, system instructions) on LangChain spans. Only enable in trusted, non-production environments |
 
 ### `InstrumentationOptions`
 
@@ -162,6 +163,9 @@ Set `enabled: true` or `enabled: false` explicitly for predictable behavior.
 
 ```typescript
 useMicrosoftOpenTelemetry({
+  // Capture GenAI message content on LangChain spans (hidden by default).
+  // Only enable in trusted, non-production environments.
+  enableSensitiveData: true,
   instrumentationOptions: {
     // Disable specific built-in instrumentations
     http: { enabled: false },
@@ -174,11 +178,14 @@ useMicrosoftOpenTelemetry({
     },
     langchain: {
       enabled: true,
-      isContentRecordingEnabled: true,
     },
   },
 });
 ```
+
+> **Capturing GenAI message content (`enableSensitiveData`)**
+>
+> LangChain instrumentation hides sensitive message content — prompts, completions, tool arguments/results, and system instructions — by default. Set the top-level `enableSensitiveData: true` to record it. This takes precedence over the OTel GenAI content-capture environment variables (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` combined with `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), which can enable content capture without the flag. Only enable content capture in trusted, non-production environments where capturing message content is intentional.
 
 Disable most built-in auto-instrumentation:
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ useMicrosoftOpenTelemetry({
 
 > **Capturing GenAI message content (`enableSensitiveData`)**
 >
-> LangChain instrumentation hides sensitive message content — prompts, completions, tool arguments/results, and system instructions — by default. Set the top-level `enableSensitiveData: true` to record it. This takes precedence over the OTel GenAI content-capture environment variables (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` combined with `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), which can enable content capture without the flag. Only enable content capture in trusted, non-production environments where capturing message content is intentional.
+> LangChain instrumentation hides sensitive message content, prompts, completions, tool arguments/results, and system instructions, by default. Set the top-level `enableSensitiveData: true` to record it. Only enable content capture in trusted, non-production environments where capturing message content is intentional.
 
 Disable most built-in auto-instrumentation:
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -22,7 +22,7 @@ These sample programs show how to use the `@microsoft/opentelemetry` distributio
 | [otlpExporter.ts][otlpexporter]             | Demonstrates how to enable the OTLP exporter alongside Azure Monitor to send telemetry to two locations. |
 | [redactQueryStrings.ts][redactquerystrings] | Demonstrates how to redact URL query strings from telemetry to protect sensitive information.            |
 | [sampling.ts][sampling]                     | Demonstrates how to enable sampling to reduce data ingestion volume and control costs.                   |
-| [langchainInstrumentation.ts][langchaininstrumentation] | Demonstrates how to enable LangChain instrumentation to trace GenAI operations.                     |
+| [langchainInstrumentation.ts][langchaininstrumentation] | Demonstrates how to enable LangChain instrumentation to trace GenAI operations, including the `enableSensitiveData` toggle for capturing message content. |
 | [openaiInstrumentation.ts][openaiinstrumentation]       | Demonstrates how to enable OpenAI Agents SDK instrumentation to trace GenAI operations.             |
 | [a365Export.ts][a365export]                 | Demonstrates A365 observability export: token resolver setup, dual export with Azure Monitor, and span routing by tenant/agent. |
 | [a365ManualScopes.ts][a365manualscopes]     | Traces a full agent turn with manual scopes (InvokeAgent → Inference → ExecuteTool → Inference → Output) and cross-service context propagation. |
@@ -77,6 +77,35 @@ Or pass the connection string directly:
 ```bash
 APPLICATIONINSIGHTS_CONNECTION_STRING="<your connection string>" node dist/basicConnection.js
 ```
+
+## Capturing GenAI message content (LangChain)
+
+By default, LangChain instrumentation **hides** sensitive GenAI message content — prompts, completions, tool call arguments/results, and system instructions — so telemetry carries only non-sensitive metadata (model, token counts, latency, tool names, etc.).
+
+[langchainInstrumentation.ts][langchaininstrumentation] demonstrates the `enableSensitiveData` toggle. Set the top-level option to record message content:
+
+```typescript
+useMicrosoftOpenTelemetry({
+  // Hidden by default. Only enable in trusted, non-production environments
+  // where capturing message content is intentional.
+  enableSensitiveData: true,
+  azureMonitor: {
+    /* ... */
+  },
+  instrumentationOptions: {
+    langchain: { enabled: true },
+  },
+});
+```
+
+Alternatively, enable content capture without code changes via the standard OpenTelemetry GenAI environment variables (the `enableSensitiveData` option takes precedence over these):
+
+```bash
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT   # or SPAN_ONLY
+```
+
+> **Note:** `enableSensitiveData` defaults to `false`. Only enable it in trusted, non-production environments where capturing message content is intentional. This setting currently applies to LangChain instrumentation.
 
 [basicconnection]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/basicConnection.ts
 [cloudrole]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/cloudRole.ts

--- a/samples/README.md
+++ b/samples/README.md
@@ -98,13 +98,6 @@ useMicrosoftOpenTelemetry({
 });
 ```
 
-Alternatively, enable content capture without code changes via the standard OpenTelemetry GenAI environment variables (the `enableSensitiveData` option takes precedence over these):
-
-```bash
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT   # or SPAN_ONLY
-```
-
 > **Note:** `enableSensitiveData` defaults to `false`. Only enable it in trusted, non-production environments where capturing message content is intentional. This setting currently applies to LangChain instrumentation.
 
 [basicconnection]: https://github.com/microsoft/opentelemetry-distro-javascript/blob/main/samples/src/basicConnection.ts

--- a/samples/src/langchainInstrumentation.ts
+++ b/samples/src/langchainInstrumentation.ts
@@ -21,6 +21,10 @@ async function main(): Promise<void> {
           process.env.APPLICATIONINSIGHTS_CONNECTION_STRING || "<your connection string>",
       },
     },
+    // Capture GenAI message content (prompts, completions, tool args/results,
+    // system instructions) on LangChain spans. Hidden by default — only enable
+    // in trusted, non-production environments.
+    enableSensitiveData: true,
     instrumentationOptions: {
       langchain: {
         enabled: true,

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -431,6 +431,7 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   // unless explicitly disabled).
   initializeGenAIInstrumentations(
     applyA365Defaults ? config.instrumentationOptions : options?.instrumentationOptions,
+    options?.enableSensitiveData ?? false,
   );
 }
 
@@ -462,7 +463,10 @@ export function _getSdkInstance(): NodeSDK | undefined {
 // is never an error.  Here we eagerly import the optional @openai/agents and
 // @langchain/core packages, so we must tolerate them not being installed.
 // This will be migrated to upstream OTel instrumentation hooks once they are ready.
-function initializeGenAIInstrumentations(options?: InstrumentationOptions): void {
+function initializeGenAIInstrumentations(
+  options?: InstrumentationOptions,
+  enableSensitiveData = false,
+): void {
   const openAIOptions = options?.openaiAgents;
   if (openAIOptions?.enabled !== false) {
     void initializeOpenAIAgentsInstrumentation(openAIOptions ?? {});
@@ -470,7 +474,7 @@ function initializeGenAIInstrumentations(options?: InstrumentationOptions): void
 
   const langChainOptions = options?.langchain;
   if (langChainOptions?.enabled !== false) {
-    void initializeLangChainInstrumentation(langChainOptions ?? {});
+    void initializeLangChainInstrumentation(langChainOptions ?? {}, enableSensitiveData);
   }
 }
 
@@ -499,6 +503,7 @@ async function initializeOpenAIAgentsInstrumentation(
 
 async function initializeLangChainInstrumentation(
   _options: LangChainInstrumentationConfig,
+  enableSensitiveData = false,
 ): Promise<void> {
   try {
     const [{ LangChainTraceInstrumentor }, callbackManagerModule] = await Promise.all([
@@ -506,7 +511,7 @@ async function initializeLangChainInstrumentation(
       import("@langchain/core/callbacks/manager"),
     ]);
     if (isShutdown) return;
-    LangChainTraceInstrumentor.instrument(callbackManagerModule);
+    LangChainTraceInstrumentor.instrument(callbackManagerModule, { enableSensitiveData });
   } catch (error) {
     Logger.getInstance().debug(
       "[GenAI] Skipping LangChain instrumentation, @langchain/core is not installed.",

--- a/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
+++ b/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
@@ -219,13 +219,23 @@ export function addTracerToHandlers(
   }
 
   if (Array.isArray(handlers)) {
-    if (!handlers.some((h) => h instanceof tracerCtor)) {
+    const existing = handlers.find((h) => h instanceof tracerCtor) as LangChainTracer | undefined;
+    if (existing) {
+      // Reconcile an already-attached tracer with the latest config so the flag
+      // never goes stale across re-instrumentation.
+      existing.setEnableSensitiveData(enableSensitiveData);
+    } else {
       handlers.push(new tracerCtor(tracer, enableSensitiveData));
     }
     return handlers;
   }
 
-  if (!handlers.inheritableHandlers.some((h) => h instanceof tracerCtor)) {
+  const existing = handlers.inheritableHandlers.find((h) => h instanceof tracerCtor) as
+    | LangChainTracer
+    | undefined;
+  if (existing) {
+    existing.setEnableSensitiveData(enableSensitiveData);
+  } else {
     handlers.addHandler(new tracerCtor(tracer, enableSensitiveData), true);
   }
   return handlers;

--- a/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
+++ b/src/genai/instrumentations/langchain/langchainTraceInstrumentor.ts
@@ -14,7 +14,7 @@ import {
 import { LangChainTracer } from "./tracer.js";
 
 type CallbackManagerModuleType = typeof CallbackManagerModule;
-type LangChainTracerCtor = new (tracer: Tracer) => LangChainTracer;
+type LangChainTracerCtor = new (tracer: Tracer, enableSensitiveData?: boolean) => LangChainTracer;
 
 class LangChainTraceInstrumentorImpl extends InstrumentationBase<InstrumentationConfig> {
   private static _instance: LangChainTraceInstrumentorImpl | null = null;
@@ -29,6 +29,12 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
   // A static import is safe: by the time `patch()` runs, the callbacks
   // manager module is already loaded (it is the `module` argument).
   private _tracerCtor: LangChainTracerCtor = LangChainTracer;
+  /**
+   * When true, the attached {@link LangChainTracer} captures sensitive message
+   * content on spans regardless of the OTel GenAI content-capture environment
+   * variables.
+   */
+  private _enableSensitiveData = false;
 
   private constructor() {
     if (LangChainTraceInstrumentorImpl._instance !== null) {
@@ -102,7 +108,12 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
         this: CallbackManagerModuleType,
         ...args: Parameters<(typeof CallbackManager)["_configureSync"]>
       ) {
-        args[0] = addTracerToHandlers(instrumentor.otelTracer, args[0], instrumentor._tracerCtor);
+        args[0] = addTracerToHandlers(
+          instrumentor.otelTracer,
+          args[0],
+          instrumentor._tracerCtor,
+          instrumentor._enableSensitiveData,
+        );
         diag.debug("[LangChainTraceInstrumentor] _configureSync wrapped to add LangChainTracer");
         return original.apply(this, args);
       };
@@ -113,7 +124,8 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
     return module;
   }
 
-  manuallyInstrumentImpl(module: CallbackManagerModuleType): void {
+  manuallyInstrumentImpl(module: CallbackManagerModuleType, enableSensitiveData = false): void {
+    this._enableSensitiveData = enableSensitiveData;
     diag.info("[LangChainTraceInstrumentor] Manually instrumenting CallbackManagerModule");
     this.patch(module);
   }
@@ -153,9 +165,19 @@ export class LangChainTraceInstrumentor {
    * Initialize and auto-instrument for LangChain
    * @param module The CallbackManager module to instrument
    * @param options Optional configuration options
+   * @param options.enableSensitiveData When true, sensitive message content
+   *   (prompts, completions, tool arguments/results, system instructions) is
+   *   captured on spans. Defaults to false. Only enable in trusted,
+   *   non-production environments.
    */
-  static instrument(module: CallbackManagerModuleType): void {
-    LangChainTraceInstrumentorImpl.getInstance().manuallyInstrumentImpl(module);
+  static instrument(
+    module: CallbackManagerModuleType,
+    options?: { enableSensitiveData?: boolean },
+  ): void {
+    LangChainTraceInstrumentorImpl.getInstance().manuallyInstrumentImpl(
+      module,
+      options?.enableSensitiveData ?? false,
+    );
   }
 
   /**
@@ -190,20 +212,21 @@ export function addTracerToHandlers(
   tracer: Tracer,
   handlers: CallbackManagerModule.Callbacks | undefined,
   tracerCtor: LangChainTracerCtor,
+  enableSensitiveData = false,
 ): CallbackManagerModule.Callbacks {
   if (handlers == null) {
-    return [new tracerCtor(tracer)];
+    return [new tracerCtor(tracer, enableSensitiveData)];
   }
 
   if (Array.isArray(handlers)) {
     if (!handlers.some((h) => h instanceof tracerCtor)) {
-      handlers.push(new tracerCtor(tracer));
+      handlers.push(new tracerCtor(tracer, enableSensitiveData));
     }
     return handlers;
   }
 
   if (!handlers.inheritableHandlers.some((h) => h instanceof tracerCtor)) {
-    handlers.addHandler(new tracerCtor(tracer), true);
+    handlers.addHandler(new tracerCtor(tracer, enableSensitiveData), true);
   }
   return handlers;
 }

--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -32,18 +32,17 @@ type RunWithSpan = { run: Run; span: Span; startTime: number; lastAccessTime: nu
  *   unmapped run types) to avoid noisy traces.
  * - Guards against unbounded memory with a hard cap of {@link MAX_RUNS}.
  * - Content attributes (messages, tool args/results, system instructions) are
- *   only recorded when content capture is enabled — either via
- *   `enableSensitiveData` or the OTel GenAI content-capture environment
- *   variables (see {@link Utils.shouldCaptureContent}). Sensitive data is
- *   hidden by default.
+ *   only recorded when {@link enableSensitiveData} is enabled. Sensitive data
+ *   is hidden by default.
  */
 export class LangChainTracer extends BaseTracer {
   /** Hard cap on concurrent tracked runs to prevent memory leaks. */
   private static readonly MAX_RUNS = 10_000;
   private tracer: Tracer;
   /**
-   * When true, sensitive message content is captured on spans regardless of the
-   * OTel GenAI content-capture environment variables.
+   * When true, sensitive message content (prompts, completions, tool
+   * arguments/results, system instructions) is captured on spans. Hidden by
+   * default.
    */
   private enableSensitiveData: boolean;
   /** Active runs keyed by LangChain run ID. */
@@ -235,11 +234,10 @@ export class LangChainTracer extends BaseTracer {
       Utils.setTokenAttributes(run, span);
 
       // Content attributes (messages, tool args/results, system instructions)
-      // are sensitive and only recorded when content capture is enabled —
-      // either via `enableSensitiveData` or the OTel GenAI content-capture
-      // environment variables. Non-content tool attributes (name, type, call
-      // id) are always set by setToolAttributes.
-      const captureContent = Utils.shouldCaptureContent(this.enableSensitiveData);
+      // are sensitive and only recorded when `enableSensitiveData` is set.
+      // Non-content tool attributes (name, type, call id) are always set by
+      // setToolAttributes.
+      const captureContent = this.enableSensitiveData;
       Utils.setToolAttributes(run, span, captureContent);
       if (captureContent) {
         Utils.setInputMessagesAttribute(run, span);

--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -31,21 +31,30 @@ type RunWithSpan = { run: Run; span: Span; startTime: number; lastAccessTime: nu
  * - Skips LangChain-internal runs (tagged `langsmith:hidden`, `Branch*`, or
  *   unmapped run types) to avoid noisy traces.
  * - Guards against unbounded memory with a hard cap of {@link MAX_RUNS}.
- * - Content attributes (messages, tool args) are always recorded
- *   (aligned with Python/.NET SDKs).
+ * - Content attributes (messages, tool args/results, system instructions) are
+ *   only recorded when content capture is enabled — either via
+ *   `enableSensitiveData` or the OTel GenAI content-capture environment
+ *   variables (see {@link Utils.shouldCaptureContent}). Sensitive data is
+ *   hidden by default.
  */
 export class LangChainTracer extends BaseTracer {
   /** Hard cap on concurrent tracked runs to prevent memory leaks. */
   private static readonly MAX_RUNS = 10_000;
   private tracer: Tracer;
+  /**
+   * When true, sensitive message content is captured on spans regardless of the
+   * OTel GenAI content-capture environment variables.
+   */
+  private enableSensitiveData: boolean;
   /** Active runs keyed by LangChain run ID. */
   private runs = new Map<string, RunWithSpan>();
   /** Maps each run ID → its parent run ID for parent-span-context lookup. */
   private parentByRunId = new Map<string, string | undefined>();
 
-  constructor(tracer: Tracer) {
+  constructor(tracer: Tracer, enableSensitiveData = false) {
     super();
     this.tracer = tracer;
+    this.enableSensitiveData = enableSensitiveData;
   }
 
   name = "OpenTelemetryLangChainTracer";
@@ -216,11 +225,18 @@ export class LangChainTracer extends BaseTracer {
       Utils.setSessionIdAttribute(run, span);
       Utils.setTokenAttributes(run, span);
 
-      // Content attributes — always recorded (aligned with Python/.NET SDKs)
-      Utils.setToolAttributes(run, span);
-      Utils.setInputMessagesAttribute(run, span);
-      Utils.setOutputMessagesAttribute(run, span);
-      Utils.setSystemInstructionsAttribute(run, span);
+      // Content attributes (messages, tool args/results, system instructions)
+      // are sensitive and only recorded when content capture is enabled —
+      // either via `enableSensitiveData` or the OTel GenAI content-capture
+      // environment variables. Non-content tool attributes (name, type, call
+      // id) are always set by setToolAttributes.
+      const captureContent = Utils.shouldCaptureContent(this.enableSensitiveData);
+      Utils.setToolAttributes(run, span, captureContent);
+      if (captureContent) {
+        Utils.setInputMessagesAttribute(run, span);
+        Utils.setOutputMessagesAttribute(run, span);
+        Utils.setSystemInstructionsAttribute(run, span);
+      }
     } catch (error) {
       diag.error(
         `[LangChainTracer] Error setting span attributes for run ${run.name}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -57,6 +57,15 @@ export class LangChainTracer extends BaseTracer {
     this.enableSensitiveData = enableSensitiveData;
   }
 
+  /**
+   * Update whether sensitive message content is captured on spans. Used to
+   * reconcile an already-attached tracer with the latest instrumentation
+   * configuration (e.g. on re-instrumentation) so the flag never goes stale.
+   */
+  setEnableSensitiveData(enableSensitiveData: boolean): void {
+    this.enableSensitiveData = enableSensitiveData;
+  }
+
   name = "OpenTelemetryLangChainTracer";
 
   protected persistRun(_run: Run): Promise<void> {

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -43,6 +43,66 @@ export function isString(value: unknown): value is string {
   return typeof value === "string";
 }
 
+// ---- Content capture gating --------------------------------------------------
+
+const CONTENT_CAPTURE_ENV_VAR = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+const SEMCONV_STABILITY_ENV_VAR = "OTEL_SEMCONV_STABILITY_OPT_IN";
+const GEN_AI_EXPERIMENTAL_OPT_IN = "gen_ai_latest_experimental";
+
+/**
+ * Whether the OTel GenAI experimental semantic conventions are opted in via
+ * `OTEL_SEMCONV_STABILITY_OPT_IN` (comma-separated, containing
+ * `gen_ai_latest_experimental`).
+ */
+function isExperimentalMode(): boolean {
+  const raw = process.env[SEMCONV_STABILITY_ENV_VAR];
+  if (!raw) {
+    return false;
+  }
+  return raw
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .includes(GEN_AI_EXPERIMENTAL_OPT_IN);
+}
+
+/**
+ * Whether span-level content capture is enabled via
+ * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Accepts the OTel
+ * content-capturing modes that include span capture (`SPAN_ONLY`,
+ * `SPAN_AND_EVENT`) as well as the boolean `true` form.
+ */
+function isSpanContentCaptureEnabledByEnv(): boolean {
+  const raw = process.env[CONTENT_CAPTURE_ENV_VAR];
+  if (!raw) {
+    return false;
+  }
+  const value = raw.trim().toLowerCase();
+  return value === "true" || value === "span_only" || value === "span_and_event";
+}
+
+/**
+ * Decide whether sensitive GenAI message content (prompts, completions, tool
+ * arguments/results, system instructions) should be captured on span
+ * attributes.
+ *
+ * - When `enableSensitiveData` is `true`, content is always captured. This
+ *   takes precedence over the environment variables.
+ * - Otherwise content is captured only when the experimental GenAI semantic
+ *   conventions are opted in (`OTEL_SEMCONV_STABILITY_OPT_IN`) AND span content
+ *   capture is enabled via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
+ *
+ * Defaults to `false` so sensitive data is hidden unless explicitly enabled.
+ */
+export function shouldCaptureContent(enableSensitiveData = false): boolean {
+  if (enableSensitiveData) {
+    return true;
+  }
+  if (!isExperimentalMode()) {
+    return false;
+  }
+  return isSpanContentCaptureEnabledByEnv();
+}
+
 // Operation type mapping
 export function getOperationType(run: Run): string {
   let operation = "unknown";
@@ -73,7 +133,7 @@ export function setAgentAttributes(run: Run, span: Span) {
 }
 
 // Tool attributes
-export function setToolAttributes(run: Run, span: Span) {
+export function setToolAttributes(run: Run, span: Span, captureContent = false) {
   if (run.run_type !== "tool") {
     return;
   }
@@ -84,32 +144,39 @@ export function setToolAttributes(run: Run, span: Span) {
   if (isString(run.name)) {
     span.setAttribute(ATTR_GEN_AI_TOOL_NAME, run.name);
   }
-  if (run.inputs) {
-    const argsValue = run.inputs?.input ?? run.inputs;
-    span.setAttribute(
-      ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
-      safeSerializeToJson(
-        typeof argsValue === "object" ? (argsValue as Record<string, unknown>) : String(argsValue),
-        "arguments",
-      ),
-    );
-  }
 
-  // Tool result: v0 uses output.kwargs.content, v1 returns output as a plain string or has content directly
-  const toolResult =
-    run.outputs?.output?.kwargs?.content ??
-    (isString(run.outputs?.output) ? run.outputs.output : null) ??
-    run.outputs?.output?.content;
-  if (toolResult != null) {
-    span.setAttribute(
-      ATTR_GEN_AI_TOOL_CALL_RESULT,
-      safeSerializeToJson(
-        typeof toolResult === "object"
-          ? (toolResult as Record<string, unknown>)
-          : String(toolResult),
-        "result",
-      ),
-    );
+  // Tool arguments and result are sensitive message content — only recorded
+  // when content capture is enabled (see shouldCaptureContent).
+  if (captureContent) {
+    if (run.inputs) {
+      const argsValue = run.inputs?.input ?? run.inputs;
+      span.setAttribute(
+        ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+        safeSerializeToJson(
+          typeof argsValue === "object"
+            ? (argsValue as Record<string, unknown>)
+            : String(argsValue),
+          "arguments",
+        ),
+      );
+    }
+
+    // Tool result: v0 uses output.kwargs.content, v1 returns output as a plain string or has content directly
+    const toolResult =
+      run.outputs?.output?.kwargs?.content ??
+      (isString(run.outputs?.output) ? run.outputs.output : null) ??
+      run.outputs?.output?.content;
+    if (toolResult != null) {
+      span.setAttribute(
+        ATTR_GEN_AI_TOOL_CALL_RESULT,
+        safeSerializeToJson(
+          typeof toolResult === "object"
+            ? (toolResult as Record<string, unknown>)
+            : String(toolResult),
+          "result",
+        ),
+      );
+    }
   }
 
   span.setAttribute(ATTR_GEN_AI_TOOL_TYPE, "extension");

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -67,17 +67,22 @@ function isExperimentalMode(): boolean {
 
 /**
  * Whether span-level content capture is enabled via
- * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Accepts the OTel
- * content-capturing modes that include span capture (`SPAN_ONLY`,
- * `SPAN_AND_EVENT`) as well as the boolean `true` form.
+ * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
+ *
+ * Only the OTel GenAI content-capturing modes that include span capture are
+ * accepted: `SPAN_ONLY` and `SPAN_AND_EVENT`. Matching upstream parsing
+ * (`ContentCapturingMode[value.upper()]`), comparison is case-insensitive but
+ * the value is NOT trimmed and boolean forms (e.g. `true`) are not accepted —
+ * any other value (including `NO_CONTENT`, `EVENT_ONLY`, whitespace-padded, or
+ * unknown) hides content.
  */
 function isSpanContentCaptureEnabledByEnv(): boolean {
   const raw = process.env[CONTENT_CAPTURE_ENV_VAR];
   if (!raw) {
     return false;
   }
-  const value = raw.trim().toLowerCase();
-  return value === "true" || value === "span_only" || value === "span_and_event";
+  const value = raw.toUpperCase();
+  return value === "SPAN_ONLY" || value === "SPAN_AND_EVENT";
 }
 
 /**

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -53,6 +53,11 @@ const GEN_AI_EXPERIMENTAL_OPT_IN = "gen_ai_latest_experimental";
  * Whether the OTel GenAI experimental semantic conventions are opted in via
  * `OTEL_SEMCONV_STABILITY_OPT_IN` (comma-separated, containing
  * `gen_ai_latest_experimental`).
+ *
+ * Matches upstream parsing (`[s.strip() for s in opt_in.split(",")]` with an
+ * exact comparison against the lowercase mode value): each token is trimmed but
+ * NOT lowercased, so the opt-in is case-sensitive — only the exact lowercase
+ * `gen_ai_latest_experimental` enables experimental mode.
  */
 function isExperimentalMode(): boolean {
   const raw = process.env[SEMCONV_STABILITY_ENV_VAR];
@@ -61,7 +66,7 @@ function isExperimentalMode(): boolean {
   }
   return raw
     .split(",")
-    .map((token) => token.trim().toLowerCase())
+    .map((token) => token.trim())
     .includes(GEN_AI_EXPERIMENTAL_OPT_IN);
 }
 

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -43,76 +43,6 @@ export function isString(value: unknown): value is string {
   return typeof value === "string";
 }
 
-// ---- Content capture gating --------------------------------------------------
-
-const CONTENT_CAPTURE_ENV_VAR = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
-const SEMCONV_STABILITY_ENV_VAR = "OTEL_SEMCONV_STABILITY_OPT_IN";
-const GEN_AI_EXPERIMENTAL_OPT_IN = "gen_ai_latest_experimental";
-
-/**
- * Whether the OTel GenAI experimental semantic conventions are opted in via
- * `OTEL_SEMCONV_STABILITY_OPT_IN` (comma-separated, containing
- * `gen_ai_latest_experimental`).
- *
- * Matches upstream parsing (`[s.strip() for s in opt_in.split(",")]` with an
- * exact comparison against the lowercase mode value): each token is trimmed but
- * NOT lowercased, so the opt-in is case-sensitive — only the exact lowercase
- * `gen_ai_latest_experimental` enables experimental mode.
- */
-function isExperimentalMode(): boolean {
-  const raw = process.env[SEMCONV_STABILITY_ENV_VAR];
-  if (!raw) {
-    return false;
-  }
-  return raw
-    .split(",")
-    .map((token) => token.trim())
-    .includes(GEN_AI_EXPERIMENTAL_OPT_IN);
-}
-
-/**
- * Whether span-level content capture is enabled via
- * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
- *
- * Only the OTel GenAI content-capturing modes that include span capture are
- * accepted: `SPAN_ONLY` and `SPAN_AND_EVENT`. Matching upstream parsing
- * (`ContentCapturingMode[value.upper()]`), comparison is case-insensitive but
- * the value is NOT trimmed and boolean forms (e.g. `true`) are not accepted —
- * any other value (including `NO_CONTENT`, `EVENT_ONLY`, whitespace-padded, or
- * unknown) hides content.
- */
-function isSpanContentCaptureEnabledByEnv(): boolean {
-  const raw = process.env[CONTENT_CAPTURE_ENV_VAR];
-  if (!raw) {
-    return false;
-  }
-  const value = raw.toUpperCase();
-  return value === "SPAN_ONLY" || value === "SPAN_AND_EVENT";
-}
-
-/**
- * Decide whether sensitive GenAI message content (prompts, completions, tool
- * arguments/results, system instructions) should be captured on span
- * attributes.
- *
- * - When `enableSensitiveData` is `true`, content is always captured. This
- *   takes precedence over the environment variables.
- * - Otherwise content is captured only when the experimental GenAI semantic
- *   conventions are opted in (`OTEL_SEMCONV_STABILITY_OPT_IN`) AND span content
- *   capture is enabled via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
- *
- * Defaults to `false` so sensitive data is hidden unless explicitly enabled.
- */
-export function shouldCaptureContent(enableSensitiveData = false): boolean {
-  if (enableSensitiveData) {
-    return true;
-  }
-  if (!isExperimentalMode()) {
-    return false;
-  }
-  return isSpanContentCaptureEnabledByEnv();
-}
-
 // Operation type mapping
 export function getOperationType(run: Run): string {
   let operation = "unknown";
@@ -156,7 +86,7 @@ export function setToolAttributes(run: Run, span: Span, captureContent = false) 
   }
 
   // Tool arguments and result are sensitive message content — only recorded
-  // when content capture is enabled (see shouldCaptureContent).
+  // when content capture is enabled (`captureContent`, i.e. enableSensitiveData).
   if (captureContent) {
     if (run.inputs) {
       const argsValue = run.inputs?.input ?? run.inputs;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,11 +56,9 @@ export interface MicrosoftOpenTelemetryOptions {
    * tool arguments/results, and system instructions — on spans. Defaults to
    * `false`.
    *
-   * When `true`, content is captured for LangChain instrumentation regardless
-   * of the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` /
-   * `OTEL_SEMCONV_STABILITY_OPT_IN` environment variables (this flag takes
-   * precedence over them). Only enable in trusted, non-production environments
-   * where capturing message content is intentional.
+   * When `true`, content is captured for LangChain instrumentation. Only enable
+   * in trusted, non-production environments where capturing message content is
+   * intentional.
    */
   enableSensitiveData?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,19 @@ export interface MicrosoftOpenTelemetryOptions {
 
   /** Enable console exporters for traces, metrics, and logs. Auto-enabled when no other exporter is active. */
   enableConsoleExporters?: boolean;
+
+  /**
+   * Enable capture of sensitive GenAI message content — prompts, completions,
+   * tool arguments/results, and system instructions — on spans. Defaults to
+   * `false`.
+   *
+   * When `true`, content is captured for LangChain instrumentation regardless
+   * of the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` /
+   * `OTEL_SEMCONV_STABILITY_OPT_IN` environment variables (this flag takes
+   * precedence over them). Only enable in trusted, non-production environments
+   * where capturing message content is intentional.
+   */
+  enableSensitiveData?: boolean;
 }
 
 /**

--- a/test/internal/functional/langchain.test.ts
+++ b/test/internal/functional/langchain.test.ts
@@ -246,8 +246,45 @@ describe("LangChain Instrumentation Functional Tests", () => {
   });
 
   describe("content recording", () => {
-    it("always records message content", async () => {
+    it("hides message content by default (sensitive data hidden)", async () => {
       setup();
+
+      const run = makeRun({
+        id: "llm-no-content",
+        name: "ChatOpenAI",
+        run_type: "llm",
+        inputs: {
+          messages: [[{ role: "user", content: "What is 2+2?" }]],
+        },
+        outputs: {
+          generations: [[{ text: "4" }]],
+        },
+      });
+
+      await langchainTracer.onRunCreate(run);
+      await (langchainTracer as unknown as { _endTrace(r: Run): Promise<void> })._endTrace(run);
+
+      const spans = exporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 1);
+
+      const span = spans[0];
+      assert.ok(
+        !span.attributes[ATTR_GEN_AI_INPUT_MESSAGES],
+        "input messages should be hidden by default",
+      );
+      assert.ok(
+        !span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+        "output messages should be hidden by default",
+      );
+    });
+
+    it("records message content when enableSensitiveData is true", async () => {
+      exporter = new InMemorySpanExporter();
+      provider = new BasicTracerProvider({
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+      });
+      const tracer = provider.getTracer("test-langchain", "1.0.0");
+      const sensitiveTracer = new LangChainTracer(tracer, true);
 
       const run = makeRun({
         id: "llm-with-content",
@@ -261,8 +298,8 @@ describe("LangChain Instrumentation Functional Tests", () => {
         },
       });
 
-      await langchainTracer.onRunCreate(run);
-      await (langchainTracer as unknown as { _endTrace(r: Run): Promise<void> })._endTrace(run);
+      await sensitiveTracer.onRunCreate(run);
+      await (sensitiveTracer as unknown as { _endTrace(r: Run): Promise<void> })._endTrace(run);
 
       const spans = exporter.getFinishedSpans();
       assert.strictEqual(spans.length, 1);

--- a/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
+++ b/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
@@ -80,6 +80,44 @@ describe("LangChainTraceInstrumentor", () => {
         "LangChainTracer should be attached on the first call, not deferred to a later microtask",
       );
     });
+
+    it("propagates enableSensitiveData to the attached LangChainTracer", () => {
+      const configureSyncOriginal = vi.fn();
+      const mockModule = {
+        CallbackManager: {
+          _configureSync: configureSyncOriginal,
+        },
+      };
+
+      LangChainTraceInstrumentor.instrument(mockModule as any, { enableSensitiveData: true });
+      mockModule.CallbackManager._configureSync(undefined as any);
+
+      const attached = configureSyncOriginal.mock.calls[0][0][0] as LangChainTracer;
+      assert.ok(attached instanceof LangChainTracer);
+      assert.strictEqual(
+        (attached as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+        true,
+        "the attached tracer should capture sensitive data",
+      );
+    });
+
+    it("defaults enableSensitiveData to false on the attached LangChainTracer", () => {
+      const configureSyncOriginal = vi.fn();
+      const mockModule = {
+        CallbackManager: {
+          _configureSync: configureSyncOriginal,
+        },
+      };
+
+      LangChainTraceInstrumentor.instrument(mockModule as any);
+      mockModule.CallbackManager._configureSync(undefined as any);
+
+      const attached = configureSyncOriginal.mock.calls[0][0][0] as LangChainTracer;
+      assert.strictEqual(
+        (attached as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+        false,
+      );
+    });
   });
 
   describe("enable / disable", () => {
@@ -184,5 +222,24 @@ describe("addTracerToHandlers", () => {
     const result = addTracerToHandlers(tracer, undefined, LangChainTracer);
     assert.ok(Array.isArray(result));
     assert.ok(result[0] instanceof LangChainTracer);
+  });
+
+  it("passes enableSensitiveData to the created LangChainTracer", () => {
+    const tracer = createMockTracer();
+    const result = addTracerToHandlers(tracer, undefined, LangChainTracer, true);
+    assert.ok(Array.isArray(result));
+    assert.strictEqual(
+      (result[0] as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+      true,
+    );
+  });
+
+  it("defaults enableSensitiveData to false when omitted", () => {
+    const tracer = createMockTracer();
+    const result = addTracerToHandlers(tracer, undefined, LangChainTracer);
+    assert.strictEqual(
+      (result[0] as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+      false,
+    );
   });
 });

--- a/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
+++ b/test/internal/unit/genai/langchain/langchainTraceInstrumentor.test.ts
@@ -242,4 +242,52 @@ describe("addTracerToHandlers", () => {
       false,
     );
   });
+
+  it("reconciles enableSensitiveData on an existing array tracer instead of duplicating", () => {
+    const tracer = createMockTracer();
+    const existingTracer = new LangChainTracer(tracer, false);
+    const handlers = [existingTracer] as any;
+
+    const result = addTracerToHandlers(tracer, handlers, LangChainTracer, true);
+
+    assert.strictEqual(result.length, 1, "should not duplicate");
+    assert.strictEqual(
+      (existingTracer as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+      true,
+      "existing tracer's flag should be updated to the latest value",
+    );
+  });
+
+  it("reconciles enableSensitiveData back to false on an existing array tracer", () => {
+    const tracer = createMockTracer();
+    const existingTracer = new LangChainTracer(tracer, true);
+    const handlers = [existingTracer] as any;
+
+    addTracerToHandlers(tracer, handlers, LangChainTracer, false);
+
+    assert.strictEqual(
+      (existingTracer as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+      false,
+      "existing tracer's flag should be reset to the latest value",
+    );
+  });
+
+  it("reconciles enableSensitiveData on an existing CallbackManager-style tracer", () => {
+    const tracer = createMockTracer();
+    const existingTracer = new LangChainTracer(tracer, false);
+    const addHandlerSpy = vi.fn();
+    const handlers = {
+      inheritableHandlers: [existingTracer],
+      addHandler: addHandlerSpy,
+    } as any;
+
+    addTracerToHandlers(tracer, handlers, LangChainTracer, true);
+
+    assert.strictEqual(addHandlerSpy.mock.calls.length, 0, "should not add duplicate");
+    assert.strictEqual(
+      (existingTracer as unknown as { enableSensitiveData: boolean }).enableSensitiveData,
+      true,
+      "existing tracer's flag should be updated to the latest value",
+    );
+  });
 });

--- a/test/internal/unit/genai/langchain/tracer.test.ts
+++ b/test/internal/unit/genai/langchain/tracer.test.ts
@@ -141,18 +141,6 @@ describe("LangChainTracer", () => {
   });
 
   describe("enableSensitiveData content gating", () => {
-    const CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
-    const SEMCONV_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN";
-    const savedContent = process.env[CONTENT_ENV];
-    const savedSemconv = process.env[SEMCONV_ENV];
-
-    afterEach(() => {
-      if (savedContent === undefined) delete process.env[CONTENT_ENV];
-      else process.env[CONTENT_ENV] = savedContent;
-      if (savedSemconv === undefined) delete process.env[SEMCONV_ENV];
-      else process.env[SEMCONV_ENV] = savedSemconv;
-    });
-
     function makeContentRun() {
       return makeRun({
         run_type: "llm",
@@ -168,8 +156,6 @@ describe("LangChainTracer", () => {
     }
 
     it("hides input/output messages by default", async () => {
-      delete process.env[CONTENT_ENV];
-      delete process.env[SEMCONV_ENV];
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer);
       const run = makeContentRun();
@@ -182,8 +168,6 @@ describe("LangChainTracer", () => {
     });
 
     it("records input/output messages when enableSensitiveData is true", async () => {
-      delete process.env[CONTENT_ENV];
-      delete process.env[SEMCONV_ENV];
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer, true);
       const run = makeContentRun();
@@ -195,22 +179,7 @@ describe("LangChainTracer", () => {
       assert.ok(attrKeys.includes(ATTR_GEN_AI_OUTPUT_MESSAGES), "output messages recorded");
     });
 
-    it("records message content when env vars opt in even without the flag", async () => {
-      process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
-      process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
-      const tracer = createMockTracer();
-      const lct = new LangChainTracer(tracer);
-      const run = makeContentRun();
-      await endTraceFor(lct, run);
-      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
-        (c: unknown[]) => c[0],
-      );
-      assert.ok(attrKeys.includes(ATTR_GEN_AI_INPUT_MESSAGES), "input messages recorded via env");
-    });
-
     it("hides tool arguments/results by default but keeps tool name", async () => {
-      delete process.env[CONTENT_ENV];
-      delete process.env[SEMCONV_ENV];
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer);
       const run = makeRun({
@@ -230,8 +199,6 @@ describe("LangChainTracer", () => {
     });
 
     it("records tool arguments/results when enableSensitiveData is true", async () => {
-      delete process.env[CONTENT_ENV];
-      delete process.env[SEMCONV_ENV];
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer, true);
       const run = makeRun({

--- a/test/internal/unit/genai/langchain/tracer.test.ts
+++ b/test/internal/unit/genai/langchain/tracer.test.ts
@@ -14,12 +14,17 @@ import type { Run } from "@langchain/core/tracers/base";
 import { LangChainTracer } from "../../../../../src/genai/instrumentations/langchain/tracer.js";
 import {
   ATTR_ERROR_MESSAGE,
+  ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_CHOICE_COUNT,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_RESPONSE_ID,
   ATTR_GEN_AI_RESPONSE_MODEL,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
 } from "../../../../../src/genai/index.js";
@@ -132,6 +137,116 @@ describe("LangChainTracer", () => {
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer);
       assert.strictEqual(lct.name, "OpenTelemetryLangChainTracer");
+    });
+  });
+
+  describe("enableSensitiveData content gating", () => {
+    const CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+    const SEMCONV_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN";
+    const savedContent = process.env[CONTENT_ENV];
+    const savedSemconv = process.env[SEMCONV_ENV];
+
+    afterEach(() => {
+      if (savedContent === undefined) delete process.env[CONTENT_ENV];
+      else process.env[CONTENT_ENV] = savedContent;
+      if (savedSemconv === undefined) delete process.env[SEMCONV_ENV];
+      else process.env[SEMCONV_ENV] = savedSemconv;
+    });
+
+    function makeContentRun() {
+      return makeRun({
+        run_type: "llm",
+        name: "ChatOpenAI",
+        inputs: { messages: [[{ role: "user", content: "secret question" }]] },
+        outputs: { generations: [[{ text: "secret answer" }]] },
+      });
+    }
+
+    async function endTraceFor(lct: LangChainTracer, run: Run) {
+      await lct.onRunCreate(run);
+      await (lct as unknown as { _endTrace(r: Run): Promise<void> })._endTrace(run);
+    }
+
+    it("hides input/output messages by default", async () => {
+      delete process.env[CONTENT_ENV];
+      delete process.env[SEMCONV_ENV];
+      const tracer = createMockTracer();
+      const lct = new LangChainTracer(tracer);
+      const run = makeContentRun();
+      await endTraceFor(lct, run);
+      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      assert.ok(!attrKeys.includes(ATTR_GEN_AI_INPUT_MESSAGES), "input messages hidden");
+      assert.ok(!attrKeys.includes(ATTR_GEN_AI_OUTPUT_MESSAGES), "output messages hidden");
+    });
+
+    it("records input/output messages when enableSensitiveData is true", async () => {
+      delete process.env[CONTENT_ENV];
+      delete process.env[SEMCONV_ENV];
+      const tracer = createMockTracer();
+      const lct = new LangChainTracer(tracer, true);
+      const run = makeContentRun();
+      await endTraceFor(lct, run);
+      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_INPUT_MESSAGES), "input messages recorded");
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_OUTPUT_MESSAGES), "output messages recorded");
+    });
+
+    it("records message content when env vars opt in even without the flag", async () => {
+      process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
+      process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
+      const tracer = createMockTracer();
+      const lct = new LangChainTracer(tracer);
+      const run = makeContentRun();
+      await endTraceFor(lct, run);
+      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_INPUT_MESSAGES), "input messages recorded via env");
+    });
+
+    it("hides tool arguments/results by default but keeps tool name", async () => {
+      delete process.env[CONTENT_ENV];
+      delete process.env[SEMCONV_ENV];
+      const tracer = createMockTracer();
+      const lct = new LangChainTracer(tracer);
+      const run = makeRun({
+        run_type: "tool",
+        name: "search",
+        serialized: { name: "search" },
+        inputs: { input: "secret query" },
+        outputs: { output: { kwargs: { content: "secret result" }, tool_call_id: "tc-1" } },
+      });
+      await endTraceFor(lct, run);
+      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_TOOL_NAME), "tool name always recorded");
+      assert.ok(!attrKeys.includes(ATTR_GEN_AI_TOOL_CALL_ARGUMENTS), "tool arguments hidden");
+      assert.ok(!attrKeys.includes(ATTR_GEN_AI_TOOL_CALL_RESULT), "tool result hidden");
+    });
+
+    it("records tool arguments/results when enableSensitiveData is true", async () => {
+      delete process.env[CONTENT_ENV];
+      delete process.env[SEMCONV_ENV];
+      const tracer = createMockTracer();
+      const lct = new LangChainTracer(tracer, true);
+      const run = makeRun({
+        run_type: "tool",
+        name: "search",
+        serialized: { name: "search" },
+        inputs: { input: "secret query" },
+        outputs: { output: { kwargs: { content: "secret result" }, tool_call_id: "tc-1" } },
+      });
+      await endTraceFor(lct, run);
+      const attrKeys = (tracer.lastSpan!.setAttribute as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_TOOL_CALL_ARGUMENTS), "tool arguments recorded");
+      assert.ok(attrKeys.includes(ATTR_GEN_AI_TOOL_CALL_RESULT), "tool result recorded");
     });
   });
 
@@ -252,7 +367,7 @@ describe("LangChainTracer", () => {
       );
     });
 
-    it("sets content attributes (always recorded)", async () => {
+    it("sets non-content tool attributes (tool name) regardless of content capture", async () => {
       const tracer = createMockTracer();
       const lct = new LangChainTracer(tracer);
       const run = makeRun({

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -1140,13 +1140,28 @@ describe("shouldCaptureContent", () => {
     assert.strictEqual(shouldCaptureContent(false), true);
   });
 
-  it("returns true for SPAN_ONLY and the boolean true form", () => {
+  it("accepts SPAN_ONLY and is case-insensitive, but rejects boolean/whitespace/unknown forms", () => {
     clearEnv();
     process.env[SEMCONV_ENV] = "http/dup,gen_ai_latest_experimental";
+
+    // Span-capturing modes accepted (case-insensitive, matching Python's upper()).
     process.env[CONTENT_ENV] = "SPAN_ONLY";
     assert.strictEqual(shouldCaptureContent(false), true);
-    process.env[CONTENT_ENV] = "true";
+    process.env[CONTENT_ENV] = "span_and_event";
     assert.strictEqual(shouldCaptureContent(false), true);
+
+    // Boolean form is NOT a valid ContentCapturingMode — must hide content.
+    process.env[CONTENT_ENV] = "true";
+    assert.strictEqual(shouldCaptureContent(false), false);
+
+    // Value is not trimmed (Python does ContentCapturingMode[value.upper()]),
+    // so whitespace-padded modes are invalid and hide content.
+    process.env[CONTENT_ENV] = " SPAN_ONLY ";
+    assert.strictEqual(shouldCaptureContent(false), false);
+
+    // Unknown values hide content.
+    process.env[CONTENT_ENV] = "EVENT_ONLY";
+    assert.strictEqual(shouldCaptureContent(false), false);
   });
 
   it("returns false when experimental mode is opted in but content capture is off", () => {

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -1140,6 +1140,28 @@ describe("shouldCaptureContent", () => {
     assert.strictEqual(shouldCaptureContent(false), true);
   });
 
+  it("treats the semconv opt-in as case-sensitive and trims tokens (parity with upstream strip())", () => {
+    // Upstream parses `[s.strip() for s in opt_in.split(",")]` and matches the
+    // exact lowercase mode value, so it is case-sensitive.
+    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
+
+    // Exact lowercase token opts in.
+    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
+    assert.strictEqual(shouldCaptureContent(false), true);
+
+    // Surrounding whitespace is stripped, so it still opts in.
+    process.env[SEMCONV_ENV] = " gen_ai_latest_experimental , http/dup ";
+    assert.strictEqual(shouldCaptureContent(false), true);
+
+    // Uppercase does NOT opt in (must hide content — matches Python).
+    process.env[SEMCONV_ENV] = "GEN_AI_LATEST_EXPERIMENTAL";
+    assert.strictEqual(shouldCaptureContent(false), false);
+
+    // Mixed case does NOT opt in either.
+    process.env[SEMCONV_ENV] = "Gen_AI_Latest_Experimental";
+    assert.strictEqual(shouldCaptureContent(false), false);
+  });
+
   it("accepts SPAN_ONLY and is case-insensitive, but rejects boolean/whitespace/unknown forms", () => {
     clearEnv();
     process.env[SEMCONV_ENV] = "http/dup,gen_ai_latest_experimental";

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -18,6 +18,7 @@ import {
   setSessionIdAttribute,
   setSystemInstructionsAttribute,
   setTokenAttributes,
+  shouldCaptureContent,
   isString,
 } from "../../../../../src/genai/instrumentations/langchain/utils.js";
 import {
@@ -171,7 +172,7 @@ describe("setAgentAttributes", () => {
 });
 
 describe("setToolAttributes", () => {
-  it("sets tool attributes for tool runs", () => {
+  it("sets tool content attributes for tool runs when content capture is enabled", () => {
     const span = makeSpan();
     const run = makeRun({
       run_type: "tool",
@@ -185,7 +186,7 @@ describe("setToolAttributes", () => {
         },
       },
     });
-    setToolAttributes(run, span);
+    setToolAttributes(run, span, true);
     const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
     assert.ok(
       calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_NAME && c[1] === "search_web"),
@@ -196,10 +197,43 @@ describe("setToolAttributes", () => {
     assert.ok(calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_CALL_ID && c[1] === "tc-123"));
   });
 
+  it("omits tool arguments/results but keeps name/type/id when content capture is disabled", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      run_type: "tool",
+      name: "search_web",
+      serialized: { name: "search_web" },
+      inputs: { input: "query text" },
+      outputs: {
+        output: {
+          kwargs: { content: "result content" },
+          tool_call_id: "tc-123",
+        },
+      },
+    });
+    // captureContent defaults to false
+    setToolAttributes(run, span);
+    const calls = (span.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    assert.ok(
+      calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_NAME && c[1] === "search_web"),
+      "tool name should always be recorded",
+    );
+    assert.ok(calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_TYPE && c[1] === "extension"));
+    assert.ok(calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_CALL_ID && c[1] === "tc-123"));
+    assert.ok(
+      !calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_CALL_ARGUMENTS),
+      "tool arguments (sensitive content) should be omitted",
+    );
+    assert.ok(
+      !calls.some((c: unknown[]) => c[0] === ATTR_GEN_AI_TOOL_CALL_RESULT),
+      "tool result (sensitive content) should be omitted",
+    );
+  });
+
   it("does nothing for non-tool runs", () => {
     const span = makeSpan();
     const run = makeRun({ run_type: "llm" });
-    setToolAttributes(run, span);
+    setToolAttributes(run, span, true);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
   });
 
@@ -209,7 +243,7 @@ describe("setToolAttributes", () => {
       run_type: "tool",
       serialized: undefined as unknown as Record<string, unknown>,
     });
-    setToolAttributes(run, span);
+    setToolAttributes(run, span, true);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
   });
 });
@@ -1054,5 +1088,71 @@ describe("setTokenAttributes", () => {
     const run = makeRun({ outputs: {} });
     setTokenAttributes(run, span);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+});
+
+describe("shouldCaptureContent", () => {
+  const CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+  const SEMCONV_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN";
+  // Snapshot the original values so each test can freely mutate them.
+  const savedContent = process.env[CONTENT_ENV];
+  const savedSemconv = process.env[SEMCONV_ENV];
+
+  function clearEnv() {
+    delete process.env[CONTENT_ENV];
+    delete process.env[SEMCONV_ENV];
+  }
+
+  afterEach(() => {
+    if (savedContent === undefined) delete process.env[CONTENT_ENV];
+    else process.env[CONTENT_ENV] = savedContent;
+    if (savedSemconv === undefined) delete process.env[SEMCONV_ENV];
+    else process.env[SEMCONV_ENV] = savedSemconv;
+  });
+
+  it("returns true when enableSensitiveData is true, regardless of env", () => {
+    clearEnv();
+    assert.strictEqual(shouldCaptureContent(true), true);
+  });
+
+  it("enableSensitiveData=true takes precedence even when env disables capture", () => {
+    clearEnv();
+    process.env[CONTENT_ENV] = "false";
+    assert.strictEqual(shouldCaptureContent(true), true);
+  });
+
+  it("defaults to false when neither the flag nor env vars are set", () => {
+    clearEnv();
+    assert.strictEqual(shouldCaptureContent(), false);
+    assert.strictEqual(shouldCaptureContent(false), false);
+  });
+
+  it("returns false when content capture env is set but experimental mode is not opted in", () => {
+    clearEnv();
+    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
+    assert.strictEqual(shouldCaptureContent(false), false);
+  });
+
+  it("returns true when experimental mode is opted in and content mode is SPAN_AND_EVENT", () => {
+    clearEnv();
+    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
+    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
+    assert.strictEqual(shouldCaptureContent(false), true);
+  });
+
+  it("returns true for SPAN_ONLY and the boolean true form", () => {
+    clearEnv();
+    process.env[SEMCONV_ENV] = "http/dup,gen_ai_latest_experimental";
+    process.env[CONTENT_ENV] = "SPAN_ONLY";
+    assert.strictEqual(shouldCaptureContent(false), true);
+    process.env[CONTENT_ENV] = "true";
+    assert.strictEqual(shouldCaptureContent(false), true);
+  });
+
+  it("returns false when experimental mode is opted in but content capture is off", () => {
+    clearEnv();
+    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
+    process.env[CONTENT_ENV] = "NO_CONTENT";
+    assert.strictEqual(shouldCaptureContent(false), false);
   });
 });

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -18,7 +18,6 @@ import {
   setSessionIdAttribute,
   setSystemInstructionsAttribute,
   setTokenAttributes,
-  shouldCaptureContent,
   isString,
 } from "../../../../../src/genai/instrumentations/langchain/utils.js";
 import {
@@ -1088,108 +1087,5 @@ describe("setTokenAttributes", () => {
     const run = makeRun({ outputs: {} });
     setTokenAttributes(run, span);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
-  });
-});
-
-describe("shouldCaptureContent", () => {
-  const CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
-  const SEMCONV_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN";
-  // Snapshot the original values so each test can freely mutate them.
-  const savedContent = process.env[CONTENT_ENV];
-  const savedSemconv = process.env[SEMCONV_ENV];
-
-  function clearEnv() {
-    delete process.env[CONTENT_ENV];
-    delete process.env[SEMCONV_ENV];
-  }
-
-  afterEach(() => {
-    if (savedContent === undefined) delete process.env[CONTENT_ENV];
-    else process.env[CONTENT_ENV] = savedContent;
-    if (savedSemconv === undefined) delete process.env[SEMCONV_ENV];
-    else process.env[SEMCONV_ENV] = savedSemconv;
-  });
-
-  it("returns true when enableSensitiveData is true, regardless of env", () => {
-    clearEnv();
-    assert.strictEqual(shouldCaptureContent(true), true);
-  });
-
-  it("enableSensitiveData=true takes precedence even when env disables capture", () => {
-    clearEnv();
-    process.env[CONTENT_ENV] = "false";
-    assert.strictEqual(shouldCaptureContent(true), true);
-  });
-
-  it("defaults to false when neither the flag nor env vars are set", () => {
-    clearEnv();
-    assert.strictEqual(shouldCaptureContent(), false);
-    assert.strictEqual(shouldCaptureContent(false), false);
-  });
-
-  it("returns false when content capture env is set but experimental mode is not opted in", () => {
-    clearEnv();
-    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
-    assert.strictEqual(shouldCaptureContent(false), false);
-  });
-
-  it("returns true when experimental mode is opted in and content mode is SPAN_AND_EVENT", () => {
-    clearEnv();
-    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
-    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
-    assert.strictEqual(shouldCaptureContent(false), true);
-  });
-
-  it("treats the semconv opt-in as case-sensitive and trims tokens (parity with upstream strip())", () => {
-    // Upstream parses `[s.strip() for s in opt_in.split(",")]` and matches the
-    // exact lowercase mode value, so it is case-sensitive.
-    process.env[CONTENT_ENV] = "SPAN_AND_EVENT";
-
-    // Exact lowercase token opts in.
-    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
-    assert.strictEqual(shouldCaptureContent(false), true);
-
-    // Surrounding whitespace is stripped, so it still opts in.
-    process.env[SEMCONV_ENV] = " gen_ai_latest_experimental , http/dup ";
-    assert.strictEqual(shouldCaptureContent(false), true);
-
-    // Uppercase does NOT opt in (must hide content — matches Python).
-    process.env[SEMCONV_ENV] = "GEN_AI_LATEST_EXPERIMENTAL";
-    assert.strictEqual(shouldCaptureContent(false), false);
-
-    // Mixed case does NOT opt in either.
-    process.env[SEMCONV_ENV] = "Gen_AI_Latest_Experimental";
-    assert.strictEqual(shouldCaptureContent(false), false);
-  });
-
-  it("accepts SPAN_ONLY and is case-insensitive, but rejects boolean/whitespace/unknown forms", () => {
-    clearEnv();
-    process.env[SEMCONV_ENV] = "http/dup,gen_ai_latest_experimental";
-
-    // Span-capturing modes accepted (case-insensitive, matching Python's upper()).
-    process.env[CONTENT_ENV] = "SPAN_ONLY";
-    assert.strictEqual(shouldCaptureContent(false), true);
-    process.env[CONTENT_ENV] = "span_and_event";
-    assert.strictEqual(shouldCaptureContent(false), true);
-
-    // Boolean form is NOT a valid ContentCapturingMode — must hide content.
-    process.env[CONTENT_ENV] = "true";
-    assert.strictEqual(shouldCaptureContent(false), false);
-
-    // Value is not trimmed (Python does ContentCapturingMode[value.upper()]),
-    // so whitespace-padded modes are invalid and hide content.
-    process.env[CONTENT_ENV] = " SPAN_ONLY ";
-    assert.strictEqual(shouldCaptureContent(false), false);
-
-    // Unknown values hide content.
-    process.env[CONTENT_ENV] = "EVENT_ONLY";
-    assert.strictEqual(shouldCaptureContent(false), false);
-  });
-
-  it("returns false when experimental mode is opted in but content capture is off", () => {
-    clearEnv();
-    process.env[SEMCONV_ENV] = "gen_ai_latest_experimental";
-    process.env[CONTENT_ENV] = "NO_CONTENT";
-    assert.strictEqual(shouldCaptureContent(false), false);
   });
 });

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -1461,7 +1461,35 @@ describe("Main functions", () => {
     });
 
     await vi.waitFor(() => {
-      expect(instrumentSpy).toHaveBeenCalledWith(expect.any(Object));
+      expect(instrumentSpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ enableSensitiveData: false }),
+      );
+    });
+
+    await shutdownMicrosoftOpenTelemetry();
+  });
+
+  it("forwards enableSensitiveData to LangChain instrumentation when set", async () => {
+    const instrumentSpy = vi.spyOn(LangChainTraceInstrumentor, "instrument");
+
+    useMicrosoftOpenTelemetry({
+      azureMonitor: { enabled: false },
+      enableConsoleExporters: false,
+      enableSensitiveData: true,
+      instrumentationOptions: {
+        openaiAgents: { enabled: false },
+        langchain: {
+          enabled: true,
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(instrumentSpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ enableSensitiveData: true }),
+      );
     });
 
     await shutdownMicrosoftOpenTelemetry();


### PR DESCRIPTION
## Summary

Adds a top-level `enableSensitiveData` option (default `false`) that controls whether the LangChain instrumentation captures **sensitive GenAI message content** (prompts, completions, tool call arguments/results, and system instructions) on exported spans.

By default this content is **hidden**, so telemetry still carries non-sensitive metadata (model, token counts, latency, operation type, tool names, response IDs) without shipping conversation text into the telemetry backend.

## Behavior

Content capture is controlled **solely by the `enableSensitiveData` config option**. There is no environment-variable path: the distro does not read or set `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` or `OTEL_SEMCONV_STABILITY_OPT_IN`. This aligns with the upstream JS LangChain instrumentation, which exposes a config option rather than these env vars.

- `enableSensitiveData: true` captures message content.
- `enableSensitiveData` unset or `false` (default) hides it.
- Non-content tool attributes (`gen_ai.tool.name`, `gen_ai.tool.type`, `gen_ai.tool.call.id`) and all metadata remain always-on.

```typescript
useMicrosoftOpenTelemetry({
  enableSensitiveData: true, // capture prompts/completions (trusted, non-prod only)
  azureMonitor: { /* ... */ },
  instrumentationOptions: { langchain: { enabled: true } },
});
```

### Fields hidden by default

When `enableSensitiveData` is false, these span attributes are not set:

- `gen_ai.input.messages`
- `gen_ai.output.messages`
- `gen_ai.system_instructions`
- `gen_ai.tool.call.arguments`
- `gen_ai.tool.call.result`

## Changes

- `tracer.ts`: `LangChainTracer` gains an `enableSensitiveData` constructor arg plus a `setEnableSensitiveData()` setter. `_endTrace` gates input/output messages, system instructions, and tool content on `enableSensitiveData`.
- `utils.ts`: `setToolAttributes(run, span, captureContent)` gates the tool call arguments and result behind the `captureContent` flag; tool name/type/call id stay always-on.
- `langchainTraceInstrumentor.ts`: plumbs the flag through `instrument(module, { enableSensitiveData })`, the singleton, and `addTracerToHandlers`, which reconciles an already-attached tracer via the setter.
- `distro.ts` + `types.ts`: new top-level `MicrosoftOpenTelemetryOptions.enableSensitiveData` (default `false`) wired into LangChain init.
- README, CHANGELOG, and the LangChain sample/sample README updated.

## Before / after

Verified end-to-end against Azure Monitor with a real `gpt-4o-mini` call:

- Without the change (default): the chat span carried `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions` with the real prompt/response text.
- With the change (default): those content attributes are absent; only non-sensitive metadata is exported. A full-text search for the prompt across all telemetry returns zero matches.
- With `enableSensitiveData: true`: content is captured again.

## Testing

- `npm run build` (ESM + CJS)
- `npm run test:unit` and `npm run test:functional` (added coverage for content gating, tracer gating, instrumentor plumbing/reconciliation, and distro forwarding)
- `npm run lint` (0 errors)
