### PR TITLE
fix(sdk-stats): scope AKS resource detector feature to real AKS detections

### DIFF
--- a/src/azureMonitor/index.ts
+++ b/src/azureMonitor/index.ts
@@ -12,13 +12,6 @@ import type { SdkStatsFeatures } from "../types.js";
 import { BrowserSdkLoader } from "./browserSdkLoader/browserSdkLoader.js";
 import { setSdkPrefix } from "./metrics/quickpulse/utils.js";
 import { Logger } from "../shared/logging/index.js";
-import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-conventions";
-
-/**
- * Semantic attribute for cloud resource ID, defined by \@opentelemetry/resource-detector-azure
- * @internal
- */
-const CLOUD_RESOURCE_ID_ATTRIBUTE = "cloud.resource_id";
 
 /**
  * Check whether Azure Monitor has a usable connection string available
@@ -59,15 +52,14 @@ export function validateAzureMonitorConfig(config: InternalConfig): boolean {
  * @internal
  */
 export function getAzureMonitorSdkStatsFeatures(config: InternalConfig): SdkStatsFeatures {
-  const resourceAttributes = config.resource.attributes;
-  const aksResourceDetected =
-    SEMRESATTRS_K8S_CLUSTER_NAME in resourceAttributes ||
-    CLOUD_RESOURCE_ID_ATTRIBUTE in resourceAttributes;
   return {
     browserSdkLoader: config.browserSdkLoaderOptions.enabled,
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
     diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
-    aksResourceDetectorPopulation: aksResourceDetected,
+    // Only report this when the AKS resource detector itself populated the AKS cluster
+    // attributes, which requires the customer to have configured access to the
+    // aks-cluster-metadata ConfigMap (RBAC + env var or mounted ConfigMap).
+    aksResourceDetectorPopulation: config.aksResourceDetectorPopulated,
   };
 }
 

