### PR TITLE
feat(logs): add console log collection via instrumentation-console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 - Add top-level `enableSensitiveData` option to capture GenAI message content (prompts, completions, tool arguments/results, system instructions) for LangChain; content is hidden by default
 - Emit `gen_ai.response.finish_reasons` on LangChain chat spans, extracted from the LLM run output
+- Add console log collection via `@opentelemetry/instrumentation-console`; opt in with `instrumentationOptions: { console: { enabled: true } }` and filter by severity with `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL`
 
 ### Other Changes
 - Remove the unused `AZURE_MONITOR_DISTRO_VERSION` env var and its constant; the distro reports its version via `MICROSOFT_OPENTELEMETRY_VERSION`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ That's it — traces, metrics, and logs are collected automatically with built-i
 Most instrumentations use `InstrumentationConfig` shape (`{ enabled?: boolean, ... }`).
 
 - Built-in infra instrumentations (`http`, `azureSdk`, `mongoDb`, `mySql`, `postgreSql`, `redis`, `redis4`) are enabled by default.
-- Logging instrumentations (`bunyan`, `winston`) are disabled by default.
+- Logging instrumentations (`bunyan`, `winston`, `console`) are disabled by default.
 - GenAI instrumentations (`openaiAgents`, `langchain`) are enabled by default.
 - When `a365.enabled` is `true`, non-GenAI instrumentations (`http`, `azureSdk`, DB/cache, and logging) are disabled by default unless explicitly set in `instrumentationOptions`.
 
@@ -156,6 +156,7 @@ Set `enabled: true` or `enabled: false` explicitly for predictable behavior.
 | `redis4`       | `InstrumentationConfig`             | enabled  | Redis 4 instrumentation                                       |
 | `bunyan`       | `InstrumentationConfig`             | disabled | Bunyan log instrumentation                                    |
 | `winston`      | `InstrumentationConfig`             | disabled | Winston log instrumentation                                   |
+| `console`      | `InstrumentationConfig`             | disabled | Console log instrumentation                                   |
 | `openaiAgents` | `OpenAIAgentsInstrumentationConfig` | enabled  | OpenAI Agents SDK instrumentation (requires `@openai/agents`) |
 | `langchain`    | `LangChainInstrumentationConfig`    | enabled  | LangChain instrumentation (requires `@langchain/core`)        |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/instrumentation": "^0.219.0",
         "@opentelemetry/instrumentation-bunyan": "^0.63.0",
+        "@opentelemetry/instrumentation-console": "^0.2.0",
         "@opentelemetry/instrumentation-http": "^0.219.0",
         "@opentelemetry/instrumentation-mongodb": "^0.71.0",
         "@opentelemetry/instrumentation-mysql": "^0.64.0",
@@ -2328,6 +2329,51 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-console": {
+      "version": "0.2.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-console/-/instrumentation-console-0.2.0.tgz",
+      "integrity": "sha1-VYCKYTScPoLYR85W5cwlBCSzkOc=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.1"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-console/node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha1-su0jXeS188F2mt+l87wkfYLN+8k=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-console/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha1-VCs2v0hx3YPchOE3OsS7zTWov7g=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/instrumentation": "^0.219.0",
     "@opentelemetry/instrumentation-bunyan": "^0.63.0",
+    "@opentelemetry/instrumentation-console": "^0.2.0",
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/instrumentation-mongodb": "^0.71.0",
     "@opentelemetry/instrumentation-mysql": "^0.64.0",

