### PR TITLE
feat: emit gen_ai.response.finish_reasons on LangChain chat spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Add top-level `enableSensitiveData` option to capture GenAI message content (prompts, completions, tool arguments/results, system instructions) for LangChain; content is hidden by default
+- Emit `gen_ai.response.finish_reasons` on LangChain chat spans, extracted from the LLM run output
 
 ### Other Changes
 - Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`

--- a/src/genai/instrumentations/langchain/tracer.ts
+++ b/src/genai/instrumentations/langchain/tracer.ts
@@ -229,6 +229,7 @@ export class LangChainTracer extends BaseTracer {
       Utils.setModelAttribute(run, span);
       Utils.setChoiceCountAttribute(run, span);
       Utils.setResponseIdAttribute(run, span);
+      Utils.setFinishReasonsAttribute(run, span);
       Utils.setProviderNameAttribute(run, span);
       Utils.setSessionIdAttribute(run, span);
       Utils.setTokenAttributes(run, span);

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -14,6 +14,7 @@ import {
   ATTR_GEN_AI_REQUEST_CHOICE_COUNT,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
@@ -615,6 +616,99 @@ export function setResponseIdAttribute(run: Run, span: Span): void {
   const responseId = getResponseId(run);
   if (responseId) {
     span.setAttribute(ATTR_GEN_AI_RESPONSE_ID, responseId);
+  }
+}
+
+// Finish reasons - one per generation, parallel to n. Chat Completions:
+// generationInfo/response_metadata.finish_reason. Responses API: derived from
+// status/incomplete_details (no finish_reason field).
+export function getFinishReasons(run: Run): string[] | undefined {
+  const generations = run.outputs?.generations;
+  if (!Array.isArray(generations)) {
+    return undefined;
+  }
+
+  const reasons: string[] = [];
+  for (const choice of generations) {
+    if (!Array.isArray(choice)) continue;
+    for (const item of choice as Record<string, unknown>[]) {
+      const message = item?.message as Record<string, unknown> | undefined;
+      const messageKwargs = message?.kwargs as Record<string, unknown> | undefined;
+      const responseMetadata =
+        (message?.response_metadata as Record<string, unknown> | undefined) ??
+        (messageKwargs?.response_metadata as Record<string, unknown> | undefined);
+      const generationInfo = item?.generationInfo as Record<string, unknown> | undefined;
+
+      // Native Chat Completions finish_reason (preferred).
+      const native =
+        generationInfo?.finish_reason ??
+        responseMetadata?.finish_reason ??
+        message?.finish_reason ??
+        messageKwargs?.finish_reason;
+
+      let reason: string | undefined;
+      if (isString(native) && native.trim().length > 0) {
+        reason = native.trim();
+      } else if (message) {
+        reason = deriveResponsesFinishReason(message, responseMetadata);
+      }
+
+      if (reason) reasons.push(reason);
+    }
+  }
+
+  return reasons.length > 0 ? reasons : undefined;
+}
+
+// Map a Responses status/incomplete_details to a Chat-Completions-style reason.
+function deriveResponsesFinishReason(
+  message: Record<string, unknown>,
+  responseMetadata: Record<string, unknown> | undefined,
+): string | undefined {
+  const status = responseMetadata?.status;
+  if (!isString(status)) return undefined;
+
+  switch (status) {
+    case "completed":
+      return messageHasToolCalls(message) ? "tool_calls" : "stop";
+    case "incomplete": {
+      const incompleteDetails = responseMetadata?.incomplete_details as
+        | Record<string, unknown>
+        | undefined;
+      const detailReason = incompleteDetails?.reason;
+      if (detailReason === "max_output_tokens") return "length";
+      if (detailReason === "content_filter") return "content_filter";
+      return isString(detailReason) && detailReason.trim().length > 0
+        ? detailReason.trim()
+        : "incomplete";
+    }
+    case "failed":
+    case "cancelled":
+      return "error";
+    default:
+      return undefined;
+  }
+}
+
+// Any tool calls present, including malformed ones (invalid_tool_calls still
+// map to "tool_calls" in Chat Completions).
+function messageHasToolCalls(message: Record<string, unknown>): boolean {
+  for (const key of ["tool_calls", "invalid_tool_calls"]) {
+    const candidates = [
+      getNestedValue(message, key),
+      getNestedValue(message, "lc_kwargs", key),
+      getNestedValue(message, "kwargs", key),
+    ];
+    if (candidates.some((calls) => Array.isArray(calls) && calls.length > 0)) return true;
+  }
+  return false;
+}
+
+// Set gen_ai.response.finish_reasons when any reason is available.
+export function setFinishReasonsAttribute(run: Run, span: Span): void {
+  const finishReasons = getFinishReasons(run);
+  if (finishReasons) {
+    span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, finishReasons);
   }
 }
 

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -30,7 +30,7 @@ import {
   GEN_AI_OPERATION_INVOKE_AGENT,
 } from "../../index.js";
 import { serializeMessages, safeSerializeToJson } from "../../../a365/message-utils.js";
-import { MessageRole } from "../../../a365/contracts.js";
+import { MessageRole, FinishReason } from "../../../a365/contracts.js";
 import type {
   ChatMessage,
   OutputMessage,
@@ -648,7 +648,7 @@ export function getFinishReasons(run: Run): string[] | undefined {
 
       let reason: string | undefined;
       if (isString(native) && native.trim().length > 0) {
-        reason = native.trim();
+        reason = normalizeFinishReason(native);
       } else if (message) {
         reason = deriveResponsesFinishReason(message, responseMetadata);
       }
@@ -658,6 +658,27 @@ export function getFinishReasons(run: Run): string[] | undefined {
   }
 
   return reasons.length > 0 ? reasons : undefined;
+}
+
+// Map a provider-reported finish_reason string to the repo's GenAI
+// `FinishReason` contract value. OpenAI Chat Completions reports the plural
+// `finish_reason: "tool_calls"` (and the legacy `"function_call"`), but the
+// shared contract value is `"tool_call"` (see `FinishReason`, matched by the
+// Python distro's `messages.py`). Unrecognized values are passed through
+// trimmed so legitimate reasons are not dropped.
+const FINISH_REASON_ALIASES: Record<string, FinishReason> = {
+  stop: FinishReason.STOP,
+  length: FinishReason.LENGTH,
+  content_filter: FinishReason.CONTENT_FILTER,
+  tool_call: FinishReason.TOOL_CALL,
+  tool_calls: FinishReason.TOOL_CALL,
+  function_call: FinishReason.TOOL_CALL,
+  error: FinishReason.ERROR,
+};
+
+function normalizeFinishReason(value: string): string {
+  const trimmed = value.trim();
+  return FINISH_REASON_ALIASES[trimmed.toLowerCase()] ?? trimmed;
 }
 
 // Map a Responses status/incomplete_details to a Chat-Completions-style reason.
@@ -670,28 +691,28 @@ function deriveResponsesFinishReason(
 
   switch (status) {
     case "completed":
-      return messageHasToolCalls(message) ? "tool_calls" : "stop";
+      return messageHasToolCalls(message) ? FinishReason.TOOL_CALL : FinishReason.STOP;
     case "incomplete": {
       const incompleteDetails = responseMetadata?.incomplete_details as
         | Record<string, unknown>
         | undefined;
       const detailReason = incompleteDetails?.reason;
-      if (detailReason === "max_output_tokens") return "length";
-      if (detailReason === "content_filter") return "content_filter";
-      return isString(detailReason) && detailReason.trim().length > 0
-        ? detailReason.trim()
-        : "incomplete";
+      if (detailReason === "max_output_tokens") return FinishReason.LENGTH;
+      if (detailReason === "content_filter") return FinishReason.CONTENT_FILTER;
+      // No conformant mapping for this status; omit rather than emit a
+      // non-standard finish-reason value.
+      return undefined;
     }
     case "failed":
     case "cancelled":
-      return "error";
+      return FinishReason.ERROR;
     default:
       return undefined;
   }
 }
 
 // Any tool calls present, including malformed ones (invalid_tool_calls still
-// map to "tool_calls" in Chat Completions).
+// count as a tool call, mapped to the "tool_call" contract value).
 function messageHasToolCalls(message: Record<string, unknown>): boolean {
   for (const key of ["tool_calls", "invalid_tool_calls"]) {
     const candidates = [

--- a/src/genai/instrumentations/langchain/utils.ts
+++ b/src/genai/instrumentations/langchain/utils.ts
@@ -632,6 +632,7 @@ export function getFinishReasons(run: Run): string[] | undefined {
   for (const choice of generations) {
     if (!Array.isArray(choice)) continue;
     for (const item of choice as Record<string, unknown>[]) {
+      if (!item || typeof item !== "object") continue;
       const message = item?.message as Record<string, unknown> | undefined;
       const messageKwargs = message?.kwargs as Record<string, unknown> | undefined;
       const responseMetadata =
@@ -639,21 +640,33 @@ export function getFinishReasons(run: Run): string[] | undefined {
         (messageKwargs?.response_metadata as Record<string, unknown> | undefined);
       const generationInfo = item?.generationInfo as Record<string, unknown> | undefined;
 
-      // Native Chat Completions finish_reason (preferred).
-      const native =
-        generationInfo?.finish_reason ??
-        responseMetadata?.finish_reason ??
-        message?.finish_reason ??
-        messageKwargs?.finish_reason;
-
+      // Native Chat Completions finish_reason (preferred). Pick the first
+      // non-blank string candidate; a blank/non-string value in an earlier
+      // source must not mask a valid later one (so `??` is not sufficient).
       let reason: string | undefined;
-      if (isString(native) && native.trim().length > 0) {
-        reason = normalizeFinishReason(native);
-      } else if (message) {
+      for (const candidate of [
+        generationInfo?.finish_reason,
+        responseMetadata?.finish_reason,
+        message?.finish_reason,
+        messageKwargs?.finish_reason,
+      ]) {
+        if (isString(candidate) && candidate.trim().length > 0) {
+          reason = normalizeFinishReason(candidate);
+          break;
+        }
+      }
+
+      // Responses API derivation (no native finish_reason field).
+      if (!reason && message) {
         reason = deriveResponsesFinishReason(message, responseMetadata);
       }
 
-      if (reason) reasons.push(reason);
+      // `gen_ai.response.finish_reasons` is positional and must correspond 1:1
+      // with the received generations. OTel string arrays cannot hold gaps, so
+      // if any generation lacks a valid reason, omit the attribute entirely
+      // rather than emit a compacted/misaligned array.
+      if (!reason) return undefined;
+      reasons.push(reason);
     }
   }
 

--- a/src/genai/semconv.ts
+++ b/src/genai/semconv.ts
@@ -30,6 +30,7 @@ export const ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model" as const;
 export const ATTR_GEN_AI_REQUEST_CHOICE_COUNT = "gen_ai.request.choice.count" as const;
 export const ATTR_GEN_AI_RESPONSE_MODEL = "gen_ai.response.model" as const;
 export const ATTR_GEN_AI_RESPONSE_ID = "gen_ai.response.id" as const;
+export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons" as const;
 export const ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name" as const;
 export const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions" as const;
 export const ATTR_GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages" as const;

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -951,7 +951,7 @@ describe("setFinishReasonsAttribute", () => {
     assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["length"]);
   });
 
-  it("extracts finish reason from response_metadata nested under kwargs (v0)", () => {
+  it("normalizes provider finish_reason 'tool_calls' to the contract value 'tool_call' (v0)", () => {
     const span = makeSpan();
     const run = makeRun({
       outputs: {
@@ -961,7 +961,7 @@ describe("setFinishReasonsAttribute", () => {
       },
     });
     setFinishReasonsAttribute(run, span);
-    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_call"]);
   });
 
   it("prefers generationInfo.finish_reason over response_metadata when both are present", () => {
@@ -1023,7 +1023,7 @@ describe("setFinishReasonsAttribute", () => {
     assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
   });
 
-  it("derives 'tool_calls' from Responses API status 'completed' when the message has tool calls", () => {
+  it("derives 'tool_call' from Responses API status 'completed' when the message has tool calls", () => {
     const span = makeSpan();
     const run = makeRun({
       outputs: {
@@ -1040,10 +1040,10 @@ describe("setFinishReasonsAttribute", () => {
       },
     });
     setFinishReasonsAttribute(run, span);
-    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_call"]);
   });
 
-  it("derives 'tool_calls' from Responses API status 'completed' when the message has invalid tool calls", () => {
+  it("derives 'tool_call' from Responses API status 'completed' when the message has invalid tool calls", () => {
     const span = makeSpan();
     const run = makeRun({
       outputs: {
@@ -1060,10 +1060,10 @@ describe("setFinishReasonsAttribute", () => {
       },
     });
     setFinishReasonsAttribute(run, span);
-    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_call"]);
   });
 
-  it("derives 'tool_calls' when an empty direct tool_calls array masks nested kwargs tool calls", () => {
+  it("derives 'tool_call' when an empty direct tool_calls array masks nested kwargs tool calls", () => {
     const span = makeSpan();
     const run = makeRun({
       outputs: {
@@ -1081,7 +1081,7 @@ describe("setFinishReasonsAttribute", () => {
       },
     });
     setFinishReasonsAttribute(run, span);
-    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_call"]);
   });
 
   it("derives 'length' from Responses API incomplete_details.reason 'max_output_tokens'", () => {
@@ -1128,6 +1128,39 @@ describe("setFinishReasonsAttribute", () => {
     });
     setFinishReasonsAttribute(run, span);
     assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["content_filter"]);
+  });
+
+  it("omits the finish reason when Responses API status is 'incomplete' with a missing/blank reason", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: {
+                  status: "incomplete",
+                  incomplete_details: { reason: "" },
+                },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
+  it("derives 'error' from Responses API status 'failed'", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [[{ message: { response_metadata: { status: "failed" } } }]],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["error"]);
   });
 
   it("prefers a native finish_reason over the Responses API status derivation", () => {

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -1005,6 +1005,56 @@ describe("setFinishReasonsAttribute", () => {
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
   });
 
+  it("falls back to response_metadata.finish_reason when generationInfo.finish_reason is blank", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              generationInfo: { finish_reason: "" },
+              message: { response_metadata: { finish_reason: "length" } },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["length"]);
+  });
+
+  it("falls back to response_metadata.finish_reason when generationInfo.finish_reason is non-string", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              generationInfo: { finish_reason: 42 },
+              message: { response_metadata: { finish_reason: "stop" } },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
+  });
+
+  it("omits the attribute when any generation lacks a valid finish reason (avoids positional misalignment)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [{ generationInfo: {} }],
+          [{ generationInfo: { finish_reason: "length" } }],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
   it("does nothing when no finish reason is found", () => {
     const span = makeSpan();
     const run = makeRun();

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -15,6 +15,7 @@ import {
   setChoiceCountAttribute,
   setProviderNameAttribute,
   setResponseIdAttribute,
+  setFinishReasonsAttribute,
   setSessionIdAttribute,
   setSystemInstructionsAttribute,
   setTokenAttributes,
@@ -29,6 +30,7 @@ import {
   ATTR_GEN_AI_REQUEST_CHOICE_COUNT,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
@@ -925,6 +927,226 @@ describe("setResponseIdAttribute", () => {
     const run = makeRun();
     setResponseIdAttribute(run, span);
     assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+});
+
+describe("setFinishReasonsAttribute", () => {
+  it("extracts finish reason from generationInfo (Chat Completions API)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { generations: [[{ generationInfo: { finish_reason: "stop" } }]] },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
+  });
+
+  it("extracts finish reason from response_metadata (v1, top-level)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [[{ message: { response_metadata: { finish_reason: "length" } } }]],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["length"]);
+  });
+
+  it("extracts finish reason from response_metadata nested under kwargs (v0)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [{ message: { kwargs: { response_metadata: { finish_reason: "tool_calls" } } } }],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+  });
+
+  it("prefers generationInfo.finish_reason over response_metadata when both are present", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              generationInfo: { finish_reason: "stop" },
+              message: { response_metadata: { finish_reason: "length" } },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
+  });
+
+  it("collects one reason per generation when n > 1", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [{ generationInfo: { finish_reason: "stop" } }],
+          [{ generationInfo: { finish_reason: "length" } }],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop", "length"]);
+  });
+
+  it("ignores non-string finish reason values", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: { generations: [[{ generationInfo: { finish_reason: 42 } }]] },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
+  it("does nothing when no finish reason is found", () => {
+    const span = makeSpan();
+    const run = makeRun();
+    setFinishReasonsAttribute(run, span);
+    assert.strictEqual((span.setAttribute as ReturnType<typeof vi.fn>).mock.calls.length, 0);
+  });
+
+  it("derives 'stop' from Responses API status 'completed' (no native finish_reason)", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [[{ message: { response_metadata: { status: "completed" } } }]],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
+  });
+
+  it("derives 'tool_calls' from Responses API status 'completed' when the message has tool calls", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: { status: "completed" },
+                tool_calls: [{ id: "call_1", name: "get_weather", args: {} }],
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+  });
+
+  it("derives 'tool_calls' from Responses API status 'completed' when the message has invalid tool calls", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: { status: "completed" },
+                invalid_tool_calls: [{ name: "broken", args: "not-json" }],
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+  });
+
+  it("derives 'tool_calls' when an empty direct tool_calls array masks nested kwargs tool calls", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: { status: "completed" },
+                tool_calls: [],
+                kwargs: { tool_calls: [{ id: "call_1", name: "get_weather", args: {} }] },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["tool_calls"]);
+  });
+
+  it("derives 'length' from Responses API incomplete_details.reason 'max_output_tokens'", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: {
+                  status: "incomplete",
+                  incomplete_details: { reason: "max_output_tokens" },
+                },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["length"]);
+  });
+
+  it("derives 'content_filter' from Responses API incomplete_details.reason 'content_filter'", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                kwargs: {
+                  response_metadata: {
+                    status: "incomplete",
+                    incomplete_details: { reason: "content_filter" },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["content_filter"]);
+  });
+
+  it("prefers a native finish_reason over the Responses API status derivation", () => {
+    const span = makeSpan();
+    const run = makeRun({
+      outputs: {
+        generations: [
+          [
+            {
+              message: {
+                response_metadata: { finish_reason: "stop", status: "incomplete" },
+              },
+            },
+          ],
+        ],
+      },
+    });
+    setFinishReasonsAttribute(run, span);
+    assert.deepStrictEqual(span.attrs[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], ["stop"]);
   });
 });
 

--- a/test/internal/unit/genai/langchain/utils.test.ts
+++ b/test/internal/unit/genai/langchain/utils.test.ts
@@ -1045,10 +1045,7 @@ describe("setFinishReasonsAttribute", () => {
     const span = makeSpan();
     const run = makeRun({
       outputs: {
-        generations: [
-          [{ generationInfo: {} }],
-          [{ generationInfo: { finish_reason: "length" } }],
-        ],
+        generations: [[{ generationInfo: {} }], [{ generationInfo: { finish_reason: "length" } }]],
       },
     });
     setFinishReasonsAttribute(run, span);


### PR DESCRIPTION
## Summary

Emits the OTel GenAI semantic-convention attribute `gen_ai.response.finish_reasons` on LangChain **chat** spans, which the instrumentation previously never recorded.

Reasons are normalized to the repo's shared `FinishReason` contract (`stop`, `length`, `content_filter`, `tool_call`, `error`) and collected one-per-generation so the array stays parallel to the requested choices (`n`). If any generation lacks a valid reason the whole attribute is omitted (OTel string arrays can't hold gaps), avoiding compacted/misaligned values.

## Details

- **Chat Completions API**: reads the native `finish_reason` from `generationInfo` and `response_metadata` (v1 top-level, v0 nested under `kwargs`), selecting the first non-blank string source. Provider values are normalized to the contract enum (`tool_calls` / `function_call` → `tool_call`).
- **Responses API**: there is no per-choice `finish_reason` field — LangChain stores `status` + `incomplete_details` on `response_metadata` instead — so an equivalent reason is derived:
  - `completed` → `stop` (or `tool_call` when the message carries tool/invalid-tool calls)
  - `incomplete` → `length` (`max_output_tokens`) / `content_filter`; otherwise omitted (no non-standard value emitted)
  - `failed` / `cancelled` → `error`
- Native `finish_reason` is always preferred when present; the Responses derivation is a fallback.

## Files

- `src/genai/semconv.ts` — new `ATTR_GEN_AI_RESPONSE_FINISH_REASONS` constant.
- `src/genai/instrumentations/langchain/utils.ts` — `getFinishReasons` / `setFinishReasonsAttribute` (+ `normalizeFinishReason`, `deriveResponsesFinishReason`, `messageHasToolCalls`).
- `src/genai/instrumentations/langchain/tracer.ts` — call `setFinishReasonsAttribute` in `_endTrace`.
- `test/internal/unit/genai/langchain/utils.test.ts` — unit tests for extraction, normalization, Responses derivation, source fallback, and positional integrity.
- `CHANGELOG.md` — Features Added entry.

## Testing

- `npm run build`, `eslint`, Prettier, and the langchain utils unit suite (80 tests) all pass.
- Verified **end-to-end** against Azure OpenAI with telemetry landing in Application Insights:

  | Scenario | `gen_ai.response.finish_reasons` | Path |
  |---|---|---|
  | Chat Completions, simple | `["stop"]` | native |
  | Chat Completions, tool call | `["tool_call"]` | native (normalized from `tool_calls`) |
  | Chat Completions, `maxTokens: 1` | `["length"]` | native |
  | Responses API (`useResponsesApi`) | `["stop"]` | derived from `status: "completed"` |

## Notes

- This is net-new relative to the upstream A365 LangChain tracer (which does not emit this attribute). The Microsoft Python distro defines the same `FinishReason` enum, but its LangChain path stamps `finish_reason` on each output message rather than emitting the span-level `gen_ai.response.finish_reasons`. This JS implementation additionally normalizes provider values to the shared contract and covers the Responses API status derivation.