--- a/src/azureMonitor/utils/common.ts
+++ b/src/azureMonitor/utils/common.ts
@@ -1,6 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import type http from "node:http";
+import type { Attributes } from "@opentelemetry/api";
+
+/**
+ * Resource attribute holding the ARM resource ID of the AKS cluster, populated by the AKS
+ * resource detector. Declared locally because it is an unstable semantic convention that the
+ * detector package does not export.
+ * @internal
+ */
+const CLOUD_RESOURCE_ID_ATTRIBUTE = "cloud.resource_id";
+
+/**
+ * Matches the full ARM resource ID of an AKS managed cluster, for example
+ * `/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}`.
+ * @internal
+ */
+const AKS_MANAGED_CLUSTER_RESOURCE_ID_REGEX =
+  /^\/subscriptions\/[^/\s]+\/resourceGroups\/[^/\s]+\/providers\/Microsoft\.ContainerService\/managedClusters\/[^/\s]+\/?$/i;
 
 export function ignoreOutgoingRequestHook(request: http.RequestOptions): boolean {
   if (request && request.headers && !Array.isArray(request.headers)) {
@@ -60,6 +77,50 @@ export const isFunctionApp = (): boolean => {
 export const isAks = (): boolean => {
   return process.env.AKS_ARM_NAMESPACE_ID || process.env.KUBERNETES_SERVICE_HOST ? true : false;
 };
+
+/**
+ * Determines whether the AKS resource detector was actually able to populate the AKS cluster
+ * attributes, based on the attributes that detector - and only that detector - produced.
+ *
+ * This is only the case when the customer is running in AKS *and* has correctly wired up access
+ * to the `aks-cluster-metadata` ConfigMap in the `kube-public` namespace (RBAC role and role
+ * binding, surfaced either through the `CLUSTER_RESOURCE_ID` environment variable or through the
+ * mounted ConfigMap).
+ *
+ * The merged resource is deliberately not inspected, because `k8s.cluster.name` and
+ * `cloud.resource_id` can also be contributed by other sources - the App Service, Functions and
+ * VM detectors all set `cloud.resource_id`, and both attributes can be supplied by the customer
+ * through `OTEL_RESOURCE_ATTRIBUTES` or a custom resource - none of which indicate that the AKS
+ * resource detector is working. The cluster resource ID is additionally validated to be a full
+ * AKS managed cluster ARM ID, since the detector does not validate the value it reads.
+ * @internal
+ */
+export function isAksResourceDetectorPopulated(attributes: Attributes = {}): boolean {
+  if (!isAks()) {
+    return false;
+  }
+  const clusterResourceId = attributes[CLOUD_RESOURCE_ID_ATTRIBUTE];
+  return (
+    typeof clusterResourceId === "string" &&
+    AKS_MANAGED_CLUSTER_RESOURCE_ID_REGEX.test(clusterResourceId.trim())
+  );
+}
+
+/**
+ * Tests a flag without 32-bit coercion.
+ * @internal
+ */
+export function hasNumberFlag(mask: number, flag: number): boolean {
+  return flag > 0 && Math.floor(mask / flag) % 2 === 1;
+}
+
+/**
+ * Clears a flag without 32-bit coercion.
+ * @internal
+ */
+export function removeNumberFlag(mask: number, flag: number): number {
+  return hasNumberFlag(mask, flag) ? mask - flag : mask;
+}
 
 /**
  * Get prefix resource provider, vm will considered as "unknown RP"

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -16,6 +16,7 @@ import type {
 import type { Sampler } from "@opentelemetry/sdk-trace-base";
 import type { AzureMonitorExporterOptions } from "@azure/monitor-opentelemetry-exporter";
 import { EnvConfig } from "./envConfig.js";
+import { isAksResourceDetectorPopulated } from "../azureMonitor/utils/common.js";
 import {
   azureAksDetector,
   azureAppServiceDetector,
@@ -51,6 +52,7 @@ export class InternalConfig {
   public sampler?: Sampler;
 
   private _resource: Resource = emptyResource();
+  private _aksResourceDetectorPopulated: boolean = false;
 
   public set resource(resource: Resource) {
     this._resource = this._resource.merge(resource);
@@ -61,6 +63,15 @@ export class InternalConfig {
    */
   public get resource(): Resource {
     return this._resource;
+  }
+
+  /**
+   * Whether the AKS resource detector was able to populate the AKS cluster attributes, which
+   * requires the customer to have configured access to the `aks-cluster-metadata` ConfigMap.
+   * @internal
+   */
+  public get aksResourceDetectorPopulated(): boolean {
+    return this._aksResourceDetectorPopulated;
   }
 
   public browserSdkLoaderOptions: BrowserSdkLoaderOptions;
@@ -160,11 +171,18 @@ export class InternalConfig {
     const envResource = detectResources(detectResourceConfig);
     resource = resource.merge(envResource);
 
-    // Load resource attributes from Azure
-    const azureResource: Resource = detectResources({
-      detectors: [azureAksDetector, azureAppServiceDetector, azureFunctionsDetector],
+    // Load resource attributes from Azure. AKS is detected on its own so that we can tell
+    // whether the AKS detector itself populated the cluster attributes - other detectors and the
+    // customer can populate the same attributes without AKS being involved.
+    const aksResource: Resource = detectResources({
+      detectors: [azureAksDetector],
     });
-    this._resource = resource.merge(azureResource);
+    this._aksResourceDetectorPopulated = isAksResourceDetectorPopulated(aksResource.attributes);
+
+    const azureResource: Resource = detectResources({
+      detectors: [azureAppServiceDetector, azureFunctionsDetector],
+    });
+    this._resource = resource.merge(aksResource).merge(azureResource);
 
     // Handle VM resource detection asynchronously to avoid warnings
     // about accessing resource attributes before async attributes are settled

--- a/src/utils/sdkStats.ts
+++ b/src/utils/sdkStats.ts
@@ -13,6 +13,7 @@ import {
   SdkStatsFeaturesMap,
   SdkStatsInstrumentation,
 } from "../types.js";
+import { removeNumberFlag } from "../azureMonitor/utils/common.js";
 
 let instance: SdkStatsConfiguration;
 
@@ -21,6 +22,16 @@ class SdkStatsConfiguration {
   private initializedByShim = false;
   private currentSdkStatsInstrumentations: SdkStatsInstrumentations = {};
   private currentSdkStatsFeatures: SdkStatsFeatures = {};
+
+  /**
+   * Removes features that describe the state of the current process from an inherited
+   * bit map. The AKS resource detector feature always reflects whether *this* process was
+   * able to read the AKS cluster metadata, so it must never be inherited from a seed set
+   * by a parent process, the shim, or a previous configuration.
+   */
+  private stripPerProcessFeatures(featureBitMap: number): number {
+    return removeNumberFlag(featureBitMap, SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION);
+  }
 
   constructor() {
     // Check for shim initialization upon construction
@@ -137,12 +148,12 @@ class SdkStatsConfiguration {
         const asNumber = Number(envValue);
         if (!isNaN(asNumber)) {
           // Plain number format (e.g. set by the shim)
-          featureBitMap |= asNumber;
+          featureBitMap |= this.stripPerProcessFeatures(asNumber);
         } else {
           // JSON format (e.g. set by a previous call to this function)
           const parsed = JSON.parse(envValue);
           if (parsed && typeof parsed.feature === "number") {
-            featureBitMap |= parsed.feature;
+            featureBitMap |= this.stripPerProcessFeatures(parsed.feature);
           }
         }
       }

--- a/test/internal/unit/azureMonitor/getAzureMonitorSdkStatsFeatures.test.ts
+++ b/test/internal/unit/azureMonitor/getAzureMonitorSdkStatsFeatures.test.ts
@@ -1,13 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { InternalConfig } from "../../../../src/shared/config.js";
 import { getAzureMonitorSdkStatsFeatures } from "../../../../src/azureMonitor/index.js";
 import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-conventions";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 
+const AKS_CLUSTER_RESOURCE_ID =
+  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster";
+
 describe("getAzureMonitorSdkStatsFeatures", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env;
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   it("should return browserSdkLoader true when enabled in config", () => {
     const config = new InternalConfig();
     config.browserSdkLoaderOptions.enabled = true;
@@ -56,13 +70,11 @@ describe("getAzureMonitorSdkStatsFeatures", () => {
     expect(features.diskRetry).toBe(false);
   });
 
-  it("should detect AKS resource when k8s.cluster.name attribute is present", () => {
-    const config = new InternalConfig();
-    config.resource = resourceFromAttributes({
-      [SEMRESATTRS_K8S_CLUSTER_NAME]: "my-cluster",
-    });
+  it("should detect AKS resource when the AKS resource detector populated the cluster resource ID", () => {
+    process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    process.env.CLUSTER_RESOURCE_ID = AKS_CLUSTER_RESOURCE_ID;
 
-    const features = getAzureMonitorSdkStatsFeatures(config);
+    const features = getAzureMonitorSdkStatsFeatures(new InternalConfig());
     expect(features.aksResourceDetectorPopulation).toBe(true);
   });
 
@@ -70,6 +82,42 @@ describe("getAzureMonitorSdkStatsFeatures", () => {
     const config = new InternalConfig();
 
     const features = getAzureMonitorSdkStatsFeatures(config);
+    expect(features.aksResourceDetectorPopulation).toBe(false);
+  });
+
+  it("should not detect AKS resource for a customer supplied k8s.cluster.name attribute", () => {
+    process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    const config = new InternalConfig();
+    config.resource = resourceFromAttributes({
+      [SEMRESATTRS_K8S_CLUSTER_NAME]: "my-cluster",
+    });
+
+    const features = getAzureMonitorSdkStatsFeatures(config);
+    expect(features.aksResourceDetectorPopulation).toBe(false);
+  });
+
+  it("should not detect AKS resource in App Service, which also sets cloud.resource_id", () => {
+    process.env.WEBSITE_SITE_NAME = "testSiteName";
+    process.env.WEBSITE_OWNER_NAME =
+      "00000000-0000-0000-0000-000000000000+testResourceGroup-CentralUS";
+    process.env.WEBSITE_RESOURCE_GROUP = "testResourceGroup";
+
+    const features = getAzureMonitorSdkStatsFeatures(new InternalConfig());
+    expect(features.aksResourceDetectorPopulation).toBe(false);
+  });
+
+  it("should not detect AKS resource for a cluster resource ID that is not an AKS cluster", () => {
+    process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    process.env.CLUSTER_RESOURCE_ID = "my-self-managed-cluster";
+
+    const features = getAzureMonitorSdkStatsFeatures(new InternalConfig());
+    expect(features.aksResourceDetectorPopulation).toBe(false);
+  });
+
+  it("should not detect AKS resource outside of a Kubernetes environment", () => {
+    process.env.CLUSTER_RESOURCE_ID = AKS_CLUSTER_RESOURCE_ID;
+
+    const features = getAzureMonitorSdkStatsFeatures(new InternalConfig());
     expect(features.aksResourceDetectorPopulation).toBe(false);
   });
 });

--- a/test/internal/unit/main.test.ts
+++ b/test/internal/unit/main.test.ts
@@ -382,6 +382,7 @@ describe("Main functions", () => {
 
   it("should set AKS_RESOURCE_DETECTOR_POPULATION feature when AKS resource attributes are populated", () => {
     const env = <{ [id: string]: string }>{};
+    env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
     env.CLUSTER_RESOURCE_ID =
       "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster";
     process.env = env;
@@ -415,6 +416,116 @@ describe("Main functions", () => {
     assert.notOk(
       features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
       "AKS_RESOURCE_DETECTOR_POPULATION should not be set",
+    );
+  });
+
+  it("should not set AKS_RESOURCE_DETECTOR_POPULATION feature in AKS when the cluster metadata is not available", () => {
+    const env = <{ [id: string]: string }>{};
+    env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    process.env = env;
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    assert.notOk(
+      features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+      "AKS_RESOURCE_DETECTOR_POPULATION should not be set without AKS cluster metadata",
+    );
+  });
+
+  it("should not set AKS_RESOURCE_DETECTOR_POPULATION feature in App Service", () => {
+    const env = <{ [id: string]: string }>{};
+    // App Service populates cloud.resource_id via its own resource detector.
+    env.WEBSITE_SITE_NAME = "testSiteName";
+    env.WEBSITE_OWNER_NAME = "00000000-0000-0000-0000-000000000000+testResourceGroup-CentralUS";
+    env.WEBSITE_RESOURCE_GROUP = "testResourceGroup";
+    process.env = env;
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    assert.notOk(
+      features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+      "AKS_RESOURCE_DETECTOR_POPULATION should not be set in App Service",
+    );
+  });
+
+  it("should not set AKS_RESOURCE_DETECTOR_POPULATION feature for a malformed AKS cluster resource ID", () => {
+    const env = <{ [id: string]: string }>{};
+    env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    env.CLUSTER_RESOURCE_ID =
+      "garbage/providers/Microsoft.ContainerService/managedClusters/test-cluster";
+    process.env = env;
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    assert.notOk(
+      features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+      "AKS_RESOURCE_DETECTOR_POPULATION should not be set for a malformed cluster resource ID",
+    );
+  });
+
+  it("should not inherit a seeded AKS_RESOURCE_DETECTOR_POPULATION feature bit", () => {
+    const env = <{ [id: string]: string }>{};
+    // Numeric seed, the format used by the shim.
+    env.AZURE_MONITOR_STATSBEAT_FEATURES =
+      SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION.toString();
+    process.env = env;
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    assert.notOk(
+      features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+      "AKS_RESOURCE_DETECTOR_POPULATION should not be inherited from a numeric seed",
+    );
+  });
+
+  it("should not inherit a seeded AKS_RESOURCE_DETECTOR_POPULATION feature bit in JSON form", () => {
+    const env = <{ [id: string]: string }>{};
+    env.AZURE_MONITOR_STATSBEAT_FEATURES = JSON.stringify({
+      instrumentation: 0,
+      feature: SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+    });
+    process.env = env;
+    const config: MicrosoftOpenTelemetryOptions = {
+      azureMonitor: {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      },
+    };
+    useMicrosoftOpenTelemetry(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    assert.notOk(
+      features & SdkStatsFeature.AKS_RESOURCE_DETECTOR_POPULATION,
+      "AKS_RESOURCE_DETECTOR_POPULATION should not be inherited from a JSON seed",
     );
   });
 


### PR DESCRIPTION
### Problem

`AKS_RESOURCE_DETECTOR_POPULATION` (bit `256`) was inferred from the merged OpenTelemetry resource. That produced false positives because `cloud.resource_id` and `k8s.cluster.name` can also come from App Service, Functions, environment attributes, or a customer-provided resource.

The bit could also be inherited from a numeric or JSON `AZURE_MONITOR_STATSBEAT_FEATURES` seed even when the current process did not detect AKS metadata.

### Changes

- Run `azureAksDetector` separately and calculate the feature from only its result.
- Require an AKS/Kubernetes environment and a complete AKS managed-cluster ARM resource ID.
- Strip bit `256` from inherited numeric and JSON feature seeds.
- Preserve the existing resource merge order for AKS, App Service, and Functions attributes.

The bit now means that this process successfully read valid AKS cluster metadata.

### Validation

- `npm run test:unit`: 944 passed, 5 todo.
- `npm run build`: passed.
- Tested with the exact companion PR artifacts on AKS 1.35.6:

| Scenario | Result |
| --- | --- |
| Real ConfigMap through `configMapKeyRef` | mask `265`, bit set |
| Real ConfigMap mounted as a volume | mask `265`, bit set |
| Real ConfigMap key mounted with `subPath` | mask `265`, bit set |
| No metadata, bogus ID, numeric/JSON seed, customer attributes, or App Service attributes | mask `9`, bit not set |

### Integration dependency

Volume and `subPath` support depends on open-telemetry/opentelemetry-js-contrib#3649. The AKS tests forced that PR's detector tarball into this package.

After the detector fix is released, update `@opentelemetry/resource-detector-azure` and the lockfile before merging this PR. The current `^0.26.0` range does not select detector `0.29.0`.