--- a/src/distro/distro.ts
+++ b/src/distro/distro.ts
@@ -5,6 +5,7 @@ import { metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import type { NodeSDKConfiguration } from "@opentelemetry/sdk-node";
 import { NodeSDK } from "@opentelemetry/sdk-node";
+import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { MetricReader, ViewOptions } from "@opentelemetry/sdk-metrics";
 import {
   type SpanProcessor,
@@ -60,6 +61,15 @@ let sdk: NodeSDK;
 let disposeAzureMonitor: (() => void) | undefined;
 let isShutdown = false;
 
+// The console instrumentation is the only one that patches the global `console`.
+// NodeSDK.shutdown() does not disable instrumentations, so we track it and disable it
+// ourselves on shutdown / re-init to restore console. It is constructed disabled and
+// enabled by the SDK during registration (see createInstrumentations), which lets its
+// own disable() correctly restore the original console methods.
+let consoleInstrumentation: Instrumentation | undefined;
+
+const CONSOLE_INSTRUMENTATION_NAME = "@opentelemetry/instrumentation-console";
+
 const A365_DISABLED_INSTRUMENTATIONS_BY_DEFAULT: ReadonlyArray<keyof InstrumentationOptions> = [
   "http",
   "azureSdk",
@@ -70,6 +80,7 @@ const A365_DISABLED_INSTRUMENTATIONS_BY_DEFAULT: ReadonlyArray<keyof Instrumenta
   "redis4",
   "bunyan",
   "winston",
+  "console",
 ];
 
 /**
@@ -218,6 +229,9 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   metrics.disable();
   trace.disable();
   logs.disable();
+  // Restore any console patch from a previous initialization before re-patching.
+  consoleInstrumentation?.disable();
+  consoleInstrumentation = undefined;
 
   // Clear the entire OpenTelemetry API global state to avoid version conflicts.
   // The disable() calls above remove individual providers but leave the `version` field
@@ -244,6 +258,11 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
   const instrumentations = createInstrumentations(config, {
     filterAzureMonitorRequests: azureMonitorEnabled,
   });
+  // The console instrumentation patches the global `console`, which NodeSDK.shutdown()
+  // does not restore; track it so we can disable it on shutdown / re-init.
+  consoleInstrumentation = instrumentations.find(
+    (instrumentation) => instrumentation.instrumentationName === CONSOLE_INSTRUMENTATION_NAME,
+  );
   const sampler = createSampler(config);
   const views: ViewOptions[] = createViews(config);
 
@@ -440,6 +459,9 @@ export function useMicrosoftOpenTelemetry(options?: MicrosoftOpenTelemetryOption
  */
 export function shutdownMicrosoftOpenTelemetry(): Promise<void> {
   isShutdown = true;
+  // Unpatch `console` — NodeSDK.shutdown() does not disable instrumentations.
+  consoleInstrumentation?.disable();
+  consoleInstrumentation = undefined;
   disposeAzureMonitor?.();
   const sdkShutdown = sdk?.shutdown() ?? Promise.resolve();
   return sdkShutdown

--- a/src/distro/instrumentations.ts
+++ b/src/distro/instrumentations.ts
@@ -22,6 +22,7 @@ import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { RedisInstrumentation } from "@opentelemetry/instrumentation-redis";
 import { BunyanInstrumentation } from "@opentelemetry/instrumentation-bunyan";
 import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
+import { ConsoleInstrumentation } from "@opentelemetry/instrumentation-console";
 import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { ViewOptions } from "@opentelemetry/sdk-metrics";
 
@@ -106,6 +107,20 @@ export function createInstrumentations(
     instrumentations.push(
       new WinstonInstrumentation({
         ...config.instrumentationOptions.winston,
+        logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
+      }),
+    );
+  }
+
+  if (config.instrumentationOptions.console?.enabled) {
+    instrumentations.push(
+      new ConsoleInstrumentation({
+        ...config.instrumentationOptions.console,
+        // Construct disabled so the SDK enables (patches) it once during registration.
+        // instrumentation-console records the original console methods on enable(); doing
+        // that in its constructor lets a field initializer wipe them so disable() can no
+        // longer restore console. Deferring the patch to registration avoids that.
+        enabled: false,
         logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
       }),
     );

--- a/src/shared/logging/diagFileConsoleLogger.ts
+++ b/src/shared/logging/diagFileConsoleLogger.ts
@@ -16,6 +16,11 @@ import {
   unlinkAsync,
 } from "../../utils/index.js";
 
+// Capture console.log at module load, before the console instrumentation patches it,
+// so distro diagnostics are never captured as customer telemetry (which would recurse)
+// and always reach the real console regardless of patch/unpatch cycles.
+const originalConsoleLog: (...args: any[]) => void = console.log.bind(console);
+
 export class DiagFileConsoleLogger implements DiagLogger {
   private _TAG = "DiagFileConsoleLogger:";
   private _cleanupTimeOut = 60 * 30 * 1000; // 30 minutes;
@@ -129,11 +134,16 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await this._storeToDisk(args);
       }
       if (this._logToConsole) {
-        console.log(...args);
+        this._writeToConsole(...args);
       }
     } catch (err: any) {
-      console.log(this._TAG, `Failed to log to file: ${err && err.message}`);
+      this._writeToConsole(this._TAG, `Failed to log to file: ${err && err.message}`);
     }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _writeToConsole(...args: any[]): void {
+    originalConsoleLog(...args);
   }
 
   /**
@@ -204,7 +214,10 @@ export class DiagFileConsoleLogger implements DiagLogger {
     try {
       await confirmDirExists(this._tempDir);
     } catch (err: any) {
-      console.log(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
+      this._writeToConsole(
+        this._TAG,
+        `Failed to create directory for log file: ${err && err.message}`,
+      );
       return;
     }
     try {
@@ -214,7 +227,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       try {
         await appendFileAsync(this._fileFullPath, data);
       } catch (appendError: any) {
-        console.log(
+        this._writeToConsole(
           this._TAG,
           `Failed to put log into file: ${appendError && appendError.message}`,
         );
@@ -236,7 +249,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       const backupPath = path.join(this._tempDir, `${new Date().getTime()}.${this._logFileName}`);
       await writeFileAsync(backupPath, buffer);
     } catch (err: any) {
-      console.log("Failed to generate backup log file", err);
+      this._writeToConsole(this._TAG, "Failed to generate backup log file", err);
     } finally {
       // Store logs
       await writeFileAsync(this._fileFullPath, data);
@@ -265,7 +278,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await unlinkAsync(pathToDelete);
       }
     } catch (err: any) {
-      console.log(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
+      this._writeToConsole(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,8 @@ export interface InstrumentationOptions {
   bunyan?: InstrumentationConfig;
   /** Winston Instrumentation Config */
   winston?: InstrumentationConfig;
+  /** Console Instrumentation Config */
+  console?: InstrumentationConfig;
 
   // ── GenAI & agent framework instrumentations ──────────────────────
 

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -1551,4 +1551,103 @@ describe("Main functions", () => {
 
     await shutdownMicrosoftOpenTelemetry();
   });
+
+  describe("console instrumentation", () => {
+    it("patches the global console when enabled and restores it on shutdown (unpatch)", async () => {
+      const original = console.log;
+      useMicrosoftOpenTelemetry({
+        azureMonitor: { enabled: false },
+        enableConsoleExporters: false,
+        instrumentationOptions: {
+          console: { enabled: true },
+          openaiAgents: { enabled: false },
+          langchain: { enabled: false },
+        },
+      });
+
+      expect(console.log).not.toBe(original);
+
+      await shutdownMicrosoftOpenTelemetry();
+      // Shutdown must unpatch console — NodeSDK.shutdown() does not do this on its own.
+
+      expect(console.log).toBe(original);
+    });
+
+    it("does not patch the global console when console instrumentation is disabled (default)", async () => {
+      const original = console.log;
+      useMicrosoftOpenTelemetry({
+        azureMonitor: { enabled: false },
+        enableConsoleExporters: false,
+        instrumentationOptions: {
+          openaiAgents: { enabled: false },
+          langchain: { enabled: false },
+        },
+      });
+
+      expect(console.log).toBe(original);
+      await shutdownMicrosoftOpenTelemetry();
+    });
+
+    it("does not leak a stale console patch across re-initialization", async () => {
+      const original = console.log;
+      const options: MicrosoftOpenTelemetryOptions = {
+        azureMonitor: { enabled: false },
+        enableConsoleExporters: false,
+        instrumentationOptions: {
+          console: { enabled: true },
+          openaiAgents: { enabled: false },
+          langchain: { enabled: false },
+        },
+      };
+      useMicrosoftOpenTelemetry(options);
+
+      const firstPatch = console.log;
+      expect(firstPatch).not.toBe(original);
+
+      // Re-init should disable the previous console instrumentation (restoring
+      // console) before installing a fresh patch, so no double-patching occurs.
+      useMicrosoftOpenTelemetry(options);
+
+      const secondPatch = console.log;
+      expect(secondPatch).not.toBe(original);
+      expect(secondPatch).not.toBe(firstPatch);
+
+      await shutdownMicrosoftOpenTelemetry();
+      // A single disable must fully restore the original — proving there is only
+      // one active console patch, not a stack of them.
+
+      expect(console.log).toBe(original);
+    });
+
+    it("emits a log record when console.log is called with console instrumentation enabled", async () => {
+      const processor: LogRecordProcessor = {
+        forceFlush: () => Promise.resolve(),
+        onEmit(_logRecord: SdkLogRecord, _context?: Context) {
+          /* no-op */
+        },
+        shutdown: () => Promise.resolve(),
+      };
+      const onEmitSpy = vi.spyOn(processor, "onEmit");
+      useMicrosoftOpenTelemetry({
+        azureMonitor: { enabled: false },
+        enableConsoleExporters: false,
+        logRecordProcessors: [processor],
+        instrumentationOptions: {
+          console: { enabled: true },
+          openaiAgents: { enabled: false },
+          langchain: { enabled: false },
+        },
+      });
+
+      console.log("console-instrumentation-emit-test");
+      expect(onEmitSpy).toHaveBeenCalled();
+      const emitted = onEmitSpy.mock.calls.some(
+        (call) =>
+          String((call[0] as SdkLogRecord).body).indexOf("console-instrumentation-emit-test") > -1,
+      );
+      expect(emitted).toBe(true);
+
+      await shutdownMicrosoftOpenTelemetry();
+    });
+  });
 });

--- a/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -9,7 +9,6 @@ import { DiagFileConsoleLogger } from "../../../../../src/shared/logging/diagFil
 
 // These tests use real SDK diagnostics instead of fabricated log strings.
 describe("DiagFileConsoleLogger filtering", () => {
-  let originalConsoleLog: typeof console.log;
   let loggedMessages: any[];
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -22,11 +21,17 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env };
-    originalConsoleLog = console.log;
     loggedMessages = [];
-    console.log = vi.fn((...args: any[]) => {
-      loggedMessages.push(args);
-    });
+    // The logger writes console output through its private `_writeToConsole`
+    // helper (which uses the original console.log reference captured at module
+    // load, before the console instrumentation can patch it). Spy on that helper
+    // so we observe what the logger intends to write regardless of how the global
+    // `console` is (re)bound.
+    vi.spyOn(DiagFileConsoleLogger.prototype as any, "_writeToConsole").mockImplementation(
+      (...args: any[]) => {
+        loggedMessages.push(args);
+      },
+    );
     setDiagLogger();
     // Ignore any diagnostics emitted by setLogger itself
     loggedMessages.length = 0;
@@ -34,7 +39,6 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   afterEach(() => {
     process.env = originalEnv;
-    console.log = originalConsoleLog;
     diag.disable();
     vi.restoreAllMocks();
   });

--- a/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -163,4 +163,43 @@ describe("Library/DiagFileConsoleLogger", () => {
       );
     });
   });
+
+  describe("Unpatch-safe console output", () => {
+    beforeEach(() => {
+      logger = new DiagFileConsoleLogger();
+      logger["_logToFile"] = false;
+      logger["_logToConsole"] = true;
+    });
+
+    it("should bypass a patched console.log so distro diagnostics are not captured as telemetry", async () => {
+      // Simulate `@opentelemetry/instrumentation-console` patching the global
+      // console.log AFTER the diag logger module captured its original binding
+      // at import time. Diagnostic output must NOT flow through the patched
+      // console, otherwise it would be captured as customer log telemetry and
+      // recurse (diagnostics emitted during export trigger more exports).
+      const patched = vi.fn();
+      const realConsoleLog = console.log;
+
+      console.log = patched as unknown as typeof console.log;
+      try {
+        await logger["logMessage"]("diag-output");
+        expect(patched).not.toHaveBeenCalled();
+      } finally {
+        console.log = realConsoleLog;
+      }
+    });
+
+    it("should keep writing to console after the patch is removed (unpatch)", async () => {
+      const writeSpy = vi.spyOn(logger as any, "_writeToConsole").mockImplementation(() => {});
+      // Patch then unpatch, mirroring ConsoleInstrumentation enable()/disable().
+      const realConsoleLog = console.log;
+
+      console.log = vi.fn() as unknown as typeof console.log;
+
+      console.log = realConsoleLog;
+
+      await logger["logMessage"]("still-logging");
+      expect(writeSpy).toHaveBeenCalledWith("still-logging");
+    });
+  });
 });


### PR DESCRIPTION
### Summary

Adds support for the upstream [`@opentelemetry/instrumentation-console`](https://www.npmjs.com/package/@opentelemetry/instrumentation-console) package so `console.*` calls are collected as log telemetry.

It is **opt-in / disabled by default**; enable with:

```ts
useMicrosoftOpenTelemetry({
  instrumentationOptions: { console: { enabled: true } },
});
```

The set of severities collected is filtered by the existing `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` env var, matching the behavior of the existing Bunyan and Winston log instrumentations.

This mirrors the equivalent change in `@azure/monitor-opentelemetry` ([Azure/azure-sdk-for-js#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)).

### Changes

- Add the `@opentelemetry/instrumentation-console` dependency and wire `ConsoleInstrumentation` into `createInstrumentations`, gated on `instrumentationOptions.console.enabled`.
- Add `console` to `InstrumentationOptions`, and to the set of instrumentations disabled by default when A365 is enabled.
- Track the instrumentation and `disable()` it on shutdown and on re-init so the original `console` methods are restored — `NodeSDK.shutdown()` does not disable instrumentations. Only the console instrumentation is disabled here; module-based instrumentations are intentionally left untouched so a repeated `useMicrosoftOpenTelemetry()` call does not lose their telemetry.
- Route `DiagFileConsoleLogger` output through a `console.log` reference captured at module load, so the distro's own diagnostics are never collected as customer telemetry (which would recurse: diagnostics emitted during export would trigger further exports).
- README + CHANGELOG entries and unit tests.

### Note on constructing the instrumentation disabled

`ConsoleInstrumentation` is deliberately constructed with `enabled: false` and left for the SDK to enable during registration:

```ts
new ConsoleInstrumentation({ ...options, enabled: false, logSeverity });
```

`instrumentation-console@0.2.0` records the original `console` methods into `this._originals` inside `enable()`. `InstrumentationBase`'s constructor calls `enable()` when `config.enabled` is true, but the `_originals = new Map()` class field initializer runs *after* `super()` and wipes that record — so `_originals.size === 0` immediately after construction and the instrumentation's own `disable()` can never restore `console`.

Deferring the patch to registration means `enable()` runs once, after the field initializer, so the originals are recorded correctly and `disable()` restores `console` as expected.

### Validation

- `npm run build`, `npm run lint` (0 errors), `npm run docs`, and `npm run test:esm-build` all pass.
- `npm run test:unit` (916 passing) and `npm run test:functional` (31 passing) pass.
- End-to-end against a live Application Insights resource with a TypeScript app:
  - `console.log` / `.info` / `.warn` / `.error` / `.debug` each produced **exactly one** log record (no duplicates), with correct severity mapping (`debug`→0, `log`/`info`→1, `warn`→2, `error`→3).
  - `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=WARN` produced only the `warn` and `error` records.
  - After `shutdownMicrosoftOpenTelemetry()`, `console.log` identity was restored to the original and a subsequent `console.log` was **not** collected.
  - No recursion or crash with console collection and Azure Monitor export both active.